### PR TITLE
impl EncodeAppend for EncodeLike + some helper

### DIFF
--- a/src/bit_vec.rs
+++ b/src/bit_vec.rs
@@ -19,7 +19,7 @@ use core::mem;
 use bitvec::{vec::BitVec, store::BitStore, cursor::Cursor, slice::BitSlice, boxed::BitBox};
 use byte_slice_cast::{AsByteSlice, ToByteSlice, FromByteSlice, Error as FromByteSliceError};
 
-use crate::codec::{Encode, Decode, Input, Output, Error};
+use crate::codec::{Encode, EncodeLike Decode, Input, Output, Error};
 use crate::compact::Compact;
 
 impl From<FromByteSliceError> for Error {
@@ -40,11 +40,15 @@ impl<C: Cursor, T: BitStore + ToByteSlice> Encode for BitSlice<C, T> {
 	}
 }
 
+impl<C: Cursor, T: BitStore + ToByteSlice> EncodeLike for BitSlice<C, T> {}
+
 impl<C: Cursor, T: BitStore + ToByteSlice> Encode for BitVec<C, T> {
 	fn encode_to<W: Output>(&self, dest: &mut W) {
 		self.as_bitslice().encode_to(dest)
 	}
 }
+
+impl<C: Cursor, T: BitStore + ToByteSlice> EncodeLike for BitVec<C, T> {}
 
 impl<C: Cursor, T: BitStore + FromByteSlice> Decode for BitVec<C, T> {
 	fn decode<I: Input>(input: &mut I) -> Result<Self, Error> {
@@ -67,6 +71,8 @@ impl<C: Cursor, T: BitStore + ToByteSlice> Encode for BitBox<C, T> {
 		self.as_bitslice().encode_to(dest)
 	}
 }
+
+impl<C: Cursor, T: BitStore + ToByteSlice> EncodeLike for BitBox<C, T> {}
 
 impl<C: Cursor, T: BitStore + FromByteSlice> Decode for BitBox<C, T> {
 	fn decode<I: Input>(input: &mut I) -> Result<Self, Error> {

--- a/src/bit_vec.rs
+++ b/src/bit_vec.rs
@@ -19,8 +19,9 @@ use core::mem;
 use bitvec::{vec::BitVec, store::BitStore, cursor::Cursor, slice::BitSlice, boxed::BitBox};
 use byte_slice_cast::{AsByteSlice, ToByteSlice, FromByteSlice, Error as FromByteSliceError};
 
-use crate::codec::{Encode, EncodeLike Decode, Input, Output, Error};
+use crate::codec::{Encode, Decode, Input, Output, Error};
 use crate::compact::Compact;
+use crate::EncodeLike;
 
 impl From<FromByteSliceError> for Error {
 	fn from(e: FromByteSliceError) -> Error {
@@ -39,8 +40,6 @@ impl<C: Cursor, T: BitStore + ToByteSlice> Encode for BitSlice<C, T> {
 		dest.write(self.as_slice().as_byte_slice());
 	}
 }
-
-impl<C: Cursor, T: BitStore + ToByteSlice> EncodeLike for BitSlice<C, T> {}
 
 impl<C: Cursor, T: BitStore + ToByteSlice> Encode for BitVec<C, T> {
 	fn encode_to<W: Output>(&self, dest: &mut W) {

--- a/src/encode_append.rs
+++ b/src/encode_append.rs
@@ -211,7 +211,7 @@ mod tests {
 		let max_value = 1_000_000;
 
 		let encoded = (0..max_value).fold(Vec::new(), |encoded, v| {
-			<Vec<u32> as EncodeAppend>::append_or_new(encoded, std::iter::once(&Box::new(v as u32))).unwrap()
+			<Vec<u32> as EncodeAppend>::append_or_new(encoded, std::iter::once(Box::new(v as u32))).unwrap()
 		});
 
 		let decoded = Vec::<u32>::decode(&mut &encoded[..]).unwrap();

--- a/src/encode_append.rs
+++ b/src/encode_append.rs
@@ -32,7 +32,7 @@ pub trait EncodeAppend {
 	) -> Result<Vec<u8>, Error> where Self::Item: 'a, I::IntoIter: ExactSizeIterator;
 
 	/// Append all items in `iter` to the given `self_encoded` representation
-	/// or if `self_encoded` value is empty then insert the given input data.
+	/// or if `self_encoded` value is empty, `iter` is encoded to the `Self` representation.
 	///
 	/// # Example
 	///

--- a/src/encode_like.rs
+++ b/src/encode_like.rs
@@ -48,7 +48,8 @@ use crate::Encode;
 ///
 /// Not all possible implementations of EncodeLike are implemented (for instance `Box<Box<u32>>`
 /// does not implement `EncodeLike<u32>`). To bypass this issue either open a PR to add the new
-/// combination or define a wrapper and implement `EncodeLike` on it as such:
+/// combination or use [`Ref`](./struct.Ref.html) reference wrapper or define your own wrapper
+/// and implement `EncodeLike` on it as such:
 /// ```
 ///# use parity_scale_codec::{EncodeLike, Encode, WrapperTypeEncode};
 /// fn encode_like<T: Encode, R: EncodeLike<T>>(data: &R) {
@@ -71,6 +72,20 @@ use crate::Encode;
 /// ```
 pub trait EncodeLike<T: Encode = Self>: Sized + Encode {}
 
+/// Reference wrapper that implement encode like any type that is encoded like its inner type.
+///
+/// # Example
+///
+/// ```rust
+/// # use parity_scale_codec::{EncodeLike, Ref};
+/// fn foo<T: EncodeLike<u8>>(t: T) -> T {
+///     store_t(Ref::from(&t)); // Store t using a reference.
+///     t
+/// }
+///
+/// fn store_t<T: EncodeLike<u8>>(t: T) {
+/// }
+/// ```
 pub struct Ref<'a, T: EncodeLike<U>, U: Encode>(&'a T, core::marker::PhantomData<U>);
 impl<'a, T: EncodeLike<U>, U: Encode> core::ops::Deref for Ref<'a, T, U> {
     type Target = T;

--- a/src/encode_like.rs
+++ b/src/encode_like.rs
@@ -71,6 +71,20 @@ use crate::Encode;
 /// ```
 pub trait EncodeLike<T: Encode = Self>: Sized + Encode {}
 
+pub struct Ref<'a, T: EncodeLike<U>, U: Encode>(&'a T, core::marker::PhantomData<U>);
+impl<'a, T: EncodeLike<U>, U: Encode> core::ops::Deref for Ref<'a, T, U> {
+    type Target = T;
+    fn deref(&self) -> &Self::Target { &self.0 }
+}
+
+impl<'a, T: EncodeLike<U>, U: Encode> From<&'a T> for Ref<'a, T, U> {
+	fn from(x: &'a T) -> Self {
+		Ref(x, Default::default())
+	}
+}
+impl<'a, T: EncodeLike<U>, U: Encode> crate::WrapperTypeEncode for Ref<'a, T, U> {}
+impl<'a, T: EncodeLike<U>, U: Encode> EncodeLike<U> for Ref<'a, T, U> {}
+
 #[cfg(test)]
 mod tests {
 	use super::*;

--- a/src/encode_like.rs
+++ b/src/encode_like.rs
@@ -99,6 +99,7 @@ impl<'a, T: EncodeLike<U>, U: Encode> From<&'a T> for Ref<'a, T, U> {
 }
 impl<'a, T: EncodeLike<U>, U: Encode> crate::WrapperTypeEncode for Ref<'a, T, U> {}
 impl<'a, T: EncodeLike<U>, U: Encode> EncodeLike<U> for Ref<'a, T, U> {}
+impl<'a, T: EncodeLike<U>, U: Encode> EncodeLike<U> for &Ref<'a, T, U> {}
 
 #[cfg(test)]
 mod tests {

--- a/src/encode_like.rs
+++ b/src/encode_like.rs
@@ -79,7 +79,7 @@ pub trait EncodeLike<T: Encode = Self>: Sized + Encode {}
 /// ```rust
 /// # use parity_scale_codec::{EncodeLike, Ref};
 /// fn foo<T: EncodeLike<u8>>(t: T) -> T {
-///     store_t(Ref::from(&t)); // Store t using a reference.
+///     store_t(Ref::from(&t)); // Store t without moving it, but only using a reference.
 ///     t
 /// }
 ///

--- a/src/generic_array.rs
+++ b/src/generic_array.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::{Encode, Decode, Error, Output, Input};
+use crate::{Encode, EncodeLike, Decode, Error, Output, Input};
 use crate::alloc::vec::Vec;
 
 impl<T: Encode, L: generic_array::ArrayLength<T>> Encode for generic_array::GenericArray<T, L> {
@@ -22,6 +22,8 @@ impl<T: Encode, L: generic_array::ArrayLength<T>> Encode for generic_array::Gene
 		}
 	}
 }
+
+impl<T: Encode, L: generic_array::ArrayLength<T>> EncodeLike for generic_array::GenericArray<T, L> {}
 
 impl<T: Decode, L: generic_array::ArrayLength<T>> Decode for generic_array::GenericArray<T, L> {
 	fn decode<I: Input>(input: &mut I) -> Result<Self, Error> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -256,8 +256,8 @@ mod encode_append;
 mod encode_like;
 
 pub use self::codec::{
-	Input, Output, Error, Encode, Decode, Codec, EncodeAsRef, WrapperTypeEncode,
-	WrapperTypeDecode, OptionBool, DecodeLength
+	Input, Output, Error, Decode, Encode, Codec, EncodeAsRef, WrapperTypeEncode,
+	WrapperTypeDecode, OptionBool, DecodeLength, FullCodec, FullEncode,
 };
 #[cfg(feature = "std")]
 pub use self::codec::IoReader;
@@ -266,4 +266,4 @@ pub use self::joiner::Joiner;
 pub use self::keyedvec::KeyedVec;
 pub use self::decode_all::DecodeAll;
 pub use self::encode_append::EncodeAppend;
-pub use self::encode_like::EncodeLike;
+pub use self::encode_like::{EncodeLike, Ref};


### PR DESCRIPTION
Done:
* some `impl EncodeLike for MyType<T>` as been rewritten `impl<T: EncodeLike<U>, U: Encode> EncodeLike<MyType<U>> for MyType<T>` when possible. this is actually a breaking change as some encodelike are not implemented anymore if T does implement `EncodeLike<T>`.

* FullDecode and FullEncode trait helper to bound Encode and EncodeLike at the same time.

* Ref struct: I'm not sure if it is very needed as I think the example is not a recommanded usage. If a function requires an `T: EncodeLike<u8>` and does have some clone in its body  then it must bound Clone to T so user can provide a reference directly. Because otherwise it seems if there is a lot of calls that do this reference stuff we can end up having some 10 times nested reference actual type being `Ref(&Ref(&Ref(&Ref..(&u8)))` which for u8 or almost any type is a loss.

* encode append is deprecated instead a new method is added which take an encodelike. Also you can that it lost a reference in this rewrite `Item=&'a Item` to `item=EncodeLikeItem`.

substrate branch is https://github.com/paritytech/substrate/tree/gui-encodelike-storage2