### PR TITLE
Fix preallocation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15,7 +15,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "parity-codec"
-version = "3.5.1"
+version = "3.5.2"
 dependencies = [
  "arrayvec 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-codec-derive 3.3.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "parity-codec"
 description = "Lightweight, efficient, binary serialization and deserialization codec"
-version = "3.5.1"
+version = "3.5.2"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "Apache-2.0"
 repository = "https://github.com/paritytech/parity-codec"

--- a/src/codec.rs
+++ b/src/codec.rs
@@ -1507,8 +1507,8 @@ mod tests {
 
 	#[test]
 	fn encode_for_very_large_vec_works() {
-		let vec_u8 = vec![0u8; MAXIMUM_PREALLOCATION_SIZE+100];
-		let vec_u16 = vec![0u16; MAXIMUM_PREALLOCATION_SIZE+100];
+		let vec_u8 = vec![0u8; MAXIMUM_PREALLOCATION_SIZE + 100];
+		let vec_u16 = vec![0u16; MAXIMUM_PREALLOCATION_SIZE + 100];
 		assert_eq!(Vec::<u8>::decode(&mut &vec_u8.encode()[..][..]).unwrap(), vec_u8);
 		assert_eq!(Vec::<u16>::decode(&mut &vec_u16.encode()[..][..]).unwrap(), vec_u16);
 	}

--- a/src/codec.rs
+++ b/src/codec.rs
@@ -1504,8 +1504,8 @@ mod tests {
 
 	#[test]
 	fn encode_for_very_large_vec_works() {
-		let vec_u8: Vec<u8> = (0..MAX_PREALLOCATION_SIZE).map(|i| i as u8).collect();
-		let vec_u16: Vec<u16> = (0..MAX_PREALLOCATION_SIZE).map(|i| i as u16).collect();
+		let vec_u8: Vec<u8> = (0..MAX_PREALLOCATION_SIZE*3).map(|i| i as u8).collect();
+		let vec_u16: Vec<u16> = (0..MAX_PREALLOCATION_SIZE*3).map(|i| i as u16).collect();
 		assert_eq!(Vec::<u8>::decode(&mut &vec_u8.encode()[..][..]).unwrap(), vec_u8);
 		assert_eq!(Vec::<u16>::decode(&mut &vec_u16.encode()[..][..]).unwrap(), vec_u16);
 	}

--- a/src/codec.rs
+++ b/src/codec.rs
@@ -787,7 +787,7 @@ impl Decode for Vec<u8> {
 
 			if len < MAXIMUM_PREALLOCATION_SIZE {
 				let mut vec = vec![0; len]; // len is ok here
-				if input.read(&mut vec[..len]) != len {
+				if input.read(&mut vec[..]) != len {
 					None
 				} else {
 					Some(vec)

--- a/src/codec.rs
+++ b/src/codec.rs
@@ -793,7 +793,7 @@ impl Decode for Vec<u8> {
 					Some(vec)
 				}
 			} else {
-				// if len is consider too much for preallocation then use dynamic allocation
+				// if len is considered too much for preallocation then use dynamic allocation
 				let mut vec = Vec::new();
 				let buffer_len = MAXIMUM_PREALLOCATION_SIZE;
 				let mut buffer = vec![0; buffer_len];

--- a/src/codec.rs
+++ b/src/codec.rs
@@ -799,22 +799,17 @@ impl Decode for Vec<u8> {
 				let mut buffer = vec![0; buffer_len];
 				let mut total_len_read = 0;
 
-				println!("try");
 				loop {
 					let len_read = input.read(&mut buffer[..buffer_len]);
 
-					println!("read_len:{}", len_read);
 					if len_read == 0 {
 						break
 					}
 
 					total_len_read += len_read;
 					vec.extend_from_slice(&buffer[..len_read]);
-					dbg!();
 				}
 
-					dbg!(total_len_read);
-					dbg!(len);
 				if total_len_read != len {
 					None
 				} else {

--- a/src/codec.rs
+++ b/src/codec.rs
@@ -20,7 +20,7 @@ use crate::alloc::collections::btree_map::BTreeMap;
 
 /// When decoding input we don't allocate too much in advance so a small crafted input can't
 /// trigger a big allocation.
-const MAX_PREALLOCATION_SIZE: usize = 4*1024;
+const MAX_PREALLOCATION_SIZE: usize = 4 * 1024;
 
 #[cfg(any(feature = "std", feature = "full"))]
 use crate::alloc::{

--- a/src/codec.rs
+++ b/src/codec.rs
@@ -799,7 +799,6 @@ impl Decode for Vec<u8> {
 				let mut remains = len;
 				let buffer_len = MAX_PREALLOCATION_SIZE;
 				let mut buffer = vec![0; buffer_len];
-				let mut total_len_read = 0;
 
 				while remains != 0 {
 					let len_read = input.read(&mut buffer[..buffer_len.min(remains)]);
@@ -1505,8 +1504,8 @@ mod tests {
 
 	#[test]
 	fn encode_for_very_large_vec_works() {
-		let vec_u8 = vec![0u8; MAX_PREALLOCATION_SIZE + 100];
-		let vec_u16 = vec![0u16; MAX_PREALLOCATION_SIZE + 100];
+		let vec_u8: Vec<u8> = (0..MAX_PREALLOCATION_SIZE).map(|i| i as u8).collect();
+		let vec_u16: Vec<u16> = (0..MAX_PREALLOCATION_SIZE).map(|i| i as u16).collect();
 		assert_eq!(Vec::<u8>::decode(&mut &vec_u8.encode()[..][..]).unwrap(), vec_u8);
 		assert_eq!(Vec::<u16>::decode(&mut &vec_u16.encode()[..][..]).unwrap(), vec_u16);
 	}

--- a/src/codec.rs
+++ b/src/codec.rs
@@ -893,7 +893,7 @@ impl<T: Encode> Encode for Vec<T> {
 impl<T: Decode> Decode for Vec<T> {
 	fn decode<I: Input>(input: &mut I) -> Option<Self> {
 		<Compact<u32>>::decode(input).and_then(move |Compact(len)| {
-			let max_pre_allocated_len = MAXIMUM_PREALLOCATION_SIZE/ mem::size_of::<T>();
+			let max_pre_allocated_len = MAXIMUM_PREALLOCATION_SIZE / mem::size_of::<T>();
 
 			let pre_allocated_len = (len as usize).min(max_pre_allocated_len);
 			let mut r = Vec::with_capacity(pre_allocated_len);


### PR DESCRIPTION
The implementation of Input for io::Read was using read_exact, that seems wrong was it intented ?

So apart from that this introduce a maximum preallocation which is 16MiB, related to substrate network limit.

After merging I will push tag 3.5.2 and make a new release