### PR TITLE
Bound preallocation to input len

### DIFF
--- a/derive/src/encode.rs
+++ b/derive/src/encode.rs
@@ -75,7 +75,7 @@ fn encode_single_field(
 				_parity_scale_codec::Encode::encode_to(&#final_field_variable, dest)
 			}
 
-			fn encode(&self) -> core::vec::Vec<u8> {
+			fn encode(&self) -> _parity_scale_codec::alloc::vec::Vec<u8> {
 				_parity_scale_codec::Encode::encode(&#final_field_variable)
 			}
 

--- a/derive/src/encode.rs
+++ b/derive/src/encode.rs
@@ -75,7 +75,7 @@ fn encode_single_field(
 				_parity_scale_codec::Encode::encode_to(&#final_field_variable, dest)
 			}
 
-			fn encode(&self) -> Vec<u8> {
+			fn encode(&self) -> core::vec::Vec<u8> {
 				_parity_scale_codec::Encode::encode(&#final_field_variable)
 			}
 

--- a/src/codec.rs
+++ b/src/codec.rs
@@ -156,8 +156,9 @@ impl From<std::io::Error> for Error {
 	}
 }
 
+/// Wrapper that implements Input for any `Read` and `Seek` type.
 #[cfg(feature = "std")]
-struct IoReader<R: std::io::Read + std::io::Seek>(R);
+struct IoReader<R: std::io::Read + std::io::Seek>(pub R);
 
 #[cfg(feature = "std")]
 impl<R: std::io::Read + std::io::Seek> Input for IoReader<R> {

--- a/src/codec.rs
+++ b/src/codec.rs
@@ -575,13 +575,13 @@ impl<T: Decode> Decode for Vec<T> {
 
 			if let IsU8::Yes = <T as Decode>::IS_U8 {
 				let r = if len <= max_preallocation {
-					// if len ok for preallocation then preallocate and read the slice
+					// If len is ok for preallocation then preallocate and read the slice.
 					let mut r = vec![0; len];
 
 					input.read(&mut r[..len])?;
 					r
 				} else {
-					// if len is considered too much for preallocation then use dynamic allocation
+					// If len is considered too much for preallocation then use dynamic allocation.
 					let mut r = Vec::new();
 					let mut remains = len;
 					let buffer_len = max_preallocation;

--- a/src/codec.rs
+++ b/src/codec.rs
@@ -164,16 +164,24 @@ pub struct IoReader<R: std::io::Read + std::io::Seek>(pub R);
 impl<R: std::io::Read + std::io::Seek> Input for IoReader<R> {
 	fn remaining_len(&mut self) -> Result<usize, Error> {
 		use std::convert::TryInto;
+		use std::io::SeekFrom;
 
-		let len = self.0.seek(std::io::SeekFrom::End(0))?
-			.saturating_sub(self.0.seek(std::io::SeekFrom::Current(0))?);
+		let old_pos = self.0.seek(SeekFrom::Current(0))?;
+		let len = self.0.seek(SeekFrom::End(0))?;
 
-		Ok(len.try_into().unwrap_or(usize::max_value()))
+		// Avoid seeking a third time when we were already at the end of the
+		// stream. The branch is usually way cheaper than a seek operation.
+		if old_pos != len {
+			self.0.seek(SeekFrom::Start(old_pos))?;
+		}
+
+		len.saturating_sub(old_pos)
+			.try_into()
+			.map_err(|_| "Input cannot fit into usize length".into())
 	}
 
 	fn read(&mut self, into: &mut [u8]) -> Result<(), Error> {
-		self.0.read_exact(into)?;
-		Ok(())
+		self.0.read_exact(into).map_err(Into::into)
 	}
 }
 
@@ -572,36 +580,18 @@ impl<T: Decode> Decode for Vec<T> {
 	fn decode<I: Input>(input: &mut I) -> Result<Self, Error> {
 		<Compact<u32>>::decode(input).and_then(move |Compact(len)| {
 			let len = len as usize;
-			let max_preallocation = input.remaining_len()?;
-
 			if let IsU8::Yes = <T as Decode>::IS_U8 {
-				let r = if len <= max_preallocation {
-					// If len is ok for preallocation then preallocate and read the slice.
-					let mut r = vec![0; len];
+				if len > input.remaining_len()? {
+					return Err("Not enough data to decode vector".into());
+				}
 
-					input.read(&mut r[..len])?;
-					r
-				} else {
-					// If len is considered too much for preallocation then use dynamic allocation.
-					let mut r = Vec::new();
-					let mut remains = len;
-					let buffer_len = max_preallocation;
-					let mut buffer = vec![0; buffer_len];
-
-					while remains != 0 {
-						let read_len = buffer_len.min(remains);
-						input.read(&mut buffer[..read_len])?;
-
-						remains -= read_len;
-						r.extend_from_slice(&buffer[..read_len]);
-					}
-					r
-				};
-
+				let mut r = vec![0; len];
+				input.read(&mut r)?;
 				let r = unsafe { mem::transmute::<Vec<u8>, Vec<T>>(r) };
 				Ok(r)
 			} else {
-				let capacity = max_preallocation.checked_div(mem::size_of::<T>()).unwrap_or(0);
+				let capacity = input.remaining_len()?.checked_div(mem::size_of::<T>())
+					.unwrap_or(0);
 				let mut r = Vec::with_capacity(capacity);
 				for _ in 0..len {
 					r.push(T::decode(input)?);
@@ -1191,5 +1181,24 @@ mod tests {
 			Ok(t7.into_sorted_vec()),
 		);
 		assert_eq!(Decode::decode(&mut &t8.encode()[..]), Ok(t8));
+	}
+
+	#[test]
+	fn io_reader() {
+		use std::io::{Seek, SeekFrom};
+
+		let mut io_reader = IoReader(std::io::Cursor::new(&[1u8, 2, 3][..]));
+
+		assert_eq!(io_reader.0.seek(SeekFrom::Current(0)).unwrap(), 0);
+		assert_eq!(io_reader.remaining_len().unwrap(), 3);
+
+		assert_eq!(io_reader.read_byte().unwrap(), 1);
+		assert_eq!(io_reader.0.seek(SeekFrom::Current(0)).unwrap(), 1);
+		assert_eq!(io_reader.remaining_len().unwrap(), 2);
+
+		assert_eq!(io_reader.read_byte().unwrap(), 2);
+		assert_eq!(io_reader.read_byte().unwrap(), 3);
+		assert_eq!(io_reader.0.seek(SeekFrom::Current(0)).unwrap(), 3);
+		assert_eq!(io_reader.remaining_len().unwrap(), 0);
 	}
 }

--- a/src/codec.rs
+++ b/src/codec.rs
@@ -158,7 +158,7 @@ impl From<std::io::Error> for Error {
 
 /// Wrapper that implements Input for any `Read` and `Seek` type.
 #[cfg(feature = "std")]
-struct IoReader<R: std::io::Read + std::io::Seek>(pub R);
+pub struct IoReader<R: std::io::Read + std::io::Seek>(pub R);
 
 #[cfg(feature = "std")]
 impl<R: std::io::Read + std::io::Seek> Input for IoReader<R> {

--- a/src/compact.rs
+++ b/src/compact.rs
@@ -46,6 +46,10 @@ struct PrefixInput<'a, T> {
 }
 
 impl<'a, T: 'a + Input> Input for PrefixInput<'a, T> {
+	fn remaining_len(&mut self) -> Result<usize, Error> {
+		Ok(self.input.remaining_len()?.saturating_add(1))
+	}
+
 	fn read(&mut self, buffer: &mut [u8]) -> Result<(), Error> {
 		match self.prefix.take() {
 			Some(v) if !buffer.is_empty() => {

--- a/src/compact.rs
+++ b/src/compact.rs
@@ -47,15 +47,14 @@ struct PrefixInput<'a, T> {
 
 impl<'a, T: 'a + Input> Input for PrefixInput<'a, T> {
 	fn remaining_len(&mut self) -> Result<usize, Error> {
-		Ok(self.input.remaining_len()?.saturating_add(1))
+		Ok(self.input.remaining_len()?.saturating_add(self.prefix.iter().count()))
 	}
 
 	fn read(&mut self, buffer: &mut [u8]) -> Result<(), Error> {
 		match self.prefix.take() {
 			Some(v) if !buffer.is_empty() => {
 				buffer[0] = v;
-				self.input.read(&mut buffer[1..])?;
-				Ok(())
+				self.input.read(&mut buffer[1..])
 			}
 			_ => self.input.read(buffer)
 		}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -209,6 +209,7 @@
 
 #[cfg(not(feature = "std"))]
 #[macro_use]
+#[doc(hidden)]
 pub extern crate alloc;
 
 #[cfg(feature = "parity-scale-codec-derive")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -246,7 +246,7 @@ mod decode_all;
 
 pub use self::codec::{
 	Input, Output, Error, Encode, Decode, Codec, EncodeAsRef, EncodeAppend, WrapperTypeEncode,
-	WrapperTypeDecode, OptionBool,
+	WrapperTypeDecode, OptionBool, IoReader,
 };
 pub use self::compact::{Compact, HasCompact, CompactAs};
 pub use self::joiner::Joiner;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -209,7 +209,7 @@
 
 #[cfg(not(feature = "std"))]
 #[macro_use]
-extern crate alloc;
+pub extern crate alloc;
 
 #[cfg(feature = "parity-scale-codec-derive")]
 #[allow(unused_imports)]
@@ -246,8 +246,10 @@ mod decode_all;
 
 pub use self::codec::{
 	Input, Output, Error, Encode, Decode, Codec, EncodeAsRef, EncodeAppend, WrapperTypeEncode,
-	WrapperTypeDecode, OptionBool, IoReader,
+	WrapperTypeDecode, OptionBool,
 };
+#[cfg(feature = "std")]
+pub use self::codec::IoReader;
 pub use self::compact::{Compact, HasCompact, CompactAs};
 pub use self::joiner::Joiner;
 pub use self::keyedvec::KeyedVec;

--- a/tests/mod.rs
+++ b/tests/mod.rs
@@ -491,3 +491,19 @@ fn recursive_type() {
 	}
 
 }
+
+#[test]
+fn crafted_input_for_vec_u8() {
+	assert_eq!(
+		Vec::<u8>::decode(&mut &Compact(u32::max_value()).encode()[..]).err().unwrap().what(),
+		"Not enough data to decode vector"
+	);
+}
+
+#[test]
+fn crafted_input_for_vec_t() {
+	assert_eq!(
+		Vec::<u32>::decode(&mut &Compact(u32::max_value()).encode()[..]).err().unwrap().what(),
+		"Not enough data to fill buffer"
+	);
+}


### PR DESCRIPTION
* input is no longer implemented for Read but only for &[u8] and also `
struct IoReader<R: std::io::Read + std::io::Seek>(R);` because compiler say std could choose to implement Seek on `&[u8]`.
Also as I remember in substrate we also import block from stdin. I'm not sure stdin implement seek.

* input has a new method which is remaining_len (it is not named len to avoid shadowing len method on &[u8]) which returns remaining_len. This is quite a strong constraint added to input, instead we could just add min_remaining_len and implementor can return less than actual len.

* the only structure that preallocate is Vec thus it is the only one changed