### PR TITLE
Implement min_encoded_len and required_len

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ The `Encode` trait is used for encoding of data into the SCALE format. The `Enco
 
 The `Decode` trait is used for deserialization/decoding of encoded data into the respective types.
 
+* `fn min_encoded_len() -> usize`: The minimum lenght a valid encoded value can have.
 * `fn decode<I: Input>(value: &mut I) -> Result<Self, Error>`: Tries to decode the value from SCALE format to the type it is called on. Returns an `Err` if the decoding fails.
 
 ### CompactAs

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ The `Encode` trait is used for encoding of data into the SCALE format. The `Enco
 
 The `Decode` trait is used for deserialization/decoding of encoded data into the respective types.
 
-* `fn min_encoded_len() -> usize`: The minimum lenght a valid encoded value can have.
+* `fn min_encoded_len() -> usize`: The minimum length a valid encoded value can have.
 * `fn decode<I: Input>(value: &mut I) -> Result<Self, Error>`: Tries to decode the value from SCALE format to the type it is called on. Returns an `Err` if the decoding fails.
 
 ### CompactAs

--- a/derive/src/decode.rs
+++ b/derive/src/decode.rs
@@ -72,8 +72,9 @@ pub fn quote(data: &Data, type_name: &Ident, input: &TokenStream) -> Result<Impl
 					},
 				};
 
+				let variant_index_len = 1usize;
 				let min_encoded_len = quote_spanned! { v.span() =>
-					1 + #impl_min_encoded_len
+					#variant_index_len + #impl_min_encoded_len
 				};
 
 				Ok(Impl { decode, min_encoded_len })

--- a/derive/src/decode.rs
+++ b/derive/src/decode.rs
@@ -17,6 +17,9 @@ use syn::{Data, Fields, Field, spanned::Spanned, Error};
 use crate::utils;
 use std::iter::FromIterator;
 
+// Encode macro use one byte to encode the index of the variant when encoding an enum.
+const ENUM_VARIANT_INDEX_ENCODED_LEN: usize = 1;
+
 pub struct Impl {
 	pub decode: TokenStream,
 	pub min_encoded_len: TokenStream,
@@ -72,9 +75,8 @@ pub fn quote(data: &Data, type_name: &Ident, input: &TokenStream) -> Result<Impl
 					},
 				};
 
-				let variant_index_len = 1usize;
 				let min_encoded_len = quote_spanned! { v.span() =>
-					#variant_index_len + #impl_min_encoded_len
+					#ENUM_VARIANT_INDEX_ENCODED_LEN + #impl_min_encoded_len
 				};
 
 				Ok(Impl { decode, min_encoded_len })

--- a/derive/src/encode.rs
+++ b/derive/src/encode.rs
@@ -89,7 +89,7 @@ fn encode_fields<F>(
 
 		if encoded_as.is_some() as u8 + compact as u8 + skip as u8 > 1 {
 			return Error::new(
-				Span::call_site(),
+				f.span(),
 				"`encoded_as`, `compact` and `skip` can only be used one at a time!"
 			).to_compile_error();
 		}
@@ -197,7 +197,7 @@ fn impl_encode(data: &Data, type_name: &Ident) -> TokenStream {
 
 			if data_variants().count() > 256 {
 				return Error::new(
-					Span::call_site(),
+					data.variants.span(),
 					"Currently only enums with at most 256 variants are encodable."
 				).to_compile_error();
 			}
@@ -274,7 +274,10 @@ fn impl_encode(data: &Data, type_name: &Ident) -> TokenStream {
 				}
 			}
 		},
-		Data::Union(_) => Error::new(Span::call_site(), "Union types are not supported.").to_compile_error(),
+		Data::Union(ref data) => Error::new(
+			data.union_token.span(),
+			"Union types are not supported."
+		).to_compile_error(),
 	};
 
 	quote! {

--- a/derive/src/trait_bounds.rs
+++ b/derive/src/trait_bounds.rs
@@ -12,8 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use proc_macro2::Span;
-use syn::{Generics, Ident, visit::{Visit, self}, Type, TypePath};
+use syn::{Generics, Ident, visit::{Visit, self}, Type, TypePath, spanned::Spanned};
 use std::iter;
 
 /// Visits the ast and checks if one of the given idents is found.
@@ -226,7 +225,10 @@ fn collect_types(
 				}
 			}).collect(),
 
-		Data::Union(_) => return Err(Error::new(Span::call_site(), "Union types are not supported.")),
+		Data::Union(ref data) => return Err(Error::new(
+			data.union_token.span(),
+			"Union types are not supported."
+		)),
 	};
 
 	Ok(types)

--- a/src/bit_vec.rs
+++ b/src/bit_vec.rs
@@ -92,20 +92,7 @@ fn required_bytes<T>(bits: usize) -> usize {
 mod tests {
 	use super::*;
 	use bitvec::{bitvec, cursor::BigEndian};
-
-	/// Mock
-	pub trait DecodeM: Decode {
-		fn decode_m(value: &mut &[u8]) -> Result<Self, Error> {
-			let len = value.len();
-			let res = Self::decode(value);
-			if res.is_ok() {
-				assert!(len - value.len() >= Self::min_encoded_len());
-			}
-			res
-		}
-	}
-
-	impl<T: Decode> DecodeM for T {}
+	use crate::codec::DecodeM;
 
 	macro_rules! test_data {
 		($inner_type: ty) => (

--- a/src/bit_vec.rs
+++ b/src/bit_vec.rs
@@ -47,6 +47,10 @@ impl<C: Cursor, T: Bits + ToByteSlice> Encode for BitVec<C, T> {
 }
 
 impl<C: Cursor, T: Bits + FromByteSlice> Decode for BitVec<C, T> {
+	fn min_encoded_len() -> usize {
+		<Compact<u32>>::min_encoded_len()
+	}
+
 	fn decode<I: Input>(input: &mut I) -> Result<Self, Error> {
 		<Compact<u32>>::decode(input).and_then(move |Compact(bits)| {
 			let bits = bits as usize;
@@ -69,6 +73,10 @@ impl<C: Cursor, T: Bits + ToByteSlice> Encode for BitBox<C, T> {
 }
 
 impl<C: Cursor, T: Bits + FromByteSlice> Decode for BitBox<C, T> {
+	fn min_encoded_len() -> usize {
+		<BitVec<C, T>>::min_encoded_len()
+	}
+
 	fn decode<I: Input>(input: &mut I) -> Result<Self, Error> {
 		Ok(Self::from_bitslice(BitVec::<C, T>::decode(input)?.as_bitslice()))
 	}

--- a/src/bit_vec.rs
+++ b/src/bit_vec.rs
@@ -93,6 +93,20 @@ mod tests {
 	use super::*;
 	use bitvec::{bitvec, cursor::BigEndian};
 
+	/// Mock
+	pub trait DecodeM: Decode {
+		fn decode_m(value: &mut &[u8]) -> Result<Self, Error> {
+			let len = value.len();
+			let res = Self::decode(value);
+			if res.is_ok() {
+				assert!(len - value.len() >= Self::min_encoded_len());
+			}
+			res
+		}
+	}
+
+	impl<T: Decode> DecodeM for T {}
+
 	macro_rules! test_data {
 		($inner_type: ty) => (
 			[
@@ -154,7 +168,7 @@ mod tests {
 	fn bitvec_u8() {
 		for v in &test_data!(u8) {
 			let encoded = v.encode();
-			assert_eq!(*v, BitVec::<BigEndian, u8>::decode(&mut &encoded[..]).unwrap());
+			assert_eq!(*v, BitVec::<BigEndian, u8>::decode_m(&mut &encoded[..]).unwrap());
 		}
 	}
 
@@ -162,7 +176,7 @@ mod tests {
 	fn bitvec_u16() {
 		for v in &test_data!(u16) {
 			let encoded = v.encode();
-			assert_eq!(*v, BitVec::<BigEndian, u16>::decode(&mut &encoded[..]).unwrap());
+			assert_eq!(*v, BitVec::<BigEndian, u16>::decode_m(&mut &encoded[..]).unwrap());
 		}
 	}
 
@@ -170,7 +184,7 @@ mod tests {
 	fn bitvec_u32() {
 		for v in &test_data!(u32) {
 			let encoded = v.encode();
-			assert_eq!(*v, BitVec::<BigEndian, u32>::decode(&mut &encoded[..]).unwrap());
+			assert_eq!(*v, BitVec::<BigEndian, u32>::decode_m(&mut &encoded[..]).unwrap());
 		}
 	}
 
@@ -178,7 +192,7 @@ mod tests {
 	fn bitvec_u64() {
 		for v in &test_data!(u64) {
 			let encoded = v.encode();
-			assert_eq!(*v, BitVec::<BigEndian, u64>::decode(&mut &encoded[..]).unwrap());
+			assert_eq!(*v, BitVec::<BigEndian, u64>::decode_m(&mut &encoded[..]).unwrap());
 		}
 	}
 
@@ -187,7 +201,7 @@ mod tests {
 		let data: &[u8] = &[0x69];
 		let slice: &BitSlice = data.into();
 		let encoded = slice.encode();
-		let decoded = BitVec::<BigEndian, u8>::decode(&mut &encoded[..]).unwrap();
+		let decoded = BitVec::<BigEndian, u8>::decode_m(&mut &encoded[..]).unwrap();
 		assert_eq!(slice, decoded.as_bitslice());
 	}
 
@@ -196,7 +210,7 @@ mod tests {
 		let data: &[u8] = &[5, 10];
 		let bb: BitBox = data.into();
 		let encoded = bb.encode();
-		let decoded = BitBox::<BigEndian, u8>::decode(&mut &encoded[..]).unwrap();
+		let decoded = BitBox::<BigEndian, u8>::decode_m(&mut &encoded[..]).unwrap();
 		assert_eq!(bb, decoded);
 	}
 }

--- a/src/codec.rs
+++ b/src/codec.rs
@@ -1010,24 +1010,25 @@ macro_rules! impl_non_endians {
 impl_endians!(u16, u32, u64, u128, i16, i32, i64, i128);
 impl_non_endians!(u8 {IS_U8}, i8, bool);
 
+#[cfg(test)]
+pub trait DecodeM: Decode {
+	fn decode_m(value: &mut &[u8]) -> Result<Self, Error> {
+		let len = value.len();
+		let res = Self::decode(value);
+		if res.is_ok() {
+			assert!(len - value.len() >= Self::min_encoded_len());
+		}
+		res
+	}
+}
+
+#[cfg(test)]
+impl<T: Decode> DecodeM for T {}
 
 #[cfg(test)]
 mod tests {
 	use super::*;
 	use std::borrow::Cow;
-
-	pub trait DecodeM: Decode {
-		fn decode_m(value: &mut &[u8]) -> Result<Self, Error> {
-			let len = value.len();
-			let res = Self::decode(value);
-			if res.is_ok() {
-				assert!(len - value.len() >= Self::min_encoded_len());
-			}
-			res
-		}
-	}
-
-	impl<T: Decode> DecodeM for T {}
 
 	#[test]
 	fn vec_is_slicable() {

--- a/src/codec.rs
+++ b/src/codec.rs
@@ -464,7 +464,6 @@ impl<T: Encode> Encode for Option<T> {
 	}
 }
 
-// TODO TODO: hmm so an Option<[u8; 1024]> can do some damage no ?
 impl<T: Decode> Decode for Option<T> {
 	fn min_encoded_len() -> usize {
 		1

--- a/src/codec.rs
+++ b/src/codec.rs
@@ -115,7 +115,7 @@ pub trait Input {
 impl<'a> Input for &'a [u8] {
 	fn require_min_len(&mut self, len: usize) -> Result<(), Error> {
 		if self.len() < len {
-			return Err("Not enough data for required".into());
+			return Err("Not enough data for required minimum length".into());
 		}
 
 		Ok(())

--- a/src/compact.rs
+++ b/src/compact.rs
@@ -45,8 +45,8 @@ struct PrefixInput<'a, T> {
 }
 
 impl<'a, T: 'a + Input> Input for PrefixInput<'a, T> {
-	fn require_minimum_len(&mut self, len: usize) -> Result<(), Error> {
-		self.input.require_minimum_len(len.saturating_sub(self.prefix.iter().count()))
+	fn require_min_len(&mut self, len: usize) -> Result<(), Error> {
+		self.input.require_min_len(len.saturating_sub(self.prefix.iter().count()))
 	}
 
 	fn read(&mut self, buffer: &mut [u8]) -> Result<(), Error> {

--- a/src/compact.rs
+++ b/src/compact.rs
@@ -45,6 +45,10 @@ struct PrefixInput<'a, T> {
 }
 
 impl<'a, T: 'a + Input> Input for PrefixInput<'a, T> {
+	fn require_minimum_len(&mut self, len: usize) -> Result<(), Error> {
+		self.input.require_minimum_len(len.saturating_sub(self.prefix.iter().count()))
+	}
+
 	fn read(&mut self, buffer: &mut [u8]) -> Result<(), Error> {
 		match self.prefix.take() {
 			Some(v) if !buffer.is_empty() => {
@@ -135,6 +139,10 @@ where
 	T: CompactAs,
 	Compact<T::As>: Decode,
 {
+	fn min_encoded_len() -> usize {
+		<Compact<T::As>>::min_encoded_len()
+	}
+
 	fn decode<I: Input>(input: &mut I) -> Result<Self, Error> {
 		Compact::<T::As>::decode(input)
 			.map(|x| Compact(<T as CompactAs>::decode_from(x.0)))
@@ -404,6 +412,10 @@ impl CompactLen<u128> for Compact<u128> {
 }
 
 impl Decode for Compact<()> {
+	fn min_encoded_len() -> usize {
+		0
+	}
+
 	fn decode<I: Input>(_input: &mut I) -> Result<Self, Error> {
 		Ok(Compact(()))
 	}
@@ -416,6 +428,10 @@ const U64_OUT_OF_RANGE: &'static str = "out of range decoding Compact<u64>";
 const U128_OUT_OF_RANGE: &'static str = "out of range decoding Compact<u128>";
 
 impl Decode for Compact<u8> {
+	fn min_encoded_len() -> usize {
+		1
+	}
+
 	fn decode<I: Input>(input: &mut I) -> Result<Self, Error> {
 		let prefix = input.read_byte()?;
 		Ok(Compact(match prefix % 4 {
@@ -434,6 +450,10 @@ impl Decode for Compact<u8> {
 }
 
 impl Decode for Compact<u16> {
+	fn min_encoded_len() -> usize {
+		1
+	}
+
 	fn decode<I: Input>(input: &mut I) -> Result<Self, Error> {
 		let prefix = input.read_byte()?;
 		Ok(Compact(match prefix % 4 {
@@ -460,6 +480,10 @@ impl Decode for Compact<u16> {
 }
 
 impl Decode for Compact<u32> {
+	fn min_encoded_len() -> usize {
+		1
+	}
+
 	fn decode<I: Input>(input: &mut I) -> Result<Self, Error> {
 		let prefix = input.read_byte()?;
 		Ok(Compact(match prefix % 4 {
@@ -499,6 +523,10 @@ impl Decode for Compact<u32> {
 }
 
 impl Decode for Compact<u64> {
+	fn min_encoded_len() -> usize {
+		1
+	}
+
 	fn decode<I: Input>(input: &mut I) -> Result<Self, Error> {
 		let prefix = input.read_byte()?;
 		Ok(Compact(match prefix % 4 {
@@ -554,6 +582,10 @@ impl Decode for Compact<u64> {
 }
 
 impl Decode for Compact<u128> {
+	fn min_encoded_len() -> usize {
+		1
+	}
+
 	fn decode<I: Input>(input: &mut I) -> Result<Self, Error> {
 		let prefix = input.read_byte()?;
 		Ok(Compact(match prefix % 4 {

--- a/src/compact.rs
+++ b/src/compact.rs
@@ -651,20 +651,7 @@ impl Decode for Compact<u128> {
 #[cfg(test)]
 mod tests {
 	use super::*;
-
-	/// Mock
-	pub trait DecodeM: Decode {
-		fn decode_m(value: &mut &[u8]) -> Result<Self, Error> {
-			let len = value.len();
-			let res = Self::decode(value);
-			if res.is_ok() {
-				assert!(len - value.len() >= Self::min_encoded_len());
-			}
-			res
-		}
-	}
-
-	impl<T: Decode> DecodeM for T {}
+	use crate::codec::DecodeM;
 
 	#[test]
 	fn compact_128_encoding_works() {

--- a/tests/invalid_input_len.rs
+++ b/tests/invalid_input_len.rs
@@ -1,0 +1,24 @@
+use parity_scale_codec::{Encode, Decode, OptionBool, Compact};
+
+// Test that not all input is decoded.
+#[test]
+fn vec_of_vec() {
+	let mut input = Compact::<u32>(16).encode();
+	input.extend(&[0; 15]);
+	let input = &mut &input[..];
+
+	let input_start_len = input.len();
+	let res = <Vec<Vec<()>>>::decode(input);
+	assert!(res.is_err());
+
+	// Decoding stopped early, before vec allocation.
+	assert_eq!(input.len(), input_start_len - 1);
+}
+
+// Test error returned.
+#[test]
+#[should_panic(expected = "Not enough data to fill buffer")]
+fn option_bool() {
+	let input: [u8; 0] = [];
+	OptionBool::decode(&mut &input[..]).unwrap();
+}

--- a/tests/invalid_input_len.rs
+++ b/tests/invalid_input_len.rs
@@ -8,8 +8,8 @@ fn vec_of_vec() {
 	let input = &mut &input[..];
 
 	let input_start_len = input.len();
-	let res = <Vec<Vec<()>>>::decode(input);
-	assert!(res.is_err());
+	let msg = <Vec<Vec<()>>>::decode(input).unwrap_err().what();
+	assert_eq!(msg, "Not enough data for required minimum length");
 
 	// Decoding stopped early, before vec allocation.
 	assert_eq!(input.len(), input_start_len - 1);

--- a/tests/mock.rs
+++ b/tests/mock.rs
@@ -1,0 +1,16 @@
+use parity_scale_codec::{Decode, Error};
+
+/// Mock that assert min_encoded_len is correct for the decoded value.
+pub trait DecodeM: Decode {
+	fn decode_m(value: &mut &[u8]) -> Result<Self, Error> {
+		let len = value.len();
+		let res = Self::decode(value);
+		if res.is_ok() {
+			assert!(len - value.len() >= Self::min_encoded_len());
+		}
+		res
+	}
+}
+
+impl<T: Decode> DecodeM for T {}
+

--- a/tests/mod.rs
+++ b/tests/mod.rs
@@ -18,7 +18,21 @@ extern crate serde_derive;
 #[macro_use]
 extern crate parity_scale_codec_derive;
 
-use parity_scale_codec::{Encode, Decode, HasCompact, Compact, EncodeAsRef, CompactAs};
+use parity_scale_codec::{Encode, Decode, HasCompact, Compact, EncodeAsRef, CompactAs, Error};
+
+/// Mock
+pub trait DecodeM: Decode {
+	fn decode_m(value: &mut &[u8]) -> Result<Self, Error> {
+		let len = value.len();
+		let res = Self::decode(value);
+		if res.is_ok() {
+			assert!(len - value.len() >= Self::min_encoded_len());
+		}
+		res
+	}
+}
+
+impl<T: Decode> DecodeM for T {}
 
 #[derive(Debug, PartialEq, Encode, Decode)]
 struct Unit;
@@ -124,13 +138,13 @@ fn should_work_for_simple_enum() {
 	});
 
 	let mut da: &[u8] = b"\x0f";
-	assert_eq!(EnumType::decode(&mut da).ok(), Some(a));
+	assert_eq!(EnumType::decode_m(&mut da).ok(), Some(a));
 	let mut db: &[u8] = b"\x01\x01\0\0\0\x02\0\0\0\0\0\0\0";
-	assert_eq!(EnumType::decode(&mut db).ok(), Some(b));
+	assert_eq!(EnumType::decode_m(&mut db).ok(), Some(b));
 	let mut dc: &[u8] = b"\x02\x01\0\0\0\x02\0\0\0\0\0\0\0";
-	assert_eq!(EnumType::decode(&mut dc).ok(), Some(c));
+	assert_eq!(EnumType::decode_m(&mut dc).ok(), Some(c));
 	let mut dz: &[u8] = &[0];
-	assert_eq!(EnumType::decode(&mut dz).ok(), None);
+	assert_eq!(EnumType::decode_m(&mut dz).ok(), None);
 }
 
 #[test]
@@ -146,13 +160,13 @@ fn should_work_for_enum_with_discriminant() {
 	});
 
 	let mut da: &[u8] = &[1];
-	assert_eq!(EnumWithDiscriminant::decode(&mut da), Ok(EnumWithDiscriminant::A));
+	assert_eq!(EnumWithDiscriminant::decode_m(&mut da), Ok(EnumWithDiscriminant::A));
 	let mut db: &[u8] = &[15];
-	assert_eq!(EnumWithDiscriminant::decode(&mut db), Ok(EnumWithDiscriminant::B));
+	assert_eq!(EnumWithDiscriminant::decode_m(&mut db), Ok(EnumWithDiscriminant::B));
 	let mut dc: &[u8] = &[255];
-	assert_eq!(EnumWithDiscriminant::decode(&mut dc), Ok(EnumWithDiscriminant::C));
+	assert_eq!(EnumWithDiscriminant::decode_m(&mut dc), Ok(EnumWithDiscriminant::C));
 	let mut dz: &[u8] = &[2];
-	assert_eq!(EnumWithDiscriminant::decode(&mut dz).ok(), None);
+	assert_eq!(EnumWithDiscriminant::decode_m(&mut dz).ok(), None);
 }
 
 #[test]
@@ -168,7 +182,7 @@ fn should_derive_encode() {
 fn should_derive_decode() {
 	let slice = b"\x0f\0\0\0\x09\0\0\0\0\0\0\0\x2cHello world".to_vec();
 
-	let v = TestType::decode(&mut &*slice);
+	let v = TestType::decode_m(&mut &*slice);
 
 	assert_eq!(v, Ok(TestType::new(15, 9, b"Hello world".to_vec())));
 }
@@ -182,7 +196,7 @@ fn should_work_for_unit() {
 	});
 
 	let mut a: &[u8] = &[];
-	assert_eq!(Unit::decode(&mut a), Ok(Unit));
+	assert_eq!(Unit::decode_m(&mut a), Ok(Unit));
 }
 
 #[test]
@@ -194,42 +208,42 @@ fn should_work_for_indexed() {
 	});
 
 	let mut v: &[u8] = b"\x01\0\0\0\x02\0\0\0\0\0\0\0";
-	assert_eq!(Indexed::decode(&mut v), Ok(Indexed(1, 2)));
+	assert_eq!(Indexed::decode_m(&mut v), Ok(Indexed(1, 2)));
 }
 
 #[test]
 #[should_panic(expected = "Error decoding field Indexed.0")]
 fn correct_error_for_indexed_0() {
 	let mut wrong: &[u8] = b"\x08";
-	Indexed::decode(&mut wrong).unwrap();
+	Indexed::decode_m(&mut wrong).unwrap();
 }
 
 #[test]
 #[should_panic(expected = "Error decoding field Indexed.1")]
 fn correct_error_for_indexed_1() {
 	let mut wrong: &[u8] = b"\0\0\0\0\x01";
-	Indexed::decode(&mut wrong).unwrap();
+	Indexed::decode_m(&mut wrong).unwrap();
 }
 
 #[test]
 #[should_panic(expected = "Error decoding field EnumType :: B.0")]
 fn correct_error_for_enumtype() {
 	let mut wrong: &[u8] = b"\x01";
-	EnumType::decode(&mut wrong).unwrap();
+	EnumType::decode_m(&mut wrong).unwrap();
 }
 
 #[test]
 #[should_panic(expected = "Error decoding field Struct.a")]
 fn correct_error_for_named_struct_1() {
 	let mut wrong: &[u8] = b"\x01";
-	Struct::<u32, u32, u32>::decode(&mut wrong).unwrap();
+	Struct::<u32, u32, u32>::decode_m(&mut wrong).unwrap();
 }
 
 #[test]
 #[should_panic(expected = "Error decoding field Struct.b")]
 fn correct_error_for_named_struct_2() {
 	let mut wrong: &[u8] = b"\0\0\0\0\x01";
-	Struct::<u32, u32, u32>::decode(&mut wrong).unwrap();
+	Struct::<u32, u32, u32>::decode_m(&mut wrong).unwrap();
 }
 
 const U64_TEST_COMPACT_VALUES: &[(u64, usize)] = &[
@@ -252,7 +266,7 @@ fn encoded_as_with_has_compact_works() {
 		let encoded = TestHasCompact { bar: n }.encode();
 		println!("{}", n);
 		assert_eq!(encoded.len(), l);
-		assert_eq!(<TestHasCompact<u64>>::decode(&mut &encoded[..]).unwrap().bar, n);
+		assert_eq!(<TestHasCompact<u64>>::decode_m(&mut &encoded[..]).unwrap().bar, n);
 	}
 }
 
@@ -262,7 +276,7 @@ fn compact_with_has_compact_works() {
 		let encoded = TestHasCompact { bar: n }.encode();
 		println!("{}", n);
 		assert_eq!(encoded.len(), l);
-		assert_eq!(<TestCompactHasCompact<u64>>::decode(&mut &encoded[..]).unwrap().bar, n);
+		assert_eq!(<TestCompactHasCompact<u64>>::decode_m(&mut &encoded[..]).unwrap().bar, n);
 	}
 }
 
@@ -278,7 +292,7 @@ fn enum_compact_and_encoded_as_with_has_compact_works() {
 			let encoded = value.encode();
 			println!("{:?}", value);
 			assert_eq!(encoded.len(), l);
-			assert_eq!(&<TestHasCompactEnum<u64>>::decode(&mut &encoded[..]).unwrap(), value);
+			assert_eq!(&<TestHasCompactEnum<u64>>::decode_m(&mut &encoded[..]).unwrap(), value);
 		}
 	}
 }
@@ -288,7 +302,7 @@ fn compact_meta_attribute_works() {
 	for &(n, l) in U64_TEST_COMPACT_VALUES {
 		let encoded = TestCompactAttribute { bar: n }.encode();
 		assert_eq!(encoded.len(), l);
-		assert_eq!(TestCompactAttribute::decode(&mut &encoded[..]).unwrap().bar, n);
+		assert_eq!(TestCompactAttribute::decode_m(&mut &encoded[..]).unwrap().bar, n);
 	}
 }
 
@@ -298,7 +312,7 @@ fn enum_compact_meta_attribute_works() {
 		for value in [ TestCompactAttributeEnum::Unnamed(n), TestCompactAttributeEnum::Named { bar: n } ].iter() {
 			let encoded = value.encode();
 			assert_eq!(encoded.len(), l);
-			assert_eq!(&TestCompactAttributeEnum::decode(&mut &encoded[..]).unwrap(), value);
+			assert_eq!(&TestCompactAttributeEnum::decode_m(&mut &encoded[..]).unwrap(), value);
 		}
 	}
 }
@@ -327,7 +341,7 @@ fn associated_type_bounds() {
 
 	let value: Struct<TraitImplementor, u64> = Struct { field: (vec![1, 2, 3], 42) };
 	let encoded = value.encode();
-	let decoded: Struct<TraitImplementor, u64> = Struct::decode(&mut &encoded[..]).unwrap();
+	let decoded: Struct<TraitImplementor, u64> = Struct::decode_m(&mut &encoded[..]).unwrap();
 	assert_eq!(value, decoded);
 }
 
@@ -463,7 +477,7 @@ fn encode_decode_empty_enum() {
     fn impls_encode_decode<T: Encode + Decode>() {}
 	impls_encode_decode::<EmptyEnumDerive>();
 
-	assert_eq!(EmptyEnumDerive::decode(&mut &[1, 2, 3][..]), Err("No such variant in enum EmptyEnumDerive".into()));
+	assert_eq!(EmptyEnumDerive::decode_m(&mut &[1, 2, 3][..]), Err("No such variant in enum EmptyEnumDerive".into()));
 }
 
 #[test]
@@ -475,6 +489,6 @@ fn codec_vec_u8() {
 		vec![0u8; 1000],
 	].into_iter() {
 		let e = v.encode();
-		assert_eq!(v, &Vec::<u8>::decode(&mut &e[..]).unwrap());
+		assert_eq!(v, &Vec::<u8>::decode_m(&mut &e[..]).unwrap());
 	}
 }

--- a/tests/mod.rs
+++ b/tests/mod.rs
@@ -18,21 +18,11 @@ extern crate serde_derive;
 #[macro_use]
 extern crate parity_scale_codec_derive;
 
-use parity_scale_codec::{Encode, Decode, HasCompact, Compact, EncodeAsRef, CompactAs, Error};
+use parity_scale_codec::{Encode, Decode, HasCompact, Compact, EncodeAsRef, CompactAs};
 
-/// Mock
-pub trait DecodeM: Decode {
-	fn decode_m(value: &mut &[u8]) -> Result<Self, Error> {
-		let len = value.len();
-		let res = Self::decode(value);
-		if res.is_ok() {
-			assert!(len - value.len() >= Self::min_encoded_len());
-		}
-		res
-	}
-}
+mod mock;
 
-impl<T: Decode> DecodeM for T {}
+use mock::DecodeM;
 
 #[derive(Debug, PartialEq, Encode, Decode)]
 struct Unit;

--- a/tests/single_field_struct_encoding.rs
+++ b/tests/single_field_struct_encoding.rs
@@ -1,8 +1,22 @@
 #[macro_use]
 extern crate parity_scale_codec_derive;
 
-use parity_scale_codec::{Compact, Encode, HasCompact, Decode};
+use parity_scale_codec::{Compact, Encode, HasCompact, Decode, Error};
 use serde_derive::{Serialize, Deserialize};
+
+/// Mock
+pub trait DecodeM: Decode {
+	fn decode_m(value: &mut &[u8]) -> Result<Self, Error> {
+		let len = value.len();
+		let res = Self::decode(value);
+		if res.is_ok() {
+			assert!(len - value.len() >= Self::min_encoded_len());
+		}
+		res
+	}
+}
+
+impl<T: Decode> DecodeM for T {}
 
 #[derive(Debug, PartialEq, Encode, Decode)]
 struct S {
@@ -100,16 +114,16 @@ fn test_encoding() {
 	assert_eq!(s_skip_cas.encode(), s_skip_cas_encoded);
 	assert_eq!(uh.encode(), uh_encoded);
 
-	assert_eq!(s, S::decode(&mut s_encoded).unwrap());
-	assert_eq!(s_skip, SSkip::decode(&mut s_skip_encoded).unwrap());
-	assert_eq!(sc, Sc::decode(&mut sc_encoded).unwrap());
-	assert_eq!(sh, Sh::decode(&mut sh_encoded).unwrap());
-	assert_eq!(u, U::decode(&mut u_encoded).unwrap());
-	assert_eq!(u_skip, USkip::decode(&mut u_skip_encoded).unwrap());
-	assert_eq!(uc, Uc::decode(&mut uc_encoded).unwrap());
-	assert_eq!(ucom, <Compact::<U>>::decode(&mut ucom_encoded).unwrap());
-	assert_eq!(ucas, Ucas::decode(&mut ucas_encoded).unwrap());
-	assert_eq!(u_skip_cas, USkipcas::decode(&mut u_skip_cas_encoded).unwrap());
-	assert_eq!(s_skip_cas, SSkipcas::decode(&mut s_skip_cas_encoded).unwrap());
-	assert_eq!(uh, Uh::decode(&mut uh_encoded).unwrap());
+	assert_eq!(s, S::decode_m(&mut s_encoded).unwrap());
+	assert_eq!(s_skip, SSkip::decode_m(&mut s_skip_encoded).unwrap());
+	assert_eq!(sc, Sc::decode_m(&mut sc_encoded).unwrap());
+	assert_eq!(sh, Sh::decode_m(&mut sh_encoded).unwrap());
+	assert_eq!(u, U::decode_m(&mut u_encoded).unwrap());
+	assert_eq!(u_skip, USkip::decode_m(&mut u_skip_encoded).unwrap());
+	assert_eq!(uc, Uc::decode_m(&mut uc_encoded).unwrap());
+	assert_eq!(ucom, <Compact::<U>>::decode_m(&mut ucom_encoded).unwrap());
+	assert_eq!(ucas, Ucas::decode_m(&mut ucas_encoded).unwrap());
+	assert_eq!(u_skip_cas, USkipcas::decode_m(&mut u_skip_cas_encoded).unwrap());
+	assert_eq!(s_skip_cas, SSkipcas::decode_m(&mut s_skip_cas_encoded).unwrap());
+	assert_eq!(uh, Uh::decode_m(&mut uh_encoded).unwrap());
 }

--- a/tests/single_field_struct_encoding.rs
+++ b/tests/single_field_struct_encoding.rs
@@ -1,22 +1,12 @@
 #[macro_use]
 extern crate parity_scale_codec_derive;
 
-use parity_scale_codec::{Compact, Encode, HasCompact, Decode, Error};
+use parity_scale_codec::{Compact, Encode, HasCompact};
 use serde_derive::{Serialize, Deserialize};
 
-/// Mock
-pub trait DecodeM: Decode {
-	fn decode_m(value: &mut &[u8]) -> Result<Self, Error> {
-		let len = value.len();
-		let res = Self::decode(value);
-		if res.is_ok() {
-			assert!(len - value.len() >= Self::min_encoded_len());
-		}
-		res
-	}
-}
+mod mock;
 
-impl<T: Decode> DecodeM for T {}
+use mock::DecodeM;
 
 #[derive(Debug, PartialEq, Encode, Decode)]
 struct S {

--- a/tests/skip.rs
+++ b/tests/skip.rs
@@ -1,21 +1,11 @@
 #[macro_use]
 extern crate parity_scale_codec_derive;
 
-use parity_scale_codec::{Encode, Decode, Error};
+use parity_scale_codec::Encode;
 
-/// Mock
-pub trait DecodeM: Decode {
-	fn decode_m(value: &mut &[u8]) -> Result<Self, Error> {
-		let len = value.len();
-		let res = Self::decode(value);
-		if res.is_ok() {
-			assert!(len - value.len() >= Self::min_encoded_len());
-		}
-		res
-	}
-}
+mod mock;
 
-impl<T: Decode> DecodeM for T {}
+use mock::DecodeM;
 
 #[test]
 fn enum_struct_test() {

--- a/tests/skip.rs
+++ b/tests/skip.rs
@@ -1,7 +1,21 @@
 #[macro_use]
 extern crate parity_scale_codec_derive;
 
-use parity_scale_codec::{Encode, Decode};
+use parity_scale_codec::{Encode, Decode, Error};
+
+/// Mock
+pub trait DecodeM: Decode {
+	fn decode_m(value: &mut &[u8]) -> Result<Self, Error> {
+		let len = value.len();
+		let res = Self::decode(value);
+		if res.is_ok() {
+			assert!(len - value.len() >= Self::min_encoded_len());
+		}
+		res
+	}
+}
+
+impl<T: Decode> DecodeM for T {}
 
 #[test]
 fn enum_struct_test() {
@@ -54,8 +68,8 @@ fn enum_struct_test() {
 	let mut sn_encoded: &[u8] = &sn.encode();
 	let mut su_encoded: &[u8] = &su.encode();
 
-	assert_eq!(Enum::decode(&mut eb_encoded).unwrap(), eb);
-	assert_eq!(Enum::decode(&mut ec_encoded).unwrap(), ec);
-	assert_eq!(StructNamed::decode(&mut sn_encoded).unwrap(), sn);
-	assert_eq!(StructUnnamed::decode(&mut su_encoded).unwrap(), su);
+	assert_eq!(Enum::decode_m(&mut eb_encoded).unwrap(), eb);
+	assert_eq!(Enum::decode_m(&mut ec_encoded).unwrap(), ec);
+	assert_eq!(StructNamed::decode_m(&mut sn_encoded).unwrap(), sn);
+	assert_eq!(StructUnnamed::decode_m(&mut su_encoded).unwrap(), su);
 }


### PR DESCRIPTION
Fix https://github.com/paritytech/parity-scale-codec/issues/109

Introduce `fn min_encoded_len` on `Decode` trait and `fn require_min_len` on `Input` trait.

Then when preallocating `Vec` or `array` in decode function we ensure that a valid result can actually be constructed with the input lenght. We do that by requiring that lenght of input of more than a minimum.

Thus someone cannot craft a false input which allocate tons of memory.

However if user expect its input to have certain property more than just being a valid struct it is not responsability of parity-scale-codec to consider those properties.
For example if user create: `struct A([u8; 1024])` and manually implement encode so that the array is encoded such as a `Vec`, then minimum encoded size of `[A; 32]` is 32 bytes but allocates 32*1024. Thus if this user consider that an input with mostly empty arrays is a wrong input he must implement Encode/Decode differently, this is not responsability of parity-scale-codec. Also such a situation might want to make use of constrained decoding principles proposed here: https://github.com/paritytech/parity-scale-codec/issues/112

Test has been implemented using a mock, I'm not sure it is the best strategy.

### TODO

* [x] implementation
* [x] update the README
* [x] do test minimum_len
* [ ] fuzzing of minimum_len as well ?
* [x] a bit more documentation
