### PR TITLE
Remove allow unused

### DIFF
--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -57,7 +57,6 @@ fn wrap_with_dummy_const(impl_block: proc_macro2::TokenStream) -> TokenStream {
 	let parity_codec_crate = include_parity_scale_codec_crate();
 
 	let generated = quote! {
-		#[allow(non_upper_case_globals, unused_attributes, unused_qualifications, unused)]
 		const _: () = {
 			#[allow(unknown_lints)]
 			#[cfg_attr(feature = "cargo-clippy", allow(useless_attribute))]


### PR DESCRIPTION
I can't find why but inside a `const _ = { inside here }` no usued stuff gets reported. On both stable and nightly: see https://play.rust-lang.org/?version=stable&mode=debug&edition=2018&gist=b9e33d172e399cce0ad64426c6f76d8d

I compile parity-scale-codec test and half compiled substrate no unused reported.