### PR TITLE
`len` method for some collections.

### DIFF
--- a/src/codec.rs
+++ b/src/codec.rs
@@ -34,6 +34,8 @@ use arrayvec::ArrayVec;
 #[cfg(feature = "std")]
 use std::fmt;
 
+use core::convert::TryFrom;
+
 #[cfg_attr(feature = "std", derive(Debug))]
 #[derive(PartialEq)]
 #[cfg(feature = "std")]
@@ -688,7 +690,8 @@ macro_rules! impl_len {
 	( $( $type:ident< $($g:ident),* > ),* ) => { $(
 		impl<$($g),*> DecodeLength for $type<$($g),*> {
 			fn len(self_encoded: &mut &[u8]) -> Result<usize, Error> {
-				Ok(u32::from(Compact::<u32>::decode(self_encoded)?) as usize)
+				usize::try_from(u32::from(Compact::<u32>::decode(self_encoded)?))
+					.map_err(|_| "can't convert".into())
 			}
 		}
 	)*}

--- a/src/codec.rs
+++ b/src/codec.rs
@@ -223,6 +223,13 @@ pub trait EncodeAppend {
 	fn append(self_encoded: Vec<u8>, to_append: &[Self::Item]) -> Result<Vec<u8>, Error>;
 }
 
+/// Trait that allows the length of a collection to be read, without having
+/// to read and decode the entire elements.
+pub trait EncodeLength {
+	/// Return the number of elements in `self_encoded`.
+	fn len(self_encoded: Vec<u8>) -> Result<u32, Error>;
+}
+
 /// Trait that allows zero-copy read of value-references from slices in LE format.
 pub trait Decode: Sized {
 	#[doc(hidden)]
@@ -664,6 +671,18 @@ impl Decode for () {
 	}
 }
 
+macro_rules! len_impl {
+	( $( $type:ident< $($g:ident),* > ),* ) => { $(
+		impl<$($g: Encode + Decode),*> EncodeLength for $type<$($g),*> {
+			fn len(self_encoded: Vec<u8>) -> Result<u32, Error> {
+				Ok(u32::from(Compact::<u32>::decode(&mut &self_encoded[..])?))
+			}
+		}
+	)*}
+}
+
+len_impl!(Vec<T>, BTreeSet<T>, BTreeMap<K, V>);
+
 macro_rules! tuple_impl {
 	($one:ident,) => {
 		impl<$one: Encode> Encode for ($one,) {
@@ -1025,6 +1044,25 @@ mod tests {
 			vec
 		});
 		assert_eq!(decoded, expected);
+	}
+
+	fn test_encode_length<T: Encode + Decode + EncodeLength>(thing: &T, len: usize) {
+		assert_eq!(<T as EncodeLength>::len(thing.encode()).unwrap(), len as u32);
+	}
+
+	#[test]
+	fn len_works_for_all_encode_types() {
+		let vector = vec![10; 10];
+		let mut btree_map: BTreeMap<u32, u32> = BTreeMap::new();
+		btree_map.insert(1, 1);
+		btree_map.insert(2, 2);
+		let mut btree_set: BTreeSet<u32> = BTreeSet::new();
+		btree_set.insert(1);
+		btree_set.insert(2);
+
+		test_encode_length(&vector, 10);
+		test_encode_length(&btree_map, 2);
+		test_encode_length(&btree_set, 2);
 	}
 
 	#[test]

--- a/src/codec.rs
+++ b/src/codec.rs
@@ -227,7 +227,7 @@ pub trait EncodeAppend {
 /// to read and decode the entire elements.
 pub trait DecodeLength {
 	/// Return the number of elements in `self_encoded`.
-	fn len(self_encoded: &mut &[u8]) -> Result<u32, Error>;
+	fn len(self_encoded: &mut &[u8]) -> Result<usize, Error>;
 }
 
 /// Trait that allows zero-copy read of value-references from slices in LE format.
@@ -686,9 +686,9 @@ impl Decode for () {
 
 macro_rules! impl_len {
 	( $( $type:ident< $($g:ident),* > ),* ) => { $(
-		impl<$($g: Encode + Decode),*> DecodeLength for $type<$($g),*> {
-			fn len(self_encoded: &mut &[u8]) -> Result<u32, Error> {
-				Ok(u32::from(Compact::<u32>::decode(self_encoded)?))
+		impl<$($g),*> DecodeLength for $type<$($g),*> {
+			fn len(self_encoded: &mut &[u8]) -> Result<usize, Error> {
+				Ok(u32::from(Compact::<u32>::decode(self_encoded)?) as usize)
 			}
 		}
 	)*}
@@ -1013,7 +1013,7 @@ mod tests {
 	}
 
 	fn test_encode_length<T: Encode + Decode + DecodeLength>(thing: &T, len: usize) {
-		assert_eq!(<T as DecodeLength>::len(&mut &thing.encode()[..]).unwrap(), len as u32);
+		assert_eq!(<T as DecodeLength>::len(&mut &thing.encode()[..]).unwrap(), len);
 	}
 
 	#[test]

--- a/src/codec.rs
+++ b/src/codec.rs
@@ -691,7 +691,7 @@ macro_rules! impl_len {
 		impl<$($g),*> DecodeLength for $type<$($g),*> {
 			fn len(self_encoded: &mut &[u8]) -> Result<usize, Error> {
 				usize::try_from(u32::from(Compact::<u32>::decode(self_encoded)?))
-					.map_err(|_| "can't convert".into())
+					.map_err(|_| "Failed convert decded size into usize.".into())
 			}
 		}
 	)*}

--- a/src/compact.rs
+++ b/src/compact.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! [Compact encoding](https://docs.substrate.dev/docs/low-level-data-formats#section-compactgeneral-integers)
+//! [Compact encoding](https://substrate.dev/docs/en/overview/low-level-data-format#compact-general-integers)
 
 use crate::codec::{Input, Output, Error, Encode, Decode, EncodeAsRef};
 


### PR DESCRIPTION
- I wonder if it should also be added for string and tuple. String is not really used in substrate. Tuple might make a bit of sense.
- Just saw this PR https://github.com/paritytech/parity-scale-codec/pull/99 and the same could be added for the new types there --though we should probably unify the macros.)