### PR TITLE
Improve doc for macros and export them without hidden attribute

### DIFF
--- a/derive/Cargo.toml
+++ b/derive/Cargo.toml
@@ -14,3 +14,6 @@ syn = { version = "1.0.8", features = [ "full", "visit" ] }
 quote = "1.0.2"
 proc-macro2 = "1.0.6"
 proc-macro-crate = "0.1.4"
+
+[dev-dependencies]
+parity-scale-codec = { path = ".." }

--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -14,7 +14,6 @@
 
 //! Derives serialization and deserialization codec for complex structs for simple marshalling.
 
-
 #![recursion_limit = "128"]
 extern crate proc_macro;
 

--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -14,6 +14,7 @@
 
 //! Derives serialization and deserialization codec for complex structs for simple marshalling.
 
+
 #![recursion_limit = "128"]
 extern crate proc_macro;
 

--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -74,7 +74,7 @@ fn wrap_with_dummy_const(impl_block: proc_macro2::TokenStream) -> proc_macro::To
 ///
 /// Fields can have some attributes:
 /// * `#[codec(skip)]`: the field is not encoded. It must derive `Default` if Decode is derived.
-/// * `#[codec(compact)]`: the field is encoded in its compact implementation i.e. the field must
+/// * `#[codec(compact)]`: the field is encoded in its compact representation i.e. the field must
 ///   implement `parity_scale_codec::HasCompact` and will be encoded as `HasCompact::Type`.
 /// * `#[codec(encoded_as = "$EncodeAs")]: the field is encoded as an alternative type. $EncodedAs
 ///   type must implement `parity_scale_codec::EncodeAsRef<'_, $EncodedAs>`.

--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -66,6 +66,66 @@ fn wrap_with_dummy_const(impl_block: proc_macro2::TokenStream) -> proc_macro::To
 	generated.into()
 }
 
+/// Derive `parity_scale_codec::Encode` and `parity_scale_codec::EncodeLike` for struct and enum.
+///
+/// # Struct
+///
+/// A struct is encoded by encoded each of its fields successively.
+///
+/// Fields can have some attributes:
+/// * `#[codec(skip)]`: the field is not encoded. It must derive `Default` if Decode is derived.
+/// * `#[codec(compact)]`: the field is encoded in its compact implementation i.e. the field must
+///   implement `parity_scale_codec::HasCompact` and will be encoded as `HasCompact::Type`.
+/// * `#[codec(encoded_as = "$EncodeAs")]: the field is encoded as an alternative type. $EncodedAs
+///   type must implement `parity_scale_codec::EncodeAsRef<'_, $EncodedAs>`.
+///
+/// ```
+/// # use parity_scale_codec_derive::Encode;
+/// # use parity_scale_codec::{Encode, HasCompact};
+/// #[derive(Encode)]
+/// struct StructType {
+///		#[codec(skip)]
+///		a: u32,
+///		#[codec(compact)]
+/// 	b: u32,
+///		#[codec(encoded_as = "<u32 as HasCompact>::Type")]
+///		c: u32,
+/// }
+/// ```
+///
+/// # Enum
+///
+/// The variable is encoded with one byte for the variant and then the variant struct encoding.
+/// The variant number is:
+/// * if variant has attribute: `#[codec(index = "$n")]` then n
+/// * else if variant has discrimant (like 3 in `enum T { A = 3 }`) then the discrimant.
+/// * else its position in the variant set, excluding skipped variants, but including variant with
+/// discrimant or attribute. Do collision with discrimant or attribute index.
+///
+/// variant attribute:
+/// * `#[codec(skip)]`: the variant is not encoded.
+/// * `#[codec(index = "$n")]`: override variant index.
+///
+/// fields attribute: same as struct fields attributes.
+///
+/// ```
+/// # use parity_scale_codec_derive::Encode;
+/// # use parity_scale_codec::Encode;
+/// #[derive(Encode)]
+/// enum EnumType {
+/// 	#[codec(index = "15")]
+/// 	A,
+/// 	#[codec(skip)]
+/// 	B,
+/// 	C = 3,
+/// 	D,
+/// }
+///
+/// assert_eq!(EnumType::A.encode(), vec![15]);
+/// assert_eq!(EnumType::B.encode(), vec![]);
+/// assert_eq!(EnumType::C.encode(), vec![3]);
+/// assert_eq!(EnumType::D.encode(), vec![2]);
+/// ```
 #[proc_macro_derive(Encode, attributes(codec))]
 pub fn encode_derive(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
 	let mut input: DeriveInput = match syn::parse(input) {
@@ -104,6 +164,9 @@ pub fn encode_derive(input: proc_macro::TokenStream) -> proc_macro::TokenStream 
 	wrap_with_dummy_const(impl_block)
 }
 
+/// Derive `parity_scale_codec::Decode` and for struct and enum.
+///
+/// see derive `Encode` documentation.
 #[proc_macro_derive(Decode, attributes(codec))]
 pub fn decode_derive(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
 	let mut input: DeriveInput = match syn::parse(input) {

--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -70,7 +70,7 @@ fn wrap_with_dummy_const(impl_block: proc_macro2::TokenStream) -> proc_macro::To
 ///
 /// # Struct
 ///
-/// A struct is encoded by encoded each of its fields successively.
+/// A struct is encoded by encoding each of its fields successively.
 ///
 /// Fields can have some attributes:
 /// * `#[codec(skip)]`: the field is not encoded. It must derive `Default` if Decode is derived.
@@ -100,13 +100,14 @@ fn wrap_with_dummy_const(impl_block: proc_macro2::TokenStream) -> proc_macro::To
 /// * if variant has attribute: `#[codec(index = "$n")]` then n
 /// * else if variant has discrimant (like 3 in `enum T { A = 3 }`) then the discrimant.
 /// * else its position in the variant set, excluding skipped variants, but including variant with
-/// discrimant or attribute. Do collision with discrimant or attribute index.
+/// discrimant or attribute. Warning this position does collision with discrimant or attribute
+/// index.
 ///
-/// variant attribute:
+/// variant attributes:
 /// * `#[codec(skip)]`: the variant is not encoded.
 /// * `#[codec(index = "$n")]`: override variant index.
 ///
-/// fields attribute: same as struct fields attributes.
+/// field attributes: same as struct fields attributes.
 ///
 /// ```
 /// # use parity_scale_codec_derive::Encode;
@@ -208,6 +209,20 @@ pub fn decode_derive(input: proc_macro::TokenStream) -> proc_macro::TokenStream 
 	wrap_with_dummy_const(impl_block)
 }
 
+/// Derive `parity_scale_codec::Compact` and `parity_scale_codec::CompactAs` for struct with single
+/// field.
+///
+/// Attribute skip can be used to skip other fields.
+///
+/// # Example
+///
+/// ```
+/// # use parity_scale_codec_derive::CompactAs;
+/// # use parity_scale_codec::{Encode, HasCompact};
+/// # use std::marker::PhantomData;
+/// #[derive(CompactAs)]
+/// struct MyWrapper<T>(u32, #[codec(skip)] PhantomData<T>);
+/// ```
 #[proc_macro_derive(CompactAs, attributes(codec))]
 pub fn compact_as_derive(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
 	let mut input: DeriveInput = match syn::parse(input) {

--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -81,7 +81,7 @@ fn wrap_with_dummy_const(impl_block: proc_macro2::TokenStream) -> proc_macro::To
 ///
 /// ```
 /// # use parity_scale_codec_derive::Encode;
-/// # use parity_scale_codec::{Encode, HasCompact};
+/// # use parity_scale_codec::{Encode as _, HasCompact};
 /// #[derive(Encode)]
 /// struct StructType {
 ///		#[codec(skip)]
@@ -111,7 +111,7 @@ fn wrap_with_dummy_const(impl_block: proc_macro2::TokenStream) -> proc_macro::To
 ///
 /// ```
 /// # use parity_scale_codec_derive::Encode;
-/// # use parity_scale_codec::Encode;
+/// # use parity_scale_codec::Encode as _;
 /// #[derive(Encode)]
 /// enum EnumType {
 /// 	#[codec(index = "15")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -246,7 +246,6 @@ extern crate parity_scale_codec_derive;
 extern crate serde_derive;
 
 #[cfg(feature = "parity-scale-codec-derive")]
-#[doc(hidden)]
 pub use parity_scale_codec_derive::*;
 
 #[cfg(feature = "std")]

--- a/tests/variant_number.rs
+++ b/tests/variant_number.rs
@@ -1,0 +1,41 @@
+#[cfg(not(feature="derive"))]
+use parity_scale_codec_derive::Encode;
+use parity_scale_codec::Encode;
+
+#[test]
+fn discriminant_variant_counted_in_default_index() {
+	#[derive(Encode)]
+	enum T {
+		A = 1,
+		B,
+	}
+
+	assert_eq!(T::A.encode(), vec![1]);
+	assert_eq!(T::B.encode(), vec![1]);
+}
+
+#[test]
+fn skipped_variant_not_counted_in_default_index() {
+	#[derive(Encode)]
+	enum T {
+		#[codec(skip)]
+		A,
+		B,
+	}
+
+	assert_eq!(T::A.encode(), vec![]);
+	assert_eq!(T::B.encode(), vec![0]);
+}
+
+#[test]
+fn index_attr_variant_counted_and_reused_in_default_index() {
+	#[derive(Encode)]
+	enum T {
+		#[codec(index = "1")]
+		A,
+		B,
+	}
+
+	assert_eq!(T::A.encode(), vec![1]);
+	assert_eq!(T::B.encode(), vec![1]);
+}


### PR DESCRIPTION
Fix https://github.com/paritytech/parity-scale-codec/issues/171