### PR TITLE
Update byte-slice-cast version and add bitvec benches

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -35,7 +35,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "byte-slice-cast"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -235,7 +235,7 @@ version = "1.0.0"
 dependencies = [
  "arrayvec 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "bitvec 0.11.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "byte-slice-cast 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "byte-slice-cast 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "criterion 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-scale-codec-derive 1.0.0",
  "serde 1.0.92 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -495,7 +495,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum autocfg 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "0e49efa51329a5fd37e7c79db4621af617cd4e3e5bc224939808d076077077bf"
 "checksum bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "228047a76f468627ca71776ecdebd732a3423081fcf5125585bcd7c49886ce12"
 "checksum bitvec 0.11.1 (registry+https://github.com/rust-lang/crates.io-index)" = "c28d4291b516ccfbb897d45de3c468c135e6af7c4f1f1aacfaae0a5bc2e6ea2c"
-"checksum byte-slice-cast 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "34d6eec63fe0fb4f9f0f8011d32ab1586c123f1248c930a35237ff4ef08beaf1"
+"checksum byte-slice-cast 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b6cb79b824ad8026dfaf918b0f3f072a6faf916fe843aff07321a738babfd575"
 "checksum byteorder 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "a019b10a2a7cdeb292db131fc8113e57ea2a908f6e7894b0c3c671893b65dbeb"
 "checksum cast 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "926013f2860c46252efceabb19f4a6b308197505082c609025aa6706c011d427"
 "checksum cfg-if 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)" = "b486ce3ccf7ffd79fdeb678eac06a9e6c09fc88d33836340becb8fffe87c5e33"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,12 +13,13 @@ arrayvec = { version = "0.4", default-features = false, features = ["array-sizes
 serde = { version = "1.0", optional = true }
 parity-scale-codec-derive = { path = "derive", version = "1.0", default-features = false, optional = true }
 bitvec = { version = "0.11", default-features = false, features = ["alloc"], optional = true }
-byte-slice-cast = { version = "0.3", optional = true }
+byte-slice-cast = { version = "0.3.1", optional = true }
 
 [dev-dependencies]
 serde_derive = { version = "1.0" }
 parity-scale-codec-derive = { path = "derive", version = "1.0", default-features = false }
 criterion = "0.2"
+bitvec = "0.11"
 
 [[bench]]
 name = "benches"

--- a/src/bit_vec.rs
+++ b/src/bit_vec.rs
@@ -53,14 +53,10 @@ impl<C: Cursor, T: Bits + FromByteSlice> Decode for BitVec<C, T> {
 			let mut vec = vec![0; required_bytes::<T>(bits)];
 			input.read(&mut vec)?;
 
-			Ok(if vec.is_empty() {
-				Self::new()
-			} else {
-				let mut result = Self::from_slice(T::from_byte_slice(&vec)?);
-				assert!(bits <= result.len());
-				unsafe { result.set_len(bits); }
-				result
-			})
+			let mut result = Self::from_slice(T::from_byte_slice(&vec)?);
+			assert!(bits <= result.len());
+			unsafe { result.set_len(bits); }
+			Ok(result)
 		})
 	}
 }


### PR DESCRIPTION
The newer `byte-slice-cast` version allows to cast empty slices.