### PR TITLE
Maximum preallocation in decode

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,9 @@ The `Decode` trait is used for deserialization/decoding of encoded data into the
 
 * `fn decode<I: Input>(value: &mut I) -> Result<Self, Error>`: Tries to decode the value from SCALE format to the type it is called on.
 Returns an `Err` if the decoding fails.
+* `fn decode_inner<I: Input>(value: &mut I, preallocated: usize) -> Result<Self, Error>`: Tries to decode same as decode but with information
+about how much has been pre-allocated by caller. This allows callee to cap its pre-allocation to some maximum,
+see `DEFAULT_MAX_DECODE_PREALLOCATION_SIZE` and `Input::min_len`.
 
 ### CompactAs
 

--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -132,12 +132,14 @@ pub fn decode_derive(input: TokenStream) -> TokenStream {
 	let (impl_generics, ty_generics, where_clause) = input.generics.split_for_impl();
 
 	let input_ = quote!(input);
-	let decoding = decode::quote(&input.data, name, &input_);
+	let preallocated = quote!(preallocated);
+	let decoding = decode::quote(&input.data, name, &input_, &preallocated);
 
 	let impl_block = quote! {
 		impl #impl_generics _parity_scale_codec::Decode for #name #ty_generics #where_clause {
-			fn decode<DecIn: _parity_scale_codec::Input>(
-				#input_: &mut DecIn
+			fn decode_inner<DecIn: _parity_scale_codec::Input>(
+				#input_: &mut DecIn,
+				#preallocated: usize
 			) -> core::result::Result<Self, _parity_scale_codec::Error> {
 				#decoding
 			}

--- a/src/bit_vec.rs
+++ b/src/bit_vec.rs
@@ -47,8 +47,8 @@ impl<C: Cursor, T: BitStore + ToByteSlice> Encode for BitVec<C, T> {
 }
 
 impl<C: Cursor, T: BitStore + FromByteSlice> Decode for BitVec<C, T> {
-	fn decode<I: Input>(input: &mut I) -> Result<Self, Error> {
-		<Compact<u32>>::decode(input).and_then(move |Compact(bits)| {
+	fn decode_inner<I: Input>(input: &mut I, preallocated: usize) -> Result<Self, Error> {
+		<Compact<u32>>::decode_inner(input, preallocated).and_then(move |Compact(bits)| {
 			let bits = bits as usize;
 
 			let mut vec = vec![0; required_bytes::<T>(bits)];
@@ -69,8 +69,8 @@ impl<C: Cursor, T: BitStore + ToByteSlice> Encode for BitBox<C, T> {
 }
 
 impl<C: Cursor, T: BitStore + FromByteSlice> Decode for BitBox<C, T> {
-	fn decode<I: Input>(input: &mut I) -> Result<Self, Error> {
-		Ok(Self::from_bitslice(BitVec::<C, T>::decode(input)?.as_bitslice()))
+	fn decode_inner<I: Input>(input: &mut I, preallocated: usize) -> Result<Self, Error> {
+		Ok(Self::from_bitslice(BitVec::<C, T>::decode_inner(input, preallocated)?.as_bitslice()))
 	}
 }
 

--- a/src/codec.rs
+++ b/src/codec.rs
@@ -44,7 +44,6 @@ use std::fmt;
 /// Such bound is necessary to avoid crafted input to allocate too much space
 pub const DEFAULT_MAX_DECODE_PREALLOCATION_SIZE: usize = 4 * 1024;
 
-
 /// Descriptive error type
 #[cfg(feature = "std")]
 #[derive(PartialEq, Debug)]

--- a/src/decode_all.rs
+++ b/src/decode_all.rs
@@ -79,12 +79,12 @@ mod tests {
 	}
 
 	impl Decode for TestStruct {
-		fn decode<I: Input>(input: &mut I) -> Result<Self, Error> {
+		fn decode_inner<I: Input>(input: &mut I, preallocated: usize) -> Result<Self, Error> {
 			Ok(
 				Self {
-					data: Vec::<u32>::decode(input)?,
-					other: u8::decode(input)?,
-					compact: Compact::<u128>::decode(input)?,
+					data: Vec::<u32>::decode_inner(input, preallocated)?,
+					other: u8::decode_inner(input, preallocated)?,
+					compact: Compact::<u128>::decode_inner(input, preallocated)?,
 				}
 			)
 		}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -246,7 +246,7 @@ mod decode_all;
 
 pub use self::codec::{
 	Input, Output, Error, Encode, Decode, Codec, EncodeAsRef, EncodeAppend, WrapperTypeEncode,
-	WrapperTypeDecode, OptionBool,
+	WrapperTypeDecode, OptionBool, DEFAULT_MAX_DECODE_PREALLOCATION_SIZE
 };
 pub use self::compact::{Compact, HasCompact, CompactAs};
 pub use self::joiner::Joiner;


### PR DESCRIPTION
base on this https://github.com/paritytech/parity-scale-codec/issues/131#issuecomment-513715570

To ensure total preallocation doesn't overflow some maximum we need to make information moving from caller to callee in a way.

Two possible ways:
* caller send with decode what it actually pre-allocated for later datas. thus callee can bound its preallocation to a maximum minus this already pre-allocated size.
Implemented in this PR
* caller send to decode what is the maximum pre-allocation callee is allowed, callee will have to respect this number.
This would be done with having `decode(input, Some(maximum))` allowing user to specify a maxium to preallocate or no maximum if wanted. Actually this might be better, maybe trusted input would be without limit on preallocation.

Also what changes is:
* input is not longer implemented for Read because min_len is very not accurate, I can still do a wrapper though
* DEFAULT_MAX_PREALLOCATION_SIZE is exposed publicly so users can make use of it.

Question: Finally I think implementing second way with `decode(input, preallocation: Option<usize>)` might be better after all.