### PR TITLE
Update byte-slice-cast version to support no_std

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "parity-codec"
 description = "Lightweight, efficient, binary serialization and deserialization codec"
-version = "4.1.3"
+version = "4.1.4"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "Apache-2.0"
 repository = "https://github.com/paritytech/parity-codec"
@@ -13,7 +13,7 @@ arrayvec = { version = "0.4", default-features = false }
 serde = { version = "1.0", optional = true }
 parity-codec-derive = { path = "derive", version = "3.3", default-features = false, optional = true }
 bitvec = { version = "0.11", default-features = false, features = ["alloc"], optional = true }
-byte-slice-cast = { version = "0.3", optional = true }
+byte-slice-cast = { version = "0.3.2", default-features = false, optional = true }
 
 [dev-dependencies]
 serde_derive = { version = "1.0" }
@@ -22,7 +22,7 @@ parity-codec-derive = { path = "derive", version = "3.3", default-features = fal
 [features]
 default = ["std"]
 derive = ["parity-codec-derive"]
-std = ["serde", "bitvec/std"]
+std = ["serde", "bitvec/std", "byte-slice-cast/std"]
 bit-vec = ["bitvec", "byte-slice-cast"]
 
 # WARNING: DO _NOT_ USE THIS FEATURE IF YOU ARE WORKING ON CONSENSUS CODE!*


### PR DESCRIPTION
Port #142 to the `parity-codec-v4` branch.