### PR TITLE
Add method to EncodeAppend to append with EncodeLike items

### DIFF
--- a/src/encode_append.rs
+++ b/src/encode_append.rs
@@ -64,8 +64,8 @@ impl<T: Encode> EncodeAppend for Vec<T> {
 /// Trait that allows to append items to an encoded representation without
 /// decoding all previous added items.
 ///
-/// Same as `EncodeAppend` but allow to append with items that encode like the desired type instead
-/// of being the desired type directly.
+/// Same as `EncodeAppend` but allow to append with any items that encode like the desired item
+/// instead of being the desired item directly.
 pub trait EncodeLikeAppend {
 	/// The kind of item that will be appended. Actual appended item must encode like it.
 	type Item: Encode;

--- a/src/encode_append.rs
+++ b/src/encode_append.rs
@@ -12,13 +12,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::{Encode, Error, Decode, Compact, CompactLen};
+use crate::{Encode, Error, Decode, Compact, CompactLen, EncodeLike};
 
 use core::{iter::ExactSizeIterator, mem};
 use crate::alloc::vec::Vec;
 
 /// Trait that allows to append items to an encoded representation without
 /// decoding all previous added items.
+///
+/// Note: EncodeLikeAppend should be prefered as it allows to append with any type that encode like
+/// `Item`.
 pub trait EncodeAppend {
 	/// The item that will be appended.
 	type Item: Encode;
@@ -47,6 +50,70 @@ pub trait EncodeAppend {
 	) -> Result<Vec<u8>, Error> where Self::Item: 'a, I::IntoIter: ExactSizeIterator;
 }
 
+impl<T: Encode> EncodeAppend for Vec<T> {
+	type Item = T;
+
+	fn append<'a, I: IntoIterator<Item=&'a Self::Item>>(
+		self_encoded: Vec<u8>,
+		iter: I,
+	) -> Result<Vec<u8>, Error> where Self::Item: 'a, I::IntoIter: ExactSizeIterator {
+		append_vec_with_any_item(self_encoded, iter)
+	}
+}
+
+/// Trait that allows to append items to an encoded representation without
+/// decoding all previous added items.
+///
+/// Same as `EncodeAppend` but allow to append with items that encode like the desired type instead
+/// of being the desired type directly.
+pub trait EncodeLikeAppend {
+	/// The kind of item that will be appended. Actual appended item must encode like it.
+	type Item: Encode;
+
+	/// Append all items in `iter` to the given `self_encoded` representation.
+	///
+	/// Except if `self_encoded` value is empty then it just insert the given input data.
+	///
+	/// # Example
+	///
+	/// ```
+	///# use parity_scale_codec::EncodeLikeAppend;
+	///
+	/// // Some encoded data
+	/// let data = Vec::new();
+	///
+	/// let item = (&8u32, 3u32);
+	/// let encoded = <Vec<(u32, u32)> as EncodeLikeAppend>::append(data, std::iter::once(&item)).expect("Adds new element");
+	///
+	/// // Add multiple element
+	/// <Vec<(u32, u32)> as EncodeLikeAppend>::append(encoded, &[item, item, item]).expect("Adds new elements");
+	/// ```
+	fn append<'a, EncodeLikeItem, I>(
+		self_encoded: Vec<u8>,
+		iter: I,
+	) -> Result<Vec<u8>, Error>
+	where
+		I: IntoIterator<Item = &'a EncodeLikeItem>,
+		EncodeLikeItem: 'a + EncodeLike<Self::Item>,
+		I::IntoIter: ExactSizeIterator;
+}
+
+impl<T: Encode> EncodeLikeAppend for Vec<T> {
+	type Item = T;
+
+	fn append<'a, EncodeLikeItem, I>(
+		self_encoded: Vec<u8>,
+		iter: I,
+	) -> Result<Vec<u8>, Error>
+	where
+		I: IntoIterator<Item = &'a EncodeLikeItem>,
+		EncodeLikeItem: 'a + EncodeLike<Self::Item>,
+		I::IntoIter: ExactSizeIterator,
+	{
+		append_vec_with_any_item(self_encoded, iter)
+	}
+}
+
 fn extract_length_data(data: &[u8], input_len: usize) -> Result<(u32, usize, usize), Error> {
 	let len = u32::from(Compact::<u32>::decode(&mut &data[..])?);
 	let new_len = len
@@ -59,61 +126,63 @@ fn extract_length_data(data: &[u8], input_len: usize) -> Result<(u32, usize, usi
 	Ok((new_len, encoded_len, encoded_new_len))
 }
 
-impl<T: Encode + 'static> EncodeAppend for Vec<T> {
-	type Item = T;
+// Item must have same encoding as encoded value in the encoded vec.
+fn append_vec_with_any_item<'a, Item, I>(
+	mut self_encoded: Vec<u8>,
+	iter: I,
+) -> Result<Vec<u8>, Error>
+where
+	Item: 'a + Encode,
+	I: IntoIterator<Item = &'a Item>,
+	I::IntoIter: ExactSizeIterator,
+{
+	let iter = iter.into_iter();
+	let input_len = iter.len();
 
-	fn append<'a, I: IntoIterator<Item=&'a Self::Item>>(
-		mut self_encoded: Vec<u8>,
-		iter: I,
-	) -> Result<Vec<u8>, Error> where Self::Item: 'a, I::IntoIter: ExactSizeIterator {
-		let iter = iter.into_iter();
-		let input_len = iter.len();
+	// No data present, just encode the given input data.
+	if self_encoded.is_empty() {
+		crate::codec::compact_encode_len_to(&mut self_encoded, iter.len())?;
+		iter.for_each(|e| e.encode_to(&mut self_encoded));
+		return Ok(self_encoded);
+	}
 
-		// No data present, just encode the given input data.
-		if self_encoded.is_empty() {
-			crate::codec::compact_encode_len_to(&mut self_encoded, iter.len())?;
-			iter.for_each(|e| e.encode_to(&mut self_encoded));
-			return Ok(self_encoded);
-		}
+	let (new_len, encoded_len, encoded_new_len) = extract_length_data(&self_encoded, input_len)?;
 
-		let (new_len, encoded_len, encoded_new_len) = extract_length_data(&self_encoded, input_len)?;
+	let replace_len = |dest: &mut Vec<u8>| {
+		Compact(new_len).using_encoded(|e| {
+			dest[..encoded_new_len].copy_from_slice(e);
+		})
+	};
 
-		let replace_len = |dest: &mut Vec<u8>| {
-			Compact(new_len).using_encoded(|e| {
-				dest[..encoded_new_len].copy_from_slice(e);
-			})
-		};
+	let append_new_elems = |dest: &mut Vec<u8>| iter.for_each(|a| a.encode_to(dest));
 
-		let append_new_elems = |dest: &mut Vec<u8>| iter.for_each(|a| a.encode_to(dest));
+	// If old and new encoded len is equal, we don't need to copy the
+	// already encoded data.
+	if encoded_len == encoded_new_len {
+		replace_len(&mut self_encoded);
+		append_new_elems(&mut self_encoded);
 
-		// If old and new encoded len is equal, we don't need to copy the
-		// already encoded data.
-		if encoded_len == encoded_new_len {
-			replace_len(&mut self_encoded);
-			append_new_elems(&mut self_encoded);
+		Ok(self_encoded)
+	} else {
+		let size = encoded_new_len + self_encoded.len() - encoded_len;
 
-			Ok(self_encoded)
-		} else {
-			let size = encoded_new_len + self_encoded.len() - encoded_len;
+		let mut res = Vec::with_capacity(size + input_len * mem::size_of::<Item>());
+		unsafe { res.set_len(size); }
 
-			let mut res = Vec::with_capacity(size + input_len * mem::size_of::<T>());
-			unsafe { res.set_len(size); }
+		// Insert the new encoded len, copy the already encoded data and
+		// add the new element.
+		replace_len(&mut res);
+		res[encoded_new_len..size].copy_from_slice(&self_encoded[encoded_len..]);
+		append_new_elems(&mut res);
 
-			// Insert the new encoded len, copy the already encoded data and
-			// add the new element.
-			replace_len(&mut res);
-			res[encoded_new_len..size].copy_from_slice(&self_encoded[encoded_len..]);
-			append_new_elems(&mut res);
-
-			Ok(res)
-		}
+		Ok(res)
 	}
 }
 
 #[cfg(test)]
 mod tests {
 	use super::*;
-	use crate::{Input, EncodeLike};
+	use crate::{Input, Encode, EncodeLike, EncodeLikeAppend};
 
 	#[test]
 	fn vec_encode_append_works() {
@@ -168,5 +237,17 @@ mod tests {
 
 		let decoded = <Vec<NoCopy>>::decode(&mut &encoded[..]).unwrap();
 		assert_eq!(vec![append], decoded);
+	}
+
+	#[test]
+	fn vec_encode_like_append_works() {
+		let max_value = 1_000_000;
+
+		let encoded = (0..max_value).fold(Vec::new(), |encoded, v| {
+			<Vec<u32> as EncodeLikeAppend>::append(encoded, std::iter::once(&Box::new(v as u32))).unwrap()
+		});
+
+		let decoded = Vec::<u32>::decode(&mut &encoded[..]).unwrap();
+		assert_eq!(decoded, (0..max_value).collect::<Vec<_>>());
 	}
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -265,5 +265,5 @@ pub use self::compact::{Compact, HasCompact, CompactAs, CompactLen};
 pub use self::joiner::Joiner;
 pub use self::keyedvec::KeyedVec;
 pub use self::decode_all::DecodeAll;
-pub use self::encode_append::{EncodeAppend, EncodeLikeAppend};
+pub use self::encode_append::EncodeAppend;
 pub use self::encode_like::EncodeLike;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -265,5 +265,5 @@ pub use self::compact::{Compact, HasCompact, CompactAs, CompactLen};
 pub use self::joiner::Joiner;
 pub use self::keyedvec::KeyedVec;
 pub use self::decode_all::DecodeAll;
-pub use self::encode_append::EncodeAppend;
+pub use self::encode_append::{EncodeAppend, EncodeLikeAppend};
 pub use self::encode_like::EncodeLike;


### PR DESCRIPTION
implement EncodeLikeAppend which is EncodeAppend but using EncodeLike values.

It seems we can't derive EncodeAppend for EncodeLikeAppend automatically because some type can have EncodeLike not implemented and thus the `Iterator<EncodeLike<Item>>` cannot be converted into `Iterator<Item>`.

And if I derive only for types where `Item: EncodeLike<Item>` then it is a breaking change as EncodeAppend is no longer implemented for Item which doesn't have this bound.

I'm not sure if we should deprecate things ?
And naming is not perfect either.