### PR TITLE
Handle invalid utf8 sequence

### DIFF
--- a/src/codec.rs
+++ b/src/codec.rs
@@ -670,7 +670,7 @@ impl<T> Decode for PhantomData<T> {
 #[cfg(any(feature = "std", feature = "full"))]
 impl Decode for String {
 	fn decode<I: Input>(input: &mut I) -> Result<Self, Error> {
-		Self::from_utf8(Vec::decode(input)?).map_err(|_| Error("Invalid utf8 characters"))
+		Self::from_utf8(Vec::decode(input)?).map_err(|_| "Invalid utf8 sequence".into())
 	}
 }
 

--- a/src/codec.rs
+++ b/src/codec.rs
@@ -1489,4 +1489,13 @@ mod tests {
 		let encoded = (num_secs, num_nanos).encode();
 		assert!(Duration::decode(&mut &encoded[..]).is_err());
 	}
+
+	#[test]
+	fn string_invalid_utf8() {
+		// `167, 10` is not a valid utf8 sequence, so this should be an error.
+		let mut bytes: &[u8] = &[20, 114, 167, 10, 20, 114];
+
+		let obj = <String>::decode(&mut bytes);
+		assert!(obj.is_err());
+	}
 }

--- a/src/codec.rs
+++ b/src/codec.rs
@@ -670,7 +670,7 @@ impl<T> Decode for PhantomData<T> {
 #[cfg(any(feature = "std", feature = "full"))]
 impl Decode for String {
 	fn decode<I: Input>(input: &mut I) -> Result<Self, Error> {
-		Ok(Self::from_utf8_lossy(&Vec::decode(input)?).into())
+		Self::from_utf8(Vec::decode(input)?).map_err(|_| Error("Invalid utf8 characters"))
 	}
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -284,12 +284,3 @@ pub use self::keyedvec::KeyedVec;
 pub use self::decode_all::DecodeAll;
 pub use self::encode_append::EncodeAppend;
 pub use self::encode_like::{EncodeLike, Ref};
-
-#[test]
-fn string_decode_encode_test() {
-	let mut bytes: &[u8] = &[20, 248, 159, 146, 150, 114];
-	let expected = bytes.clone();
-	let obj = <String>::decode(&mut bytes).unwrap();
-	let data: &[u8] = &obj.encode();
-	assert_eq!(expected, data);
-}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -284,3 +284,12 @@ pub use self::keyedvec::KeyedVec;
 pub use self::decode_all::DecodeAll;
 pub use self::encode_append::EncodeAppend;
 pub use self::encode_like::{EncodeLike, Ref};
+
+#[test]
+fn string_decode_encode_test() {
+	let mut bytes: &[u8] = &[20, 248, 159, 146, 150, 114];
+	let expected = bytes.clone();
+	let obj = <String>::decode(&mut bytes).unwrap();
+	let data: &[u8] = &obj.encode();
+	assert_eq!(expected, data);
+}


### PR DESCRIPTION
## Issue
Currently, we're using `from_utf8_lossy` when decoding a `String`. This results in replacing invalid utf8 sequences by the `U+FFFD REPLACEMENT CHARACTER`. This itself introduces a weird behavior:
```rust
#[test]
fn string_decode_encode_test() {
    let mut bytes: &[u8] = &[20, 114, 167, 10, 20, 114];
    let expected = bytes.clone();
    let obj = <String>::decode(&mut bytes).unwrap();
    // obj is the decoded String coming from `bytes`. Since `bytes` contains an invalid utf8 sequence
    // obj now has inserted a replacement character instead in the third position of the array.
    let data: &[u8] = &obj.encode();
    // Comparing the original bytes (expected) to data will fail, because data now has the replacement character.
    assert_eq!(expected, data);
}
```

This PR addresses this issue and uses `from_utf8` instead of `from_utf8_lossy`. It will return an error in case of invalid utf8 sequence.
This PR also adds a testcase to make sure we keep the desired behavior.