### PR TITLE
Add duration to codec

### DIFF
--- a/fuzzer/Cargo.toml
+++ b/fuzzer/Cargo.toml
@@ -7,5 +7,5 @@ publish = false
 
 [dependencies]
 parity-scale-codec = { path = "../", features = [ "derive", "bit-vec" ] }
-honggfuzz = "0.5.45"
+honggfuzz = "0.5.47"
 bitvec = { version = "0.15.2", features = ["alloc"] }

--- a/fuzzer/src/main.rs
+++ b/fuzzer/src/main.rs
@@ -1,4 +1,5 @@
 use std::collections::{BTreeMap, BTreeSet, VecDeque, LinkedList, BinaryHeap};
+use std::time::Duration;
 
 use bitvec::{vec::BitVec, cursor::BigEndian};
 use honggfuzz::fuzz;
@@ -98,6 +99,7 @@ fn fuzz_one_input(data: &[u8]){
 		MockEnum,
 		BitVec<BigEndian, u8>,
 		BitVec<BigEndian, u32>,
+		Duration,
 	}
 }
 

--- a/src/codec.rs
+++ b/src/codec.rs
@@ -15,8 +15,8 @@
 //! Serialisation.
 
 #[cfg(feature = "std")]
-use std::{fmt, time::Duration};
-use core::{mem, ops::Deref, marker::PhantomData, iter::FromIterator, convert::TryFrom};
+use std::fmt;
+use core::{mem, ops::Deref, marker::PhantomData, iter::FromIterator, convert::TryFrom, time::Duration};
 
 use arrayvec::ArrayVec;
 

--- a/src/codec.rs
+++ b/src/codec.rs
@@ -1123,7 +1123,7 @@ mod tests {
 	use std::borrow::Cow;
 
 	#[test]
-	fn vec_is_slicable() {
+	fn vec_is_sliceable() {
 		let v = b"Hello world".to_vec();
 		v.using_encoded(|ref slice|
 			assert_eq!(slice, &b"\x2cHello world")

--- a/src/codec.rs
+++ b/src/codec.rs
@@ -1115,7 +1115,7 @@ impl Decode for Duration {
 	fn decode<I: Input>(input: &mut I) -> Result<Self, Error> {
 		let (secs, nanos) = <(u64, u32)>::decode(input)?;
 		if nanos > 1_000_000_000 {
-			return Err(Error("Number of nano seconds should not be higher than 10^9"))
+			return Err(Error("Number of nano seconds should not be higher than 10^9."))
 		}
 		Ok(Duration::new(secs, nanos))
 	}
@@ -1451,10 +1451,10 @@ mod tests {
 		let num_nanos = 37u32;
 		let invalid_nanos = num_secs as u32 * 1_000_000_000 + num_nanos;
 		let encoded = (0u64, invalid_nanos).encode();
-		// This test should fail, as the the number of nano seconds encoded is bigger than 10^9.
+		// This test should fail, as the number of nano seconds encoded is bigger than 10^9.
 		assert!(Duration::decode(&mut &encoded[..]).is_err());
 
-		// Now constructing a valid duration and encoding. Those tests should be valid.
+		// Now constructing a valid duration and encoding it. Those asserts should not fail.
 		let duration = Duration::from_nanos(invalid_nanos as u64);
 		let expected = (num_secs, num_nanos).encode();
 

--- a/src/codec.rs
+++ b/src/codec.rs
@@ -1482,7 +1482,7 @@ mod tests {
 		let num_secs = u64::max_value();
 		let num_nanos = A_BILLION;
 
-		// `num_nanos`' carry should make num_secs overflow if we were to call `Duration::new()`.
+		// `num_nanos`' carry should make `num_secs` overflow if we were to call `Duration::new()`.
 		// This test checks that the we do not call `Duration::new()`.
 		let encoded = (num_secs, num_nanos).encode();
 		assert!(Duration::decode(&mut &encoded[..]).is_err());

--- a/src/codec.rs
+++ b/src/codec.rs
@@ -1437,10 +1437,7 @@ mod tests {
 		let num_secs = 13;
 		let num_nanos = 37;
 
-		let secs = Duration::from_secs(num_secs);
-		let nanos = Duration::from_nanos(num_nanos);
-
-		let duration = secs + nanos;
+		let duration = Duration::new(num_secs, num_nanos);
 		let expected = (num_secs, num_nanos as u32).encode();
 
 		assert_eq!(duration.encode(), expected);
@@ -1456,8 +1453,24 @@ mod tests {
 		// This test should fail, as the number of nano seconds encoded is bigger than 10^9.
 		assert!(Duration::decode(&mut &encoded[..]).is_err());
 
+		// This test should fail, as the number of nanoseconds encoded is exactly 10^9.
+		let invalid_nanos = A_BILLION;
+		let encoded = (0u64, invalid_nanos).encode();
+		assert!(Duration::decode(&mut &encoded[..]).is_err());
+
 		// Now constructing a valid duration and encoding it. Those asserts should not fail.
 		let duration = Duration::from_nanos(invalid_nanos as u64);
+		let expected = (num_secs, num_nanos).encode();
+
+		assert_eq!(duration.encode(), expected);
+		assert_eq!(Duration::decode(&mut &expected[..]).unwrap(), duration);
+	}
+
+	#[test]
+	fn u64_max() {
+		let num_secs = u64::max_value();
+		let num_nanos = 0;
+		let duration = Duration::new(num_secs, num_nanos);
 		let expected = (num_secs, num_nanos).encode();
 
 		assert_eq!(duration.encode(), expected);

--- a/src/codec.rs
+++ b/src/codec.rs
@@ -1115,7 +1115,7 @@ impl Decode for Duration {
 	fn decode<I: Input>(input: &mut I) -> Result<Self, Error> {
 		let (secs, nanos) = <(u64, u32)>::decode(input)?;
 		if nanos > 1_000_000_000 {
-			return Err(Error("Number of nano seconds should not be higher than 10^9."))
+			return Err(Error("Number of nanoseconds should not be higher than 10^9."))
 		}
 		Ok(Duration::new(secs, nanos))
 	}

--- a/src/codec.rs
+++ b/src/codec.rs
@@ -1431,11 +1431,13 @@ mod tests {
 	fn duration() {
 		let num_secs = 13;
 		let num_nanos = 37;
+
 		let secs = Duration::from_secs(num_secs);
 		let nanos = Duration::from_nanos(num_nanos);
+
 		let duration = secs + nanos;
-		dbg!(duration);
 		let expected = (num_secs, num_nanos as u32).encode();
+
 		assert_eq!(duration.encode(), expected);
 		assert_eq!(Duration::decode(&mut &expected[..]).unwrap(), duration);
 	}

--- a/src/codec.rs
+++ b/src/codec.rs
@@ -1116,9 +1116,10 @@ impl Decode for Duration {
 	fn decode<I: Input>(input: &mut I) -> Result<Self, Error> {
 		let (secs, nanos) = <(u64, u32)>::decode(input)?;
 		if nanos > A_BILLION {
-			return Err(Error("Number of nanoseconds should not be higher than 10^9."))
+			Err("Number of nanoseconds should not be higher than 10^9.".into())
+		} else {
+			Ok(Duration::new(secs, nanos))
 		}
-		Ok(Duration::new(secs, nanos))
 	}
 }
 

--- a/src/codec.rs
+++ b/src/codec.rs
@@ -40,6 +40,7 @@ use crate::compact::Compact;
 use crate::encode_like::EncodeLike;
 
 const MAX_PREALLOCATION: usize = 4 * 1024;
+const A_BILLION: u32 = 1_000_000_000;
 
 /// Descriptive error type
 #[cfg(feature = "std")]
@@ -1114,7 +1115,7 @@ impl Encode for Duration {
 impl Decode for Duration {
 	fn decode<I: Input>(input: &mut I) -> Result<Self, Error> {
 		let (secs, nanos) = <(u64, u32)>::decode(input)?;
-		if nanos > 1_000_000_000 {
+		if nanos > A_BILLION {
 			return Err(Error("Number of nanoseconds should not be higher than 10^9."))
 		}
 		Ok(Duration::new(secs, nanos))
@@ -1449,7 +1450,7 @@ mod tests {
 	fn malformed_duration_encoding_fails() {
 		let num_secs = 1u64;
 		let num_nanos = 37u32;
-		let invalid_nanos = num_secs as u32 * 1_000_000_000 + num_nanos;
+		let invalid_nanos = num_secs as u32 * A_BILLION + num_nanos;
 		let encoded = (0u64, invalid_nanos).encode();
 		// This test should fail, as the number of nano seconds encoded is bigger than 10^9.
 		assert!(Duration::decode(&mut &encoded[..]).is_err());


### PR DESCRIPTION
No issue addressed.

This PR adds encode / decode for `std::time::Duration` by using `as_millis()` and treating it as a `u64`.

Note: `as_millis()` returns a u128, but `from_millis(millis: u64)` takes a `u64`. I looked at [this issue](https://github.com/rust-lang/rust/issues/58580) and decided I would use `as u64` after calling `as_millis()`.