### PR TITLE
Move Input and Output traits to a separate crate codec-io

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -235,21 +235,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "parity-scale-codec"
-version = "2.0.0"
+version = "1.0.0"
 dependencies = [
  "arrayvec 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "bitvec 0.11.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "byte-slice-cast 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "codec-io 0.1.0",
  "criterion 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "parity-scale-codec-derive 2.0.0",
+ "parity-scale-codec-derive 1.0.0",
  "serde 1.0.92 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.92 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "parity-scale-codec-derive"
-version = "2.0.0"
+version = "1.0.0"
 dependencies = [
  "proc-macro-crate 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -72,6 +72,10 @@ dependencies = [
 ]
 
 [[package]]
+name = "codec-io"
+version = "0.1.0"
+
+[[package]]
 name = "criterion"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -231,20 +235,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "parity-scale-codec"
-version = "1.0.0"
+version = "2.0.0"
 dependencies = [
  "arrayvec 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "bitvec 0.11.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "byte-slice-cast 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "codec-io 0.1.0",
  "criterion 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "parity-scale-codec-derive 1.0.0",
+ "parity-scale-codec-derive 2.0.0",
  "serde 1.0.92 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.92 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "parity-scale-codec-derive"
-version = "1.0.0"
+version = "2.0.0"
 dependencies = [
  "proc-macro-crate 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "parity-scale-codec"
 description = "SCALE - Simple Concatenating Aggregated Little Endians"
-version = "1.0.0"
+version = "2.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "Apache-2.0"
 repository = "https://github.com/paritytech/parity-scale-codec"
@@ -11,13 +11,14 @@ edition = "2018"
 [dependencies]
 arrayvec = { version = "0.4", default-features = false, features = ["array-sizes-33-128", "array-sizes-129-255"] }
 serde = { version = "1.0", optional = true }
-parity-scale-codec-derive = { path = "derive", version = "1.0", default-features = false, optional = true }
+parity-scale-codec-derive = { path = "derive", version = "2.0", default-features = false, optional = true }
+codec-io = { version = "0.1", path = "io", default-features = false }
 bitvec = { version = "0.11", default-features = false, features = ["alloc"], optional = true }
 byte-slice-cast = { version = "0.3.1", optional = true }
 
 [dev-dependencies]
 serde_derive = { version = "1.0" }
-parity-scale-codec-derive = { path = "derive", version = "1.0", default-features = false }
+parity-scale-codec-derive = { path = "derive", version = "2.0", default-features = false }
 criterion = "0.2"
 bitvec = "0.11"
 
@@ -31,7 +32,7 @@ bench = false
 [features]
 default = ["std"]
 derive = ["parity-scale-codec-derive"]
-std = ["serde", "bitvec/std"]
+std = ["serde", "bitvec/std", "codec-io/std"]
 bit-vec = ["bitvec", "byte-slice-cast"]
 
 # WARNING: DO _NOT_ USE THIS FEATURE IF YOU ARE WORKING ON CONSENSUS CODE!*
@@ -44,4 +45,5 @@ full = []
 [workspace]
 members = [
 	"derive",
+	"io",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "parity-scale-codec"
 description = "SCALE - Simple Concatenating Aggregated Little Endians"
-version = "2.0.0"
+version = "1.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "Apache-2.0"
 repository = "https://github.com/paritytech/parity-scale-codec"
@@ -11,14 +11,14 @@ edition = "2018"
 [dependencies]
 arrayvec = { version = "0.4", default-features = false, features = ["array-sizes-33-128", "array-sizes-129-255"] }
 serde = { version = "1.0", optional = true }
-parity-scale-codec-derive = { path = "derive", version = "2.0", default-features = false, optional = true }
+parity-scale-codec-derive = { path = "derive", version = "1.0", default-features = false, optional = true }
 codec-io = { version = "0.1", path = "io", default-features = false }
 bitvec = { version = "0.11", default-features = false, features = ["alloc"], optional = true }
 byte-slice-cast = { version = "0.3.1", optional = true }
 
 [dev-dependencies]
 serde_derive = { version = "1.0" }
-parity-scale-codec-derive = { path = "derive", version = "2.0", default-features = false }
+parity-scale-codec-derive = { path = "derive", version = "1.0", default-features = false }
 criterion = "0.2"
 bitvec = "0.11"
 

--- a/derive/Cargo.toml
+++ b/derive/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "parity-scale-codec-derive"
 description = "Serialization and deserialization derive macro for Parity SCALE Codec"
-version = "2.0.0"
+version = "1.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "Apache-2.0"
 edition = "2018"

--- a/derive/Cargo.toml
+++ b/derive/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "parity-scale-codec-derive"
 description = "Serialization and deserialization derive macro for Parity SCALE Codec"
-version = "1.0.0"
+version = "2.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "Apache-2.0"
 edition = "2018"

--- a/derive/src/encode.rs
+++ b/derive/src/encode.rs
@@ -114,7 +114,7 @@ fn encode_fields<F>(
 					_parity_scale_codec::Encode::encode_to(
 						&<#encoded_as as
 							_parity_scale_codec::EncodeAsRef<'_, #field_type>>::RefType::from(#field),
-						#dest
+						#dest,
 					);
 				}
 			}

--- a/derive/src/encode.rs
+++ b/derive/src/encode.rs
@@ -103,7 +103,7 @@ fn encode_fields<F>(
 					_parity_scale_codec::Encode::encode_to(
 						&<<#field_type as _parity_scale_codec::HasCompact>::Type as
 							_parity_scale_codec::EncodeAsRef<'_, #field_type>>::RefType::from(#field),
-						#dest
+						#dest,
 					);
 				}
 			}

--- a/derive/src/encode.rs
+++ b/derive/src/encode.rs
@@ -100,9 +100,10 @@ fn encode_fields<F>(
 			let field_type = &f.ty;
 			quote_spanned! {
 				f.span() => {
-					#dest.push(
+					_parity_scale_codec::Encode::encode_to(
 						&<<#field_type as _parity_scale_codec::HasCompact>::Type as
-							_parity_scale_codec::EncodeAsRef<'_, #field_type>>::RefType::from(#field)
+							_parity_scale_codec::EncodeAsRef<'_, #field_type>>::RefType::from(#field),
+						#dest
 					);
 				}
 			}
@@ -110,18 +111,17 @@ fn encode_fields<F>(
 			let field_type = &f.ty;
 			quote_spanned! {
 				f.span() => {
-					#dest.push(
+					_parity_scale_codec::Encode::encode_to(
 						&<#encoded_as as
-							_parity_scale_codec::EncodeAsRef<'_, #field_type>>::RefType::from(#field)
+							_parity_scale_codec::EncodeAsRef<'_, #field_type>>::RefType::from(#field),
+						#dest
 					);
 				}
 			}
 		} else if skip {
 			quote! {}
 		} else {
-			quote_spanned! { f.span() =>
-					#dest.push(#field);
-			}
+			quote_spanned! { f.span() => _parity_scale_codec::Encode::encode_to(#field, #dest); }
 		}
 	});
 

--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -138,7 +138,9 @@ pub fn decode_derive(input: TokenStream) -> TokenStream {
 		impl #impl_generics _parity_scale_codec::Decode for #name #ty_generics #where_clause {
 			fn decode<DecIn: _parity_scale_codec::Input>(
 				#input_: &mut DecIn
-			) -> Result<Self, _parity_scale_codec::Error> {
+			) -> Result<Self, _parity_scale_codec::Error> where
+				_parity_scale_codec::Error: From<DecIn::Error>
+			{
 				#decoding
 			}
 		}

--- a/io/Cargo.toml
+++ b/io/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "codec-io"
+description = "Common Input/Output trait definition shared by encoding libraries."
+version = "0.1.0"
+authors = ["Parity Technologies <admin@parity.io>"]
+license = "Apache-2.0"
+repository = "https://github.com/paritytech/parity-scale-codec"
+categories = ["encoding"]
+edition = "2018"
+
+[features]
+default = ["std"]
+std = []

--- a/io/src/lib.rs
+++ b/io/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright 2017, 2018 Parity Technologies
+// Copyright 2019 Parity Technologies
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/io/src/lib.rs
+++ b/io/src/lib.rs
@@ -1,0 +1,101 @@
+// Copyright 2017, 2018 Parity Technologies
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! # Input/Output Trait Definition for Encoding Libraries
+//!
+//! This library defines `Input` and `Output` traits that can be used for
+//! encoding libraries to define their own `Encode` and `Decode` traits.
+
+#![warn(missing_docs)]
+
+#![cfg_attr(not(feature = "std"), no_std)]
+
+extern crate alloc;
+
+/// Trait that allows reading of data into a slice.
+pub trait Input {
+	/// Error type of this input.
+	type Error;
+
+	/// Read the exact number of bytes required to fill the given buffer.
+	///
+	/// Note that this function is similar to `std::io::Read::read_exact` and not
+	/// `std::io::Read::read`.
+	fn read(&mut self, into: &mut [u8]) -> Result<(), Self::Error>;
+
+	/// Read a single byte from the input.
+	fn read_byte(&mut self) -> Result<u8, Self::Error> {
+		let mut buf = [0u8];
+		self.read(&mut buf[..])?;
+		Ok(buf[0])
+	}
+}
+
+/// Error for slice-based input. Only used in `no_std` environments.
+#[cfg(not(feature = "std"))]
+#[derive(PartialEq, Eq, Clone)]
+pub enum SliceInputError {
+	/// Not enough data to fill the buffer.
+	NotEnoughData,
+}
+
+#[cfg(not(feature = "std"))]
+impl<'a> Input for &'a [u8] {
+	type Error = SliceInputError;
+
+	fn read(&mut self, into: &mut [u8]) -> Result<(), SliceInputError> {
+		if into.len() > self.len() {
+			return Err(SliceInputError::NotEnoughData);
+		}
+		let len = into.len();
+		into.copy_from_slice(&self[..len]);
+		*self = &self[len..];
+		Ok(())
+	}
+}
+
+#[cfg(feature = "std")]
+impl<R: std::io::Read> Input for R {
+	type Error = std::io::Error;
+
+	fn read(&mut self, into: &mut [u8]) -> Result<(), std::io::Error> {
+		(self as &mut dyn std::io::Read).read_exact(into)?;
+		Ok(())
+	}
+}
+
+/// Trait that allows writing of data.
+pub trait Output: Sized {
+	/// Write to the output.
+	fn write(&mut self, bytes: &[u8]);
+
+	/// Write a single byte to the output.
+	fn push_byte(&mut self, byte: u8) {
+		self.write(&[byte]);
+	}
+}
+
+#[cfg(not(feature = "std"))]
+impl Output for alloc::vec::Vec<u8> {
+	fn write(&mut self, bytes: &[u8]) {
+		self.extend_from_slice(bytes)
+	}
+}
+
+#[cfg(feature = "std")]
+impl<W: std::io::Write> Output for W {
+	fn write(&mut self, bytes: &[u8]) {
+		(self as &mut dyn std::io::Write).write_all(bytes).expect("Codec outputs are infallible");
+	}
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,73 +13,73 @@
 // limitations under the License.
 
 //! # Parity SCALE Codec
-//! 
-//! Rust implementation of the SCALE (Simple Concatenated Aggregate Little-Endian) data format 
+//!
+//! Rust implementation of the SCALE (Simple Concatenated Aggregate Little-Endian) data format
 //! for types used in the Parity Substrate framework.
-//! 
-//! SCALE is a light-weight format which allows encoding (and decoding) which makes it highly 
-//! suitable for resource-constrained execution environments like blockchain runtimes and low-power, 
+//!
+//! SCALE is a light-weight format which allows encoding (and decoding) which makes it highly
+//! suitable for resource-constrained execution environments like blockchain runtimes and low-power,
 //! low-memory devices.
-//! 
-//! It is important to note that the encoding context (knowledge of how the types and data structures look) 
-//! needs to be known separately at both encoding and decoding ends. 
+//!
+//! It is important to note that the encoding context (knowledge of how the types and data structures look)
+//! needs to be known separately at both encoding and decoding ends.
 //! The encoded data does not include this contextual information.
-//! 
-//! To get a better understanding of how the encoding is done for different types, 
-//! take a look at the 
+//!
+//! To get a better understanding of how the encoding is done for different types,
+//! take a look at the
 //! [low-level data formats overview page at the Substrate docs site](https://substrate.dev/docs/en/overview/low-level-data-format).
-//! 
+//!
 //! ## Implementation
-//! 
+//!
 //! The codec is implemented using the following traits:
-//! 
+//!
 //! ### Encode
-//! 
+//!
 //! The `Encode` trait is used for encoding of data into the SCALE format. The `Encode` trait contains the following functions:
 
-//! * `size_hint(&self) -> usize`: Gets the capacity (in bytes) required for the encoded data. 
-//! This is to avoid double-allocation of memory needed for the encoding. 
-//! It can be an estimate and does not need to be an exact number. 
+//! * `size_hint(&self) -> usize`: Gets the capacity (in bytes) required for the encoded data.
+//! This is to avoid double-allocation of memory needed for the encoding.
+//! It can be an estimate and does not need to be an exact number.
 //! If the size is not known, even no good maximum, then we can skip this function from the trait implementation.
 //! This is required to be a cheap operation, so should not involve iterations etc.
 //! * `encode_to<T: Output>(&self, dest: &mut T)`: Encodes the value and appends it to a destination buffer.
 //! * `encode(&self) -> Vec<u8>`: Encodes the type data and returns a slice.
-//! * `using_encoded<R, F: FnOnce(&[u8]) -> R>(&self, f: F) -> R`: Encodes the type data and executes a closure on the encoded value. 
+//! * `using_encoded<R, F: FnOnce(&[u8]) -> R>(&self, f: F) -> R`: Encodes the type data and executes a closure on the encoded value.
 //! Returns the result from the executed closure.
-//! 
-//! **Note:** Implementations should override `using_encoded` for value types and `encode_to` for allocating types. 
+//!
+//! **Note:** Implementations should override `using_encoded` for value types and `encode_to` for allocating types.
 //! `size_hint` should be implemented for all types, wherever possible. Wrapper types should override all methods.
-//! 
+//!
 //! ### Decode
-//! 
+//!
 //! The `Decode` trait is used for deserialization/decoding of encoded data into the respective types.
-//! 
-//! * `fn decode<I: Input>(value: &mut I) -> Result<Self, Error>`: Tries to decode the value from SCALE format to the type it is called on. 
+//!
+//! * `fn decode<I: Input>(value: &mut I) -> Result<Self, Error>`: Tries to decode the value from SCALE format to the type it is called on.
 //! Returns an `Err` if the decoding fails.
-//! 
+//!
 //! ### CompactAs
-//! 
-//! The `CompactAs` trait is used for wrapping custom types/structs as compact types, which makes them even more space/memory efficient. 
+//!
+//! The `CompactAs` trait is used for wrapping custom types/structs as compact types, which makes them even more space/memory efficient.
 //! The compact encoding is described [here](https://substrate.dev/docs/en/overview/low-level-data-format#compact-general-integers).
-//! 
-//! * `encode_as(&self) -> &Self::As`: Encodes the type (self) as a compact type. 
+//!
+//! * `encode_as(&self) -> &Self::As`: Encodes the type (self) as a compact type.
 //! The type `As` is defined in the same trait and its implementation should be compact encode-able.
 //! * `decode_from(_: Self::As) -> Self`: Decodes the type (self) from a compact encode-able type.
-//! 
+//!
 //! ### HasCompact
-//! 
+//!
 //! The `HasCompact` trait, if implemented, tells that the corresponding type is a compact encode-able type.
-//! 
+//!
 //! ## Usage Examples
-//! 
+//!
 //! Following are some examples to demonstrate usage of the codec.
-//! 
+//!
 //! ### Simple types
-//! 
+//!
 //! ```
 //! use parity_scale_codec_derive::{Encode, Decode};
 //! use parity_scale_codec::{Encode, Decode};
-//! 
+//!
 //! #[derive(Debug, PartialEq, Encode, Decode)]
 //! enum EnumType {
 //! 	#[codec(index = "15")]
@@ -90,108 +90,108 @@
 //! 		b: u64,
 //! 	},
 //! }
-//! 
+//!
 //! let a = EnumType::A;
 //! let b = EnumType::B(1, 2);
 //! let c = EnumType::C { a: 1, b: 2 };
-//! 
+//!
 //! a.using_encoded(|ref slice| {
 //!     assert_eq!(slice, &b"\x0f");
 //! });
-//! 
+//!
 //! b.using_encoded(|ref slice| {
 //!     assert_eq!(slice, &b"\x01\x01\0\0\0\x02\0\0\0\0\0\0\0");
 //! });
-//! 
+//!
 //! c.using_encoded(|ref slice| {
 //!     assert_eq!(slice, &b"\x02\x01\0\0\0\x02\0\0\0\0\0\0\0");
 //! });
-//! 
+//!
 //! let mut da: &[u8] = b"\x0f";
 //! assert_eq!(EnumType::decode(&mut da).ok(), Some(a));
-//! 
+//!
 //! let mut db: &[u8] = b"\x01\x01\0\0\0\x02\0\0\0\0\0\0\0";
 //! assert_eq!(EnumType::decode(&mut db).ok(), Some(b));
-//! 
+//!
 //! let mut dc: &[u8] = b"\x02\x01\0\0\0\x02\0\0\0\0\0\0\0";
 //! assert_eq!(EnumType::decode(&mut dc).ok(), Some(c));
-//! 
+//!
 //! let mut dz: &[u8] = &[0];
 //! assert_eq!(EnumType::decode(&mut dz).ok(), None);
-//! 
+//!
 //! # fn main() { }
 //! ```
-//! 
+//!
 //! ### Compact type with HasCompact
-//! 
+//!
 //! ```
 //! use parity_scale_codec_derive::{Encode, Decode};;
 //! use parity_scale_codec::{Encode, Decode, Compact, HasCompact};
-//! 
+//!
 //! #[derive(Debug, PartialEq, Encode, Decode)]
 //! struct Test1CompactHasCompact<T: HasCompact> {
 //!     #[codec(compact)]
 //!     bar: T,
 //! }
-//! 
+//!
 //! #[derive(Debug, PartialEq, Encode, Decode)]
 //! struct Test1HasCompact<T: HasCompact> {
 //!     #[codec(encoded_as = "<T as HasCompact>::Type")]
 //!     bar: T,
 //! }
-//! 
+//!
 //! let test_val: (u64, usize) = (0u64, 1usize);
-//! 
+//!
 //! let encoded = Test1HasCompact { bar: test_val.0 }.encode();
 //! assert_eq!(encoded.len(), test_val.1);
 //! assert_eq!(<Test1CompactHasCompact<u64>>::decode(&mut &encoded[..]).unwrap().bar, test_val.0);
-//! 
+//!
 //! # fn main() { }
 //! ```
 //! ### Type with CompactAs
-//! 
+//!
 //! ```rust
-//! 
+//!
 //! use serde_derive::{Serialize, Deserialize};
 //! use parity_scale_codec_derive::{Encode, Decode};;
 //! use parity_scale_codec::{Encode, Decode, Compact, HasCompact, CompactAs};
-//! 
+//!
 //! #[cfg_attr(feature = "std", derive(Serialize, Deserialize, Debug))]
 //! #[derive(PartialEq, Eq, Clone)]
 //! struct StructHasCompact(u32);
-//! 
+//!
 //! impl CompactAs for StructHasCompact {
 //!     type As = u32;
-//! 
+//!
 //!     fn encode_as(&self) -> &Self::As {
 //!         &12
 //!     }
-//! 
+//!
 //!     fn decode_from(_: Self::As) -> Self {
 //!         StructHasCompact(12)
 //!     }
 //! }
-//! 
+//!
 //! impl From<Compact<StructHasCompact>> for StructHasCompact {
 //!     fn from(_: Compact<StructHasCompact>) -> Self {
 //!         StructHasCompact(12)
 //!     }
 //! }
-//! 
+//!
 //! #[derive(Debug, PartialEq, Encode, Decode)]
 //! enum TestGenericHasCompact<T> {
 //!     A {
 //!         #[codec(compact)] a: T
 //!     },
 //! }
-//! 
+//!
 //! let a = TestGenericHasCompact::A::<StructHasCompact> {
 //!     a: StructHasCompact(12325678),
 //! };
-//! 
+//!
 //! let encoded = a.encode();
 //! assert_eq!(encoded.len(), 2);
-//! 
+//!
 //! # fn main() { }
 //! ```
 
@@ -241,8 +241,9 @@ mod keyedvec;
 #[cfg(feature = "bit-vec")]
 mod bit_vec;
 
+pub use codec_io::{Input, Output};
 pub use self::codec::{
-	Input, Output, Error, Encode, Decode, Codec, EncodeAsRef, EncodeAppend, WrapperTypeEncode,
+	Error, Encode, Decode, Codec, EncodeAsRef, EncodeAppend, WrapperTypeEncode,
 	WrapperTypeDecode, OptionBool,
 };
 pub use self::compact::{Compact, HasCompact, CompactAs};


### PR DESCRIPTION
We will eventually face the issue of dealing with multiple binary encoding formats (such as ssz). In those situations, it is apparent that serde's model (using one `Serialize` and `Deserialize` trait for everything) is not sufficient. For example, U256 needs to be serialized as string in json, while as bytearray in SCALE and ssz. This is not possible to be represented by basic Rust structures.

Instead, we need to define Encode/Decode traits for each format we want to encode (have `scale::Encode`, `ssz::Encode`, etc). Those definitions can share common traits `Input` and `Output`. In this PR, I moved those two traits into a separate crate `codec-io` to make it reusable.

~~Note that I also generalized `Error` -- in some other encoding libraries we may not want to represent Error as solely `&str` or unit type and want to actually derive the error and pass it to library user. This requires changing `Decode` trait in parity-codec to have an extra bound `From<I::Error>`, which is a breaking change.~~ (This is not needed any more. I tried a different design that alias `codec_io::Error` to `std::io::Error` in `std`.)