### PR TITLE
Derive more stuff for error and then release

### DIFF
--- a/src/codec.rs
+++ b/src/codec.rs
@@ -39,12 +39,12 @@ use core::convert::TryFrom;
 
 /// Descriptive error type
 #[cfg(feature = "std")]
-#[derive(PartialEq, Debug)]
+#[derive(PartialEq, Eq, Clone, Debug)]
 pub struct Error(&'static str);
 
 /// Undescriptive error type when compiled for no std
 #[cfg(not(feature = "std"))]
-#[derive(PartialEq, Debug)]
+#[derive(PartialEq, Eq, Clone, Debug)]
 pub struct Error;
 
 impl Error {


### PR DESCRIPTION
This all I needed for substrate, now all tests succed. I think we can release scale-codec now