### PR TITLE
Derive `CompactAs` for single field structs

### DIFF
--- a/derive/src/encode.rs
+++ b/derive/src/encode.rs
@@ -133,22 +133,11 @@ fn encode_fields<F>(
 fn try_impl_encode_single_field_optimisation(data: &Data) -> Option<TokenStream> {
 	let closure = &quote!(f);
 
-	fn filter_skip_named<'a>(fields: &'a syn::FieldsNamed) -> impl Iterator<Item=&Field> + 'a {
-		fields.named.iter()
-			.filter(|f| utils::get_skip(&f.attrs).is_none())
-	}
-
-	fn filter_skip_unnamed<'a>(fields: &'a syn::FieldsUnnamed) -> impl Iterator<Item=(usize, &Field)> + 'a {
-		fields.unnamed.iter()
-			.enumerate()
-			.filter(|(_, f)| utils::get_skip(&f.attrs).is_none())
-	}
-
 	let optimisation = match *data {
 		Data::Struct(ref data) => {
 			match data.fields {
-				Fields::Named(ref fields) if filter_skip_named(fields).count() == 1 => {
-					let field = filter_skip_named(fields).next().unwrap();
+				Fields::Named(ref fields) if utils::filter_skip_named(fields).count() == 1 => {
+					let field = utils::filter_skip_named(fields).next().unwrap();
 					let name = &field.ident;
 					Some(encode_single_field(
 						closure,
@@ -156,8 +145,8 @@ fn try_impl_encode_single_field_optimisation(data: &Data) -> Option<TokenStream>
 						quote!(&self.#name)
 					))
 				},
-				Fields::Unnamed(ref fields) if filter_skip_unnamed(fields).count() == 1 => {
-					let (id, field) = filter_skip_unnamed(fields).next().unwrap();
+				Fields::Unnamed(ref fields) if utils::filter_skip_unnamed(fields).count() == 1 => {
+					let (id, field) = utils::filter_skip_unnamed(fields).next().unwrap();
 					let id = syn::Index::from(id);
 
 					Some(encode_single_field(

--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -36,20 +36,37 @@ mod encode;
 mod utils;
 mod trait_bounds;
 
-/// Include the `parity-scale-codec` crate under a known name (`_parity_scale_codec`).
-fn include_parity_scale_codec_crate() -> proc_macro2::TokenStream {
-	// This "hack" is required for the tests.
-	if env::var("CARGO_PKG_NAME").unwrap() == "parity-scale-codec" {
-		quote!( extern crate parity_scale_codec as _parity_scale_codec; )
-	} else {
-		match crate_name("parity-scale-codec") {
-			Ok(parity_codec_crate) => {
-				let ident = Ident::new(&parity_codec_crate, Span::call_site());
-				quote!( extern crate #ident as _parity_scale_codec; )
-			},
-			Err(e) => Error::new(Span::call_site(), &e).to_compile_error(),
-		}
-	}
+/// Wraps the impl block in a "dummy const"
+fn wrap_with_dummy_const(input: &DeriveInput, prefix: &str, impl_block: proc_macro2::TokenStream) -> TokenStream {
+	let parity_codec_crate =
+		// This "hack" is required for the tests.
+		if env::var("CARGO_PKG_NAME").unwrap() == "parity-scale-codec" {
+			quote!( extern crate parity_scale_codec as _parity_scale_codec; )
+		} else {
+			match crate_name("parity-scale-codec") {
+				Ok(parity_codec_crate) => {
+					let ident = Ident::new(&parity_codec_crate, Span::call_site());
+					quote!( extern crate #ident as _parity_scale_codec; )
+				},
+				Err(e) => Error::new(Span::call_site(), &e).to_compile_error(),
+			}
+		};
+
+	let mut new_name = prefix.to_string();
+	new_name.push_str(input.ident.to_string().trim_start_matches("r#"));
+	let dummy_const = Ident::new(&new_name, Span::call_site());
+
+	let generated = quote! {
+		#[allow(non_upper_case_globals, unused_attributes, unused_qualifications)]
+		const #dummy_const: () = {
+			#[allow(unknown_lints)]
+			#[cfg_attr(feature = "cargo-clippy", allow(useless_attribute))]
+			#[allow(rust_2018_idioms)]
+			#parity_codec_crate
+			#impl_block
+		};
+	};
+	generated.into()
 }
 
 #[proc_macro_derive(Encode, attributes(codec))]
@@ -84,23 +101,7 @@ pub fn encode_derive(input: TokenStream) -> TokenStream {
 		}
 	};
 
-	let mut new_name = "_IMPL_ENCODE_FOR_".to_string();
-	new_name.push_str(name.to_string().trim_start_matches("r#"));
-	let dummy_const = Ident::new(&new_name, Span::call_site());
-	let parity_codec_crate = include_parity_scale_codec_crate();
-
-	let generated = quote! {
-		#[allow(non_upper_case_globals, unused_attributes, unused_qualifications)]
-		const #dummy_const: () = {
-			#[allow(unknown_lints)]
-			#[cfg_attr(feature = "cargo-clippy", allow(useless_attribute))]
-			#[allow(rust_2018_idioms)]
-			#parity_codec_crate
-			#impl_block
-		};
-	};
-
-	generated.into()
+	wrap_with_dummy_const(&input, "_IMPL_ENCODE_FOR_", impl_block)
 }
 
 #[proc_macro_derive(Decode, attributes(codec))]
@@ -140,23 +141,7 @@ pub fn decode_derive(input: TokenStream) -> TokenStream {
 		}
 	};
 
-	let mut new_name = "_IMPL_DECODE_FOR_".to_string();
-	new_name.push_str(name.to_string().trim_start_matches("r#"));
-	let dummy_const = Ident::new(&new_name, Span::call_site());
-	let parity_codec_crate = include_parity_scale_codec_crate();
-
-	let generated = quote! {
-		#[allow(non_upper_case_globals, unused_attributes, unused_qualifications)]
-		const #dummy_const: () = {
-			#[allow(unknown_lints)]
-			#[cfg_attr(feature = "cargo-clippy", allow(useless_attribute))]
-			#[allow(rust_2018_idioms)]
-			#parity_codec_crate
-			#impl_block
-		};
-	};
-
-	generated.into()
+	wrap_with_dummy_const(&input, "_IMPL_DECODE_FOR_", impl_block)
 }
 
 #[proc_macro_derive(CompactAs, attributes(codec))]
@@ -226,21 +211,5 @@ pub fn decode_compact_as(input: TokenStream) -> TokenStream {
 		}
 	};
 
-	let mut new_name = "_IMPL_COMPACTAS_FOR_".to_string();
-	new_name.push_str(name.to_string().trim_start_matches("r#"));
-	let dummy_const = Ident::new(&new_name, Span::call_site());
-	let parity_codec_crate = include_parity_scale_codec_crate();
-
-	let generated = quote! {
-		#[allow(non_upper_case_globals, unused_attributes, unused_qualifications)]
-		const #dummy_const: () = {
-			#[allow(unknown_lints)]
-			#[cfg_attr(feature = "cargo-clippy", allow(useless_attribute))]
-			#[allow(rust_2018_idioms)]
-			#parity_codec_crate
-			#impl_block
-		};
-	};
-
-	generated.into()
+	wrap_with_dummy_const(&input, "_IMPL_COMPACTAS_FOR_", impl_block)
 }

--- a/derive/src/utils.rs
+++ b/derive/src/utils.rs
@@ -102,3 +102,14 @@ pub fn get_skip(attrs: &Vec<Attribute>) -> Option<Span> {
 		None
 	})
 }
+
+pub fn filter_skip_named<'a>(fields: &'a syn::FieldsNamed) -> impl Iterator<Item=&Field> + 'a {
+	fields.named.iter()
+		.filter(|f| get_skip(&f.attrs).is_none())
+}
+
+pub fn filter_skip_unnamed<'a>(fields: &'a syn::FieldsUnnamed) -> impl Iterator<Item=(usize, &Field)> + 'a {
+	fields.unnamed.iter()
+		.enumerate()
+		.filter(|(_, f)| get_skip(&f.attrs).is_none())
+}

--- a/tests/single_field_struct_encoding.rs
+++ b/tests/single_field_struct_encoding.rs
@@ -34,6 +34,10 @@ struct Sh<T: HasCompact> {
 #[derive(Debug, PartialEq, Eq, Clone, Copy, Encode, Decode, CompactAs)]
 struct U(u32);
 
+#[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
+#[derive(Debug, PartialEq, Eq, Clone, Copy, Encode, Decode, CompactAs)]
+struct U2 { a: u64 }
+
 #[derive(Debug, PartialEq, Encode, Decode)]
 struct USkip(#[codec(skip)] u32, u32, #[codec(skip)] u32);
 

--- a/tests/single_field_struct_encoding.rs
+++ b/tests/single_field_struct_encoding.rs
@@ -2,6 +2,7 @@
 extern crate parity_scale_codec_derive;
 
 use parity_scale_codec::{Encode, HasCompact, Decode};
+use serde_derive::{Serialize, Deserialize};
 
 #[derive(Debug, PartialEq, Encode, Decode)]
 struct S {
@@ -29,7 +30,8 @@ struct Sh<T: HasCompact> {
 	x: T,
 }
 
-#[derive(Debug, PartialEq, Encode, Decode)]
+#[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
+#[derive(Debug, PartialEq, Eq, Clone, Copy, Encode, Decode, CompactAs)]
 struct U(u32);
 
 #[derive(Debug, PartialEq, Encode, Decode)]
@@ -37,6 +39,9 @@ struct USkip(#[codec(skip)] u32, u32, #[codec(skip)] u32);
 
 #[derive(Debug, PartialEq, Encode, Decode)]
 struct Uc(#[codec(compact)] u32);
+
+#[derive(Debug, PartialEq, Clone, Encode, Decode)]
+struct Ucas(#[codec(compact)] U);
 
 #[derive(Debug, PartialEq, Encode, Decode)]
 struct Uh<T: HasCompact>(#[codec(encoded_as = "<T as HasCompact>::Type")] T);
@@ -51,6 +56,7 @@ fn test_encoding() {
 	let u = U(x);
 	let u_skip = USkip(Default::default(), x, Default::default());
 	let uc = Uc(x);
+	let ucas = Ucas(u);
 	let uh = Uh(x);
 
 	let mut s_encoded: &[u8] = &[3, 0, 0, 0];
@@ -60,6 +66,7 @@ fn test_encoding() {
 	let mut u_encoded: &[u8] = &[3, 0, 0, 0];
 	let mut u_skip_encoded: &[u8] = &[3, 0, 0, 0];
 	let mut uc_encoded: &[u8] = &[12];
+	let mut ucas_encoded: &[u8] = &[12];
 	let mut uh_encoded: &[u8] = &[12];
 
 	assert_eq!(s.encode(), s_encoded);
@@ -69,6 +76,7 @@ fn test_encoding() {
 	assert_eq!(u.encode(), u_encoded);
 	assert_eq!(u_skip.encode(), u_skip_encoded);
 	assert_eq!(uc.encode(), uc_encoded);
+	assert_eq!(ucas.encode(), ucas_encoded);
 	assert_eq!(uh.encode(), uh_encoded);
 
 	assert_eq!(s, S::decode(&mut s_encoded).unwrap());
@@ -78,5 +86,6 @@ fn test_encoding() {
 	assert_eq!(u, U::decode(&mut u_encoded).unwrap());
 	assert_eq!(u_skip, USkip::decode(&mut u_skip_encoded).unwrap());
 	assert_eq!(uc, Uc::decode(&mut uc_encoded).unwrap());
+	assert_eq!(ucas, Ucas::decode(&mut ucas_encoded).unwrap());
 	assert_eq!(uh, Uh::decode(&mut uh_encoded).unwrap());
 }

--- a/tests/single_field_struct_encoding.rs
+++ b/tests/single_field_struct_encoding.rs
@@ -9,7 +9,8 @@ struct S {
 	x: u32,
 }
 
-#[derive(Debug, PartialEq, Encode, Decode)]
+#[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
+#[derive(Debug, PartialEq, Eq, Clone, Copy, Encode, Decode, CompactAs)]
 struct SSkip {
 	#[codec(skip)]
 	s1: u32,
@@ -38,7 +39,8 @@ struct U(u32);
 #[derive(Debug, PartialEq, Eq, Clone, Copy, Encode, Decode, CompactAs)]
 struct U2 { a: u64 }
 
-#[derive(Debug, PartialEq, Encode, Decode)]
+#[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
+#[derive(Debug, PartialEq, Eq, Clone, Copy, Encode, Decode, CompactAs)]
 struct USkip(#[codec(skip)] u32, u32, #[codec(skip)] u32);
 
 #[derive(Debug, PartialEq, Encode, Decode)]
@@ -46,6 +48,12 @@ struct Uc(#[codec(compact)] u32);
 
 #[derive(Debug, PartialEq, Clone, Encode, Decode)]
 struct Ucas(#[codec(compact)] U);
+
+#[derive(Debug, PartialEq, Clone, Encode, Decode)]
+struct USkipcas(#[codec(compact)] USkip);
+
+#[derive(Debug, PartialEq, Clone, Encode, Decode)]
+struct SSkipcas(#[codec(compact)] SSkip);
 
 #[derive(Debug, PartialEq, Encode, Decode)]
 struct Uh<T: HasCompact>(#[codec(encoded_as = "<T as HasCompact>::Type")] T);
@@ -61,6 +69,8 @@ fn test_encoding() {
 	let u_skip = USkip(Default::default(), x, Default::default());
 	let uc = Uc(x);
 	let ucas = Ucas(u);
+	let u_skip_cas = USkipcas(u_skip);
+	let s_skip_cas = SSkipcas(s_skip);
 	let uh = Uh(x);
 
 	let mut s_encoded: &[u8] = &[3, 0, 0, 0];
@@ -71,6 +81,8 @@ fn test_encoding() {
 	let mut u_skip_encoded: &[u8] = &[3, 0, 0, 0];
 	let mut uc_encoded: &[u8] = &[12];
 	let mut ucas_encoded: &[u8] = &[12];
+	let mut u_skip_cas_encoded: &[u8] = &[12];
+	let mut s_skip_cas_encoded: &[u8] = &[12];
 	let mut uh_encoded: &[u8] = &[12];
 
 	assert_eq!(s.encode(), s_encoded);
@@ -81,6 +93,8 @@ fn test_encoding() {
 	assert_eq!(u_skip.encode(), u_skip_encoded);
 	assert_eq!(uc.encode(), uc_encoded);
 	assert_eq!(ucas.encode(), ucas_encoded);
+	assert_eq!(u_skip_cas.encode(), u_skip_cas_encoded);
+	assert_eq!(s_skip_cas.encode(), s_skip_cas_encoded);
 	assert_eq!(uh.encode(), uh_encoded);
 
 	assert_eq!(s, S::decode(&mut s_encoded).unwrap());
@@ -91,5 +105,7 @@ fn test_encoding() {
 	assert_eq!(u_skip, USkip::decode(&mut u_skip_encoded).unwrap());
 	assert_eq!(uc, Uc::decode(&mut uc_encoded).unwrap());
 	assert_eq!(ucas, Ucas::decode(&mut ucas_encoded).unwrap());
+	assert_eq!(u_skip_cas, USkipcas::decode(&mut u_skip_cas_encoded).unwrap());
+	assert_eq!(s_skip_cas, SSkipcas::decode(&mut s_skip_cas_encoded).unwrap());
 	assert_eq!(uh, Uh::decode(&mut uh_encoded).unwrap());
 }

--- a/tests/single_field_struct_encoding.rs
+++ b/tests/single_field_struct_encoding.rs
@@ -1,7 +1,7 @@
 #[macro_use]
 extern crate parity_scale_codec_derive;
 
-use parity_scale_codec::{Encode, HasCompact, Decode};
+use parity_scale_codec::{Compact, Encode, HasCompact, Decode};
 use serde_derive::{Serialize, Deserialize};
 
 #[derive(Debug, PartialEq, Encode, Decode)]
@@ -68,6 +68,7 @@ fn test_encoding() {
 	let u = U(x);
 	let u_skip = USkip(Default::default(), x, Default::default());
 	let uc = Uc(x);
+	let ucom = Compact(u);
 	let ucas = Ucas(u);
 	let u_skip_cas = USkipcas(u_skip);
 	let s_skip_cas = SSkipcas(s_skip);
@@ -80,6 +81,7 @@ fn test_encoding() {
 	let mut u_encoded: &[u8] = &[3, 0, 0, 0];
 	let mut u_skip_encoded: &[u8] = &[3, 0, 0, 0];
 	let mut uc_encoded: &[u8] = &[12];
+	let mut ucom_encoded: &[u8] = &[12];
 	let mut ucas_encoded: &[u8] = &[12];
 	let mut u_skip_cas_encoded: &[u8] = &[12];
 	let mut s_skip_cas_encoded: &[u8] = &[12];
@@ -92,6 +94,7 @@ fn test_encoding() {
 	assert_eq!(u.encode(), u_encoded);
 	assert_eq!(u_skip.encode(), u_skip_encoded);
 	assert_eq!(uc.encode(), uc_encoded);
+	assert_eq!(ucom.encode(), ucom_encoded);
 	assert_eq!(ucas.encode(), ucas_encoded);
 	assert_eq!(u_skip_cas.encode(), u_skip_cas_encoded);
 	assert_eq!(s_skip_cas.encode(), s_skip_cas_encoded);
@@ -104,6 +107,7 @@ fn test_encoding() {
 	assert_eq!(u, U::decode(&mut u_encoded).unwrap());
 	assert_eq!(u_skip, USkip::decode(&mut u_skip_encoded).unwrap());
 	assert_eq!(uc, Uc::decode(&mut uc_encoded).unwrap());
+	assert_eq!(ucom, <Compact::<U>>::decode(&mut ucom_encoded).unwrap());
 	assert_eq!(ucas, Ucas::decode(&mut ucas_encoded).unwrap());
 	assert_eq!(u_skip_cas, USkipcas::decode(&mut u_skip_cas_encoded).unwrap());
 	assert_eq!(s_skip_cas, SSkipcas::decode(&mut s_skip_cas_encoded).unwrap());


### PR DESCRIPTION
Resolves #96 (assuming that @bkchr means "unit structs" = "single field structs")

- Derives `CompactAs` on named and unnamed structs with a single non-skipped field.
- Extracts common function to wrap impl block in "dummy const" 