### PR TITLE
impl debug for error in no_std + fix derive macro

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -82,7 +82,7 @@ version = "0.1.0"
 dependencies = [
  "bitvec 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "honggfuzz 0.5.45 (registry+https://github.com/rust-lang/crates.io-index)",
- "parity-scale-codec 1.0.1",
+ "parity-scale-codec 1.0.2",
 ]
 
 [[package]]
@@ -264,7 +264,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "parity-scale-codec"
-version = "1.0.1"
+version = "1.0.2"
 dependencies = [
  "arrayvec 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "bitvec 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -270,14 +270,14 @@ dependencies = [
  "bitvec 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "byte-slice-cast 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "criterion 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "parity-scale-codec-derive 1.0.0",
+ "parity-scale-codec-derive 1.0.1",
  "serde 1.0.92 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.92 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "parity-scale-codec-derive"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "proc-macro-crate 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -82,7 +82,7 @@ version = "0.1.0"
 dependencies = [
  "bitvec 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "honggfuzz 0.5.45 (registry+https://github.com/rust-lang/crates.io-index)",
- "parity-scale-codec 1.0.0",
+ "parity-scale-codec 1.0.1",
 ]
 
 [[package]]
@@ -264,7 +264,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "parity-scale-codec"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "arrayvec 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "bitvec 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "parity-scale-codec"
 description = "SCALE - Simple Concatenating Aggregated Little Endians"
-version = "1.0.1"
+version = "1.0.2"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "Apache-2.0"
 repository = "https://github.com/paritytech/parity-scale-codec"

--- a/derive/Cargo.toml
+++ b/derive/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "parity-scale-codec-derive"
 description = "Serialization and deserialization derive macro for Parity SCALE Codec"
-version = "1.0.0"
+version = "1.0.1"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "Apache-2.0"
 edition = "2018"

--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -148,7 +148,7 @@ pub fn decode_derive(input: TokenStream) -> TokenStream {
 
 			fn decode<DecIn: _parity_scale_codec::Input>(
 				#input_: &mut DecIn
-			) -> Result<Self, _parity_scale_codec::Error> {
+			) -> core::result::Result<Self, _parity_scale_codec::Error> {
 				#decode
 			}
 		}

--- a/src/codec.rs
+++ b/src/codec.rs
@@ -37,15 +37,14 @@ use std::fmt;
 
 use core::convert::TryFrom;
 
-#[cfg_attr(feature = "std", derive(Debug))]
-#[derive(PartialEq)]
-#[cfg(feature = "std")]
 /// Descriptive error type
+#[cfg(feature = "std")]
+#[derive(PartialEq, Debug)]
 pub struct Error(&'static str);
 
-#[cfg(not(feature = "std"))]
-#[derive(PartialEq)]
 /// Undescriptive error type when compiled for no std
+#[cfg(not(feature = "std"))]
+#[derive(PartialEq, Debug)]
 pub struct Error;
 
 impl Error {


### PR DESCRIPTION
we don't implement debug for error in no_std, this is very not handy when we want to use expect for instance

also derive was making use of Result, which can conflict with some locally defined result.

I have hard time dealing with patch on wasm build in for substrate but all native seems to build and wasm seems only to struggle with the Debug not being implemented.

Update codec to 1.0.2 and derive to 1.0.1