### PR TITLE
Wrong doc on encode_append

### DIFF
--- a/src/encode_append.rs
+++ b/src/encode_append.rs
@@ -25,6 +25,8 @@ pub trait EncodeAppend {
 
 	/// Append all items in `iter` to the given `self_encoded` representation.
 	///
+	/// Except if `self_encoded` value is empty then it just insert the given input data.
+	///
 	/// # Example
 	///
 	/// ```


### PR DESCRIPTION
currently if self_encoded is empty (thus being an invalid encoded value) then it just insert the given data.

Either we put that in the specification or we return an error. This PR put this into the specification.