### PR TITLE
Performance improvements

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ arrayvec = { version = "0.5.1", default-features = false, features = ["array-siz
 serde = { version = "1.0.102", optional = true }
 parity-scale-codec-derive = { path = "derive", version = "^1.0.2", default-features = false, optional = true }
 bitvec = { version = "0.15", default-features = false, features = ["alloc"], optional = true }
-byte-slice-cast = { version = "0.3.4", default-features = false, optional = true }
+byte-slice-cast = { version = "0.3.4", default-features = false, features = ["alloc"] }
 generic-array = { version = "0.13.2", optional = true }
 
 [dev-dependencies]
@@ -33,7 +33,7 @@ bench = false
 default = ["std"]
 derive = ["parity-scale-codec-derive"]
 std = ["serde", "bitvec/std", "byte-slice-cast/std"]
-bit-vec = ["bitvec", "byte-slice-cast"]
+bit-vec = ["bitvec"]
 
 # WARNING: DO _NOT_ USE THIS FEATURE IF YOU ARE WORKING ON CONSENSUS CODE!*
 #

--- a/benches/benches.rs
+++ b/benches/benches.rs
@@ -113,7 +113,7 @@ fn encode_decode_vec<T: TryFrom<u8> + Codec>(c: &mut Criterion) where T::Error: 
 	}, vec![1, 2, 5, 32, 1024, 2048, 16384]);
 
 	c.bench_function_over_inputs(&format!("vec_decode_{}", type_name::<T>()), |b, &vec_size| {
-		let vec: Vec<T> = (0..=255u8)
+		let vec: Vec<T> = (0..=127u8)
 			.cycle()
 			.take(vec_size)
 			.map(|v| v.try_into().unwrap())

--- a/src/codec.rs
+++ b/src/codec.rs
@@ -20,6 +20,8 @@ use core::{mem, ops::Deref, marker::PhantomData, iter::FromIterator, convert::Tr
 
 use arrayvec::ArrayVec;
 
+use byte_slice_cast::{AsByteSlice, IntoVecOf};
+
 #[cfg(any(feature = "std", feature = "full"))]
 use crate::alloc::{
 	string::String,
@@ -223,12 +225,25 @@ impl<W: std::io::Write> Output for W {
 	}
 }
 
-/// This enum must not be exported and must only be instantiable by parity-scale-codec.
-/// Because implementation of Encode and Decode for u8 is done in this crate
-/// and there is not other usage.
-pub enum IsU8 {
-	Yes,
-	No,
+
+/// !INTERNAL USE ONLY!
+///
+/// This enum provides type information to optimize encoding/decoding by doing fake specialization.
+#[doc(hidden)]
+#[non_exhaustive]
+pub enum TypeInfo {
+	/// Default value of [`Encode::TYPE_INFO`] to not require implementors to set this value in the trait.
+	Unknown,
+	U8,
+	I8,
+	U16,
+	I16,
+	U32,
+	I32,
+	U64,
+	I64,
+	U128,
+	I128,
 }
 
 /// Trait that allows zero-copy write of value-references to slices in LE format.
@@ -236,9 +251,10 @@ pub enum IsU8 {
 /// Implementations should override `using_encoded` for value types and `encode_to` and `size_hint` for allocating types.
 /// Wrapper types should override all methods.
 pub trait Encode {
+	// !INTERNAL USE ONLY!
+	// This const helps SCALE to optimize the encoding/decoding by doing fake specialization.
 	#[doc(hidden)]
-	// This const is used to optimise implementation of codec for Vec<u8>.
-	const IS_U8: IsU8 = IsU8::No;
+	const TYPE_INFO: TypeInfo = TypeInfo::Unknown;
 
 	/// If possible give a hint of expected size of the encoding.
 	///
@@ -275,8 +291,10 @@ pub trait DecodeLength {
 
 /// Trait that allows zero-copy read of value-references from slices in LE format.
 pub trait Decode: Sized {
+	// !INTERNAL USE ONLY!
+	// This const helps SCALE to optimize the encoding/decoding by doing fake specialization.
 	#[doc(hidden)]
-	const IS_U8: IsU8 = IsU8::No;
+	const TYPE_INFO: TypeInfo = TypeInfo::Unknown;
 
 	/// Attempt to deserialise the value from input.
 	fn decode<I: Input>(value: &mut I) -> Result<Self, Error>;
@@ -612,29 +630,105 @@ pub(crate) fn compact_encode_len_to<W: Output>(dest: &mut W, len: usize) -> Resu
 	Ok(())
 }
 
+/// A macro that matches on a [`TypeInfo`] and expands a given macro per variant.
+///
+/// The first parameter to the given macro will be the type of variant (e.g. `u8`, `u32`, etc.) and other parameters
+/// given to this macro.
+///
+/// The last parameter is the code that should be executed for the `Unknown` type info.
+macro_rules! with_type_info {
+	( $type_info:expr, $macro:ident $( ( $( $params:ident ),* ) )?, { $( $unknown_variant:tt )* }, ) => {
+		match $type_info {
+			TypeInfo::U8 => { $macro!(u8 $( $( , $params )* )? ) },
+			TypeInfo::I8 => { $macro!(i8 $( $( , $params )* )? ) },
+			TypeInfo::U16 => { $macro!(u16 $( $( , $params )* )? ) },
+			TypeInfo::I16 => { $macro!(i16 $( $( , $params )* )? ) },
+			TypeInfo::U32 => { $macro!(u32 $( $( , $params )* )? ) },
+			TypeInfo::I32 => { $macro!(i32 $( $( , $params )* )? ) },
+			TypeInfo::U64 => { $macro!(u64 $( $( , $params )* )? ) },
+			TypeInfo::I64 => { $macro!(i64 $( $( , $params )* )? ) },
+			TypeInfo::U128 => { $macro!(u128 $( $( , $params )* )? ) },
+			TypeInfo::I128 => { $macro!(i128 $( $( , $params )* )? ) },
+			TypeInfo::Unknown => { $( $unknown_variant )* },
+		}
+	};
+}
+
 impl<T: Encode> Encode for [T] {
 	fn size_hint(&self) -> usize {
-		if let IsU8::Yes = <T as Encode>::IS_U8 {
-			self.len() + mem::size_of::<u32>()
-		} else {
-			0
+		macro_rules! size_hint {
+			( $ty:ty, $self:ident ) => {{
+				let typed = unsafe { mem::transmute($self) };
+				// Max compact size   + size of the data as u8 slice
+				mem::size_of::<u32>() + <[$ty] as AsByteSlice<$ty>>::as_byte_slice(typed).len()
+			}};
+		}
+
+		with_type_info! {
+			<T as Encode>::TYPE_INFO,
+			size_hint(self),
+			{
+				// Max compact size
+				mem::size_of::<u32>()
+			},
 		}
 	}
 
 	fn encode_to<W: Output>(&self, dest: &mut W) {
 		compact_encode_len_to(dest, self.len()).expect("Compact encodes length");
 
-		if let IsU8::Yes= <T as Encode>::IS_U8 {
-			let self_transmute = unsafe {
-				core::mem::transmute::<&[T], &[u8]>(self)
-			};
-			dest.write(self_transmute)
-		} else {
-			for item in self {
-				item.encode_to(dest);
-			}
+		macro_rules! encode_to {
+			( $ty:ty, $self:ident, $dest:ident ) => {{
+				let typed = unsafe { mem::transmute($self) };
+				$dest.write(<[$ty] as AsByteSlice<$ty>>::as_byte_slice(typed))
+			}};
+		}
+
+		with_type_info! {
+			<T as Encode>::TYPE_INFO,
+			encode_to(self, dest),
+			{
+				for item in self {
+					item.encode_to(dest);
+				}
+			},
 		}
 	}
+}
+
+/// Read an `u8` vector from the given input.
+fn read_vec_u8<I: Input>(input: &mut I, len: usize) -> Result<Vec<u8>, Error> {
+	let input_len = input.remaining_len()?;
+
+	// If there is input len and it cannot be pre-allocated then return directly.
+	if input_len.map(|l| l < len).unwrap_or(false) {
+		return Err("Not enough data to decode vector".into())
+	}
+
+	// Note: we checked that if input_len is some then it can preallocated.
+	let r = if input_len.is_some() || len < MAX_PREALLOCATION {
+		// Here we pre-allocate the whole buffer.
+		let mut r = vec![0; len];
+		input.read(&mut r)?;
+
+		r
+	} else {
+		// Here we pre-allocate only the maximum pre-allocation
+		let mut r = vec![];
+
+		let mut remains = len;
+		while remains != 0 {
+			let len_read = MAX_PREALLOCATION.min(remains);
+			let len_filled = r.len();
+			r.resize(len_filled + len_read, 0);
+			input.read(&mut r[len_filled..])?;
+			remains -= len_read;
+		}
+
+		r
+	};
+
+	Ok(r)
 }
 
 impl<T> WrapperTypeEncode for Vec<T> {}
@@ -646,49 +740,31 @@ impl<T: Decode> Decode for Vec<T> {
 	fn decode<I: Input>(input: &mut I) -> Result<Self, Error> {
 		<Compact<u32>>::decode(input).and_then(move |Compact(len)| {
 			let len = len as usize;
-			if let IsU8::Yes = <T as Decode>::IS_U8 {
-				let input_len = input.remaining_len()?;
 
-				// If there is input len and it cannot be pre-allocated then return directly.
-				if input_len.map(|l| l < len).unwrap_or(false) {
-					return Err("Not enough data to decode vector".into())
-				}
+			macro_rules! decode {
+				( $ty:ty, $input:ident, $len:ident ) => {{
+					let vec = read_vec_u8($input, $len * mem::size_of::<$ty>())?;
+					let typed = vec.into_vec_of::<$ty>()
+						.map_err(|_| "Failed to convert from `Vec<u8>` to typed vec")?;
 
-				// Note: we checked that if input_len is some then it can preallocated.
-				let r = if input_len.is_some() || len < MAX_PREALLOCATION {
-					// Here we pre-allocate the whole buffer.
-					let mut r = vec![0; len];
-					input.read(&mut r)?;
+					Ok(unsafe { mem::transmute::<Vec<$ty>, Vec<T>>(typed) })
+				}};
+			}
 
-					r
-				} else {
-					// Here we pre-allocate only the maximum pre-allocation
-					let mut r = vec![];
-
-					let mut remains = len;
-					while remains != 0 {
-						let len_read = MAX_PREALLOCATION.min(remains);
-						let len_filled = r.len();
-						r.resize(len_filled + len_read, 0);
-						input.read(&mut r[len_filled..])?;
-						remains -= len_read;
+			with_type_info! {
+				<T as Decode>::TYPE_INFO,
+				decode(input, len),
+				{
+					let capacity = input.remaining_len()?
+						.unwrap_or(MAX_PREALLOCATION)
+						.checked_div(mem::size_of::<T>())
+						.unwrap_or(0);
+					let mut r = Vec::with_capacity(capacity);
+					for _ in 0..len {
+						r.push(T::decode(input)?);
 					}
-
-					r
-				};
-
-				let r = unsafe { mem::transmute::<Vec<u8>, Vec<T>>(r) };
-				Ok(r)
-			} else {
-				let capacity = input.remaining_len()?
-					.unwrap_or(MAX_PREALLOCATION)
-					.checked_div(mem::size_of::<T>())
-					.unwrap_or(0);
-				let mut r = Vec::with_capacity(capacity);
-				for _ in 0..len {
-					r.push(T::decode(input)?);
-				}
-				Ok(r)
+					Ok(r)
+				},
 			}
 		})
 	}
@@ -751,17 +827,26 @@ impl<T: Encode + Ord> Encode for VecDeque<T> {
 	fn encode_to<W: Output>(&self, dest: &mut W) {
 		compact_encode_len_to(dest, self.len()).expect("Compact encodes length");
 
-		if let IsU8::Yes = <T as Encode>::IS_U8 {
-			let slices = self.as_slices();
-			let slices_transmute = unsafe {
-				core::mem::transmute::<(&[T], &[T]), (&[u8], &[u8])>(slices)
-			};
-			dest.write(slices_transmute.0);
-			dest.write(slices_transmute.1);
-		} else {
-			for item in self {
-				item.encode_to(dest);
-			}
+		macro_rules! encode_to {
+			( $ty:ty, $self:ident, $dest:ident ) => {{
+				let slices = $self.as_slices();
+				let typed = unsafe {
+					core::mem::transmute::<(&[T], &[T]), (&[$ty], &[$ty])>(slices)
+				};
+
+				$dest.write(<[$ty] as AsByteSlice<$ty>>::as_byte_slice(typed.0));
+				$dest.write(<[$ty] as AsByteSlice<$ty>>::as_byte_slice(typed.1));
+			}};
+		}
+
+		with_type_info! {
+			<T as Encode>::TYPE_INFO,
+			encode_to(self, dest),
+			{
+				for item in self {
+					item.encode_to(dest);
+				}
+			},
 		}
 	}
 }
@@ -896,10 +981,12 @@ mod inner_tuple_impl {
 }
 
 macro_rules! impl_endians {
-	( $( $t:ty ),* ) => { $(
+	( $( $t:ty; $ty_info:ident ),* ) => { $(
 		impl EncodeLike for $t {}
 
 		impl Encode for $t {
+			const TYPE_INFO: TypeInfo = TypeInfo::$ty_info;
+
 			fn size_hint(&self) -> usize {
 				mem::size_of::<$t>()
 			}
@@ -911,6 +998,8 @@ macro_rules! impl_endians {
 		}
 
 		impl Decode for $t {
+			const TYPE_INFO: TypeInfo = TypeInfo::$ty_info;
+
 			fn decode<I: Input>(input: &mut I) -> Result<Self, Error> {
 				let mut buf = [0u8; mem::size_of::<$t>()];
 				input.read(&mut buf)?;
@@ -920,11 +1009,11 @@ macro_rules! impl_endians {
 	)* }
 }
 macro_rules! impl_one_byte {
-	( $( $t:ty $( { $is_u8:ident } )? ),* ) => { $(
+	( $( $t:ty; $ty_info:ident ),* ) => { $(
 		impl EncodeLike for $t {}
 
 		impl Encode for $t {
-			$( const $is_u8: IsU8 = IsU8::Yes; )?
+			const TYPE_INFO: TypeInfo = TypeInfo::$ty_info;
 
 			fn size_hint(&self) -> usize {
 				mem::size_of::<$t>()
@@ -936,7 +1025,7 @@ macro_rules! impl_one_byte {
 		}
 
 		impl Decode for $t {
-			$( const $is_u8: IsU8 = IsU8::Yes; )?
+			const TYPE_INFO: TypeInfo = TypeInfo::$ty_info;
 
 			fn decode<I: Input>(input: &mut I) -> Result<Self, Error> {
 				Ok(input.read_byte()? as $t)
@@ -945,8 +1034,8 @@ macro_rules! impl_one_byte {
 	)* }
 }
 
-impl_endians!(u16, u32, u64, u128, i16, i32, i64, i128);
-impl_one_byte!(u8 {IS_U8}, i8);
+impl_endians!(u16; U16, u32; U32, u64; U64, u128; U128, i16; I16, i32; I32, i64; I64, i128; I128);
+impl_one_byte!(u8; U8, i8; I8);
 
 impl EncodeLike for bool {}
 

--- a/src/compact.rs
+++ b/src/compact.rs
@@ -881,7 +881,7 @@ mod tests {
 			(u64::max_value() << 8) - 1,
 			u64::max_value() << 16,
 			(u64::max_value() << 16) - 1,
-		].into_iter() {
+		].iter() {
 			let e = Compact::<u64>::encode(&Compact(*a));
 			let d = Compact::<u64>::decode(&mut &e[..]).unwrap().0;
 			assert_eq!(*a, d);
@@ -895,7 +895,7 @@ mod tests {
 			(u64::max_value() - 10) as u128,
 			u128::max_value(),
 			u128::max_value() - 10,
-		].into_iter() {
+		].iter() {
 			let e = Compact::<u128>::encode(&Compact(*a));
 			let d = Compact::<u128>::decode(&mut &e[..]).unwrap().0;
 			assert_eq!(*a, d);

--- a/tests/mod.rs
+++ b/tests/mod.rs
@@ -489,7 +489,7 @@ fn codec_vec_u8() {
 		vec![0u8; 10],
 		vec![0u8; 100],
 		vec![0u8; 1000],
-	].into_iter() {
+	].iter() {
 		let e = v.encode();
 		assert_eq!(v, &Vec::<u8>::decode(&mut &e[..]).unwrap());
 	}

--- a/tests/mod.rs
+++ b/tests/mod.rs
@@ -476,7 +476,7 @@ fn encode_decode_empty_enum() {
 	#[derive(Encode, Decode, PartialEq, Debug)]
 	enum EmptyEnumDerive {}
 
-    fn impls_encode_decode<T: Encode + Decode>() {}
+	fn impls_encode_decode<T: Encode + Decode>() {}
 	impls_encode_decode::<EmptyEnumDerive>();
 
 	assert_eq!(EmptyEnumDerive::decode(&mut &[1, 2, 3][..]), Err("No such variant in enum EmptyEnumDerive".into()));
@@ -514,7 +514,7 @@ fn recursive_type() {
 fn crafted_input_for_vec_u8() {
 	assert_eq!(
 		Vec::<u8>::decode(&mut &Compact(u32::max_value()).encode()[..]).err().unwrap().what(),
-		"Not enough data to decode vector"
+		"Not enough data to decode vector",
 	);
 }
 
@@ -522,7 +522,7 @@ fn crafted_input_for_vec_u8() {
 fn crafted_input_for_vec_t() {
 	assert_eq!(
 		Vec::<u32>::decode(&mut &Compact(u32::max_value()).encode()[..]).err().unwrap().what(),
-		"Not enough data to fill buffer"
+		"Not enough data to decode vector",
 	);
 }
 


### PR DESCRIPTION
This pr brings some performance improvements, here are some benchmarks from before and after:

```
vec_decode_complex_type/1                                                                            
                        time:   [84.946 ns 85.588 ns 86.417 ns]
                        change: [-5.4537% -3.8573% -2.5559%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 7 outliers among 100 measurements (7.00%)
  2 (2.00%) high mild
  5 (5.00%) high severe
vec_decode_complex_type/2                                                                            
                        time:   [224.83 ns 225.17 ns 225.55 ns]
                        change: [+19.404% +19.821% +20.256%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 8 outliers among 100 measurements (8.00%)
  6 (6.00%) high mild
  2 (2.00%) high severe
vec_decode_complex_type/5                                                                            
                        time:   [483.57 ns 484.17 ns 484.89 ns]
                        change: [+19.389% +20.094% +20.636%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 8 outliers among 100 measurements (8.00%)
  3 (3.00%) high mild
  5 (5.00%) high severe
vec_decode_complex_type/32                                                                             
                        time:   [3.1287 us 3.1487 us 3.1872 us]
                        change: [+15.714% +16.734% +17.889%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 5 outliers among 100 measurements (5.00%)
  3 (3.00%) high mild
  2 (2.00%) high severe
vec_decode_complex_type/1024                                                                            
                        time:   [87.962 us 88.470 us 89.069 us]
                        change: [-91.906% -91.848% -91.796%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 10 outliers among 100 measurements (10.00%)
  6 (6.00%) high mild
  4 (4.00%) high severe
vec_decode_complex_type/2048                                                                            
                        time:   [175.26 us 175.80 us 176.46 us]
                        change: [-93.291% -93.222% -93.157%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 3 outliers among 100 measurements (3.00%)
  3 (3.00%) high severe
Benchmarking vec_decode_complex_type/16384: Warming up for 500.00 ms
Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 7.2s or reduce sample count to 50
vec_decode_complex_type/16384                                                                             
                        time:   [1.4089 ms 1.4114 ms 1.4149 ms]
                        change: [-95.519% -95.491% -95.451%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 8 outliers among 100 measurements (8.00%)
  5 (5.00%) high mild
  3 (3.00%) high severe
```

```
vec_encode_complex_type/1                                                                             
                        time:   [25.848 ns 26.059 ns 26.337 ns]
                        change: [-76.582% -76.372% -76.159%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 7 outliers among 100 measurements (7.00%)
  2 (2.00%) high mild
  5 (5.00%) high severe
vec_encode_complex_type/2                                                                             
                        time:   [40.648 ns 41.198 ns 41.896 ns]
                        change: [-82.797% -82.528% -82.175%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 6 outliers among 100 measurements (6.00%)
  2 (2.00%) high mild
  4 (4.00%) high severe
vec_encode_complex_type/5                                                                            
                        time:   [90.026 ns 90.806 ns 91.771 ns]
                        change: [-74.771% -74.517% -74.279%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 11 outliers among 100 measurements (11.00%)
  5 (5.00%) high mild
  6 (6.00%) high severe
vec_encode_complex_type/32                                                                            
                        time:   [477.59 ns 479.44 ns 481.54 ns]
                        change: [-68.468% -68.313% -68.129%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 7 outliers among 100 measurements (7.00%)
  5 (5.00%) high mild
  2 (2.00%) high severe
vec_encode_complex_type/1024                                                                             
                        time:   [13.408 us 13.443 us 13.480 us]
                        change: [-58.813% -58.468% -58.196%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 4 outliers among 100 measurements (4.00%)
  2 (2.00%) high mild
  2 (2.00%) high severe
vec_encode_complex_type/2048                                                                             
                        time:   [26.874 us 26.974 us 27.078 us]
                        change: [-58.554% -58.289% -58.049%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 2 outliers among 100 measurements (2.00%)
  2 (2.00%) high severe
vec_encode_complex_type/16384                                                                            
                        time:   [213.28 us 214.22 us 215.24 us]
                        change: [-59.009% -58.632% -58.145%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 5 outliers among 100 measurements (5.00%)
  4 (4.00%) high mild
  1 (1.00%) high severe
```

```
vec_decode_u32/1        time:   [42.708 ns 43.002 ns 43.511 ns]                              
                        change: [+54.739% +56.225% +57.650%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 4 outliers among 100 measurements (4.00%)
  2 (2.00%) high mild
  2 (2.00%) high severe
vec_decode_u32/2        time:   [64.711 ns 64.951 ns 65.214 ns]                             
                        change: [+112.99% +113.91% +114.82%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 4 outliers among 100 measurements (4.00%)
  3 (3.00%) high mild
  1 (1.00%) high severe
vec_decode_u32/5        time:   [64.485 ns 64.642 ns 64.806 ns]                             
                        change: [+52.461% +53.374% +54.169%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 2 outliers among 100 measurements (2.00%)
  1 (1.00%) high mild
  1 (1.00%) high severe
vec_decode_u32/32       time:   [80.770 ns 81.045 ns 81.348 ns]                              
                        change: [-50.849% -50.608% -50.360%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 4 outliers among 100 measurements (4.00%)
  2 (2.00%) high mild
  2 (2.00%) high severe
vec_decode_u32/1024     time:   [190.49 ns 191.91 ns 193.73 ns]                                
                        change: [-95.503% -95.475% -95.446%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 9 outliers among 100 measurements (9.00%)
  6 (6.00%) high mild
  3 (3.00%) high severe
vec_decode_u32/2048     time:   [356.93 ns 358.87 ns 361.29 ns]                                
                        change: [-95.914% -95.889% -95.862%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 8 outliers among 100 measurements (8.00%)
  4 (4.00%) high mild
  4 (4.00%) high severe
vec_decode_u32/16384    time:   [2.8900 us 2.8974 us 2.9052 us]                                  
                        change: [-95.849% -95.818% -95.791%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 3 outliers among 100 measurements (3.00%)
  1 (1.00%) high mild
  2 (2.00%) high severe
```

```
vec_decode_u8/1         time:   [32.216 ns 32.307 ns 32.407 ns]                             
                        change: [+4.3460% +4.7126% +5.0877%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 3 outliers among 100 measurements (3.00%)
  2 (2.00%) high mild
  1 (1.00%) high severe
vec_decode_u8/2         time:   [53.549 ns 53.641 ns 53.741 ns]                            
                        change: [+2.8426% +3.2120% +3.5870%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 2 outliers among 100 measurements (2.00%)
  1 (1.00%) high mild
  1 (1.00%) high severe
vec_decode_u8/5         time:   [53.720 ns 53.907 ns 54.125 ns]                            
                        change: [+5.1186% +5.8970% +6.8267%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) high mild
vec_decode_u8/32        time:   [54.240 ns 54.536 ns 55.009 ns]                             
                        change: [+2.8325% +3.3229% +3.9889%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 4 outliers among 100 measurements (4.00%)
  3 (3.00%) high mild
  1 (1.00%) high severe
vec_decode_u8/1024      time:   [105.29 ns 105.92 ns 106.77 ns]                               
                        change: [+11.231% +11.764% +12.445%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 5 outliers among 100 measurements (5.00%)
  1 (1.00%) high mild
  4 (4.00%) high severe
vec_decode_u8/2048      time:   [126.42 ns 127.47 ns 128.61 ns]                               
                        change: [-14.818% -14.225% -13.562%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 11 outliers among 100 measurements (11.00%)
  7 (7.00%) high mild
  4 (4.00%) high severe
vec_decode_u8/16384     time:   [479.35 ns 480.74 ns 482.31 ns]                                
                        change: [-15.482% -15.171% -14.841%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 4 outliers among 100 measurements (4.00%)
  3 (3.00%) high mild
  1 (1.00%) high severe
```

```
vec_encode_u8/1         time:   [15.933 ns 15.973 ns 16.015 ns]                             
                        change: [-1.5907% -1.0646% -0.5363%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 7 outliers among 100 measurements (7.00%)
  7 (7.00%) high mild
vec_encode_u8/2         time:   [15.850 ns 15.887 ns 15.929 ns]                             
                        change: [-0.1073% +0.3561% +0.8222%] (p = 0.13 > 0.05)
                        No change in performance detected.
Found 4 outliers among 100 measurements (4.00%)
  2 (2.00%) high mild
  2 (2.00%) high severe
vec_encode_u8/5         time:   [16.296 ns 16.367 ns 16.469 ns]                             
                        change: [-3.7299% -2.5045% -1.4604%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 8 outliers among 100 measurements (8.00%)
  4 (4.00%) high mild
  4 (4.00%) high severe
vec_encode_u8/32        time:   [16.214 ns 16.247 ns 16.282 ns]                              
                        change: [-0.7405% -0.3667% -0.0155%] (p = 0.05 < 0.05)
                        Change within noise threshold.
Found 3 outliers among 100 measurements (3.00%)
  2 (2.00%) high mild
  1 (1.00%) high severe
vec_encode_u8/1024      time:   [23.774 ns 23.859 ns 23.956 ns]                                
                        change: [-5.9194% -5.3765% -4.8491%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 4 outliers among 100 measurements (4.00%)
  3 (3.00%) high mild
  1 (1.00%) high severe
vec_encode_u8/2048      time:   [67.023 ns 67.239 ns 67.496 ns]                               
                        change: [-15.965% -15.245% -14.566%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 8 outliers among 100 measurements (8.00%)
  4 (4.00%) high mild
  4 (4.00%) high severe
vec_encode_u8/16384     time:   [362.63 ns 363.81 ns 365.23 ns]                                
                        change: [-1.6168% -0.8091% -0.1145%] (p = 0.04 < 0.05)
                        Change within noise threshold.
Found 6 outliers among 100 measurements (6.00%)
  5 (5.00%) high mild
  1 (1.00%) high severe
```

```
vec_encode_u32/1        time:   [17.435 ns 17.607 ns 17.820 ns]                              
                        change: [-44.685% -43.810% -42.968%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 9 outliers among 100 measurements (9.00%)
  5 (5.00%) high mild
  4 (4.00%) high severe
vec_encode_u32/2        time:   [17.533 ns 17.674 ns 17.822 ns]                              
                        change: [-73.356% -73.125% -72.874%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 5 outliers among 100 measurements (5.00%)
  4 (4.00%) high mild
  1 (1.00%) high severe
vec_encode_u32/5        time:   [17.975 ns 18.083 ns 18.198 ns]                              
                        change: [-86.811% -86.599% -86.334%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 9 outliers among 100 measurements (9.00%)
  4 (4.00%) high mild
  5 (5.00%) high severe
vec_encode_u32/32       time:   [20.431 ns 20.517 ns 20.628 ns]                               
                        change: [-93.605% -93.573% -93.539%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 13 outliers among 100 measurements (13.00%)
  5 (5.00%) low mild
  2 (2.00%) high mild
  6 (6.00%) high severe
vec_encode_u32/1024     time:   [83.495 ns 84.623 ns 86.429 ns]                                
                        change: [-98.174% -98.140% -98.107%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 5 outliers among 100 measurements (5.00%)
  4 (4.00%) high mild
  1 (1.00%) high severe
vec_encode_u32/2048     time:   [177.84 ns 178.66 ns 179.59 ns]                                
                        change: [-97.914% -97.880% -97.852%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 3 outliers among 100 measurements (3.00%)
  2 (2.00%) high mild
  1 (1.00%) high severe
vec_encode_u32/16384    time:   [1.5940 us 1.6017 us 1.6098 us]                                  
                        change: [-97.412% -97.393% -97.373%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 12 outliers among 100 measurements (12.00%)
  8 (8.00%) high mild
  4 (4.00%) high severe
````