### PR TITLE
Extend Fuzzer with Encoding

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ parity-scale-codec-derive = { path = "derive", version = "1.2.0", default-featur
 bitvec = { version = "0.15", default-features = false, features = ["alloc"], optional = true }
 byte-slice-cast = { version = "0.3.4", default-features = false, features = ["alloc"] }
 generic-array = { version = "0.13.2", optional = true }
+arbitrary = { version = "0.4.1", features = ["derive"] }
 
 [dev-dependencies]
 criterion = "0.3.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ parity-scale-codec-derive = { path = "derive", version = "1.2.0", default-featur
 bitvec = { version = "0.15", default-features = false, features = ["alloc"], optional = true }
 byte-slice-cast = { version = "0.3.4", default-features = false, features = ["alloc"] }
 generic-array = { version = "0.13.2", optional = true }
-arbitrary = { version = "0.4.1", features = ["derive"] }
+arbitrary = { version = "0.4.1", features = ["derive"], optional = true }
 
 [dev-dependencies]
 criterion = "0.3.0"
@@ -35,6 +35,7 @@ default = ["std"]
 derive = ["parity-scale-codec-derive"]
 std = ["serde", "bitvec/std", "byte-slice-cast/std"]
 bit-vec = ["bitvec"]
+fuzz = ["std", "arbitrary"]
 
 # WARNING: DO _NOT_ USE THIS FEATURE IF YOU ARE WORKING ON CONSENSUS CODE!*
 #

--- a/fuzzer/Cargo.toml
+++ b/fuzzer/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 publish = false
 
 [dependencies]
-parity-scale-codec = { path = "../", features = [ "derive", "bit-vec" ] }
+parity-scale-codec = { path = "../", features = [ "derive", "bit-vec", "fuzz" ] }
 honggfuzz = "0.5.47"
 bitvec = { version = "0.15.2", features = ["alloc"] }
 arbitrary = { version = "0.4.1", features = ["derive"] }

--- a/fuzzer/Cargo.toml
+++ b/fuzzer/Cargo.toml
@@ -9,3 +9,4 @@ publish = false
 parity-scale-codec = { path = "../", features = [ "derive", "bit-vec" ] }
 honggfuzz = "0.5.47"
 bitvec = { version = "0.15.2", features = ["alloc"] }
+arbitrary = { version = "0.4.1", features = ["derive"] }

--- a/fuzzer/src/main.rs
+++ b/fuzzer/src/main.rs
@@ -12,6 +12,7 @@ pub struct MockStruct{
 }
 
 #[derive(Encode, Decode, Debug, Clone, Arbitrary)]
+/// Used for implementing the PartialEq trait for a BinaryHeap.
 struct BinaryHeapWrapper(BinaryHeap<u32>);
 
 impl PartialEq for BinaryHeapWrapper {

--- a/fuzzer/src/main.rs
+++ b/fuzzer/src/main.rs
@@ -16,6 +16,7 @@ struct BinaryHeapWrapper(BinaryHeap<u32>);
 
 impl PartialEq for BinaryHeapWrapper {
 	fn eq(&self, other: &BinaryHeapWrapper) -> bool {
+		// Sort needed because the Iterator returns the value in arbitrary order.
 		let a = self.0.iter().cloned().collect::<Vec<u32>>().sort();
 		let b = other.0.iter().cloned().collect::<Vec<u32>>().sort();
 		a == b
@@ -74,11 +75,15 @@ macro_rules! fuzz_decoder {
 	$(
 		if $data[0] % num == $index {
 			let mut d = &$data[1..];
-			let raw1 = d.clone();
+			// Sorting here is necessary since:
+			// "The order of the elements is not fixed, depends on the container, and cannot be relied on at decoding."
+			// (see https://substrate.dev/docs/en/conceptual/core/codec).
+			let raw1 = d.clone().sort();
 			let maybe_obj = <$parsed>::decode(&mut d);
 			if let Ok(obj) = maybe_obj {
 				let mut d2: &[u8] = &obj.encode();
-				let raw2 = d2.clone();
+				// Sorting here is necessary: see above comment.
+				let raw2 = d2.clone().sort();
 				let exp_obj = <$parsed>::decode(&mut d2);
 				match exp_obj {
 					Ok(obj2) => {

--- a/fuzzer/src/main.rs
+++ b/fuzzer/src/main.rs
@@ -1,4 +1,4 @@
-use std::collections::{BTreeMap, BTreeSet, VecDeque, LinkedList};
+use std::collections::{BTreeMap, BTreeSet, VecDeque, LinkedList, BinaryHeap};
 use std::time::Duration;
 
 use bitvec::{vec::BitVec, cursor::BigEndian};
@@ -8,6 +8,17 @@ use parity_scale_codec::{Encode, Decode, Compact};
 #[derive(Encode, Decode, PartialEq, Debug)]
 pub struct MockStruct{
 	vec_u: Vec<u8>
+}
+
+#[derive(Encode, Decode, Debug)]
+struct BinaryHeapWrapper(BinaryHeap<u32>);
+
+impl PartialEq for BinaryHeapWrapper {
+	fn eq(&self, other: &BinaryHeapWrapper) -> bool {
+		let a = self.0.iter().cloned().collect::<Vec<u32>>().sort();
+		let b = other.0.iter().cloned().collect::<Vec<u32>>().sort();
+		a == b
+	}
 }
 
 #[derive(Encode, Decode, PartialEq, Debug)]
@@ -124,7 +135,7 @@ fn fuzz_one_input(data: &[u8]){
 		BTreeMap<u8, u8>,
 		BTreeSet<u32>,
 		VecDeque<u8>,
-		// BinaryHeap<u32>,
+		BinaryHeapWrapper,
 		MockStruct,
 		MockEnum,
 		BitVec<BigEndian, u8>,
@@ -138,5 +149,3 @@ fn main() {
 		fuzz!(|data: &[u8]| { fuzz_one_input(data); });
 	}
 }
-
-

--- a/fuzzer/src/main.rs
+++ b/fuzzer/src/main.rs
@@ -76,7 +76,7 @@ macro_rules! fuzz_decoder {
 	$(
 		if $data[0] % num == $index {
 			let mut d = &$data[1..];
-			let mut raw1 = &d.clone();
+			let raw1 = &d.clone();
 			// Sorting here is necessary since:
 			// "The order of the elements is not fixed, depends on the container, and cannot be relied on at decoding."
 			// (see https://substrate.dev/docs/en/conceptual/core/codec).

--- a/fuzzer/src/main.rs
+++ b/fuzzer/src/main.rs
@@ -23,8 +23,8 @@ impl<O: 'static + BitOrder, T: 'static + BitStore + Arbitrary> Arbitrary for Bit
 }
 
 
-#[derive(Encode, Decode, Debug, Clone, Arbitrary)]
 /// Used for implementing the PartialEq trait for a BinaryHeap.
+#[derive(Encode, Decode, Debug, Clone, Arbitrary)]
 struct BinaryHeapWrapper(BinaryHeap<u32>);
 
 impl PartialEq for BinaryHeapWrapper {

--- a/fuzzer/src/main.rs
+++ b/fuzzer/src/main.rs
@@ -139,7 +139,7 @@ macro_rules! fuzz_decoder {
 	};
 	// only_decode flow arm.
 	(@INTERNAL
-		minimal;
+		only_decode;
 		$data:ident;
 		$counter:expr;
 		{ $( $parsed:ty; $index:expr ),* }

--- a/fuzzer/src/main.rs
+++ b/fuzzer/src/main.rs
@@ -4,13 +4,14 @@ use std::time::Duration;
 use bitvec::{vec::BitVec, cursor::BigEndian};
 use honggfuzz::fuzz;
 use parity_scale_codec::{Encode, Decode, Compact};
+use honggfuzz::arbitrary::Arbitrary;
 
-#[derive(Encode, Decode, PartialEq, Debug)]
+#[derive(Encode, Decode, PartialEq, Debug, Arbitrary)]
 pub struct MockStruct{
 	vec_u: Vec<u8>
 }
 
-#[derive(Encode, Decode, Debug)]
+#[derive(Encode, Decode, Debug, Arbitrary)]
 struct BinaryHeapWrapper(BinaryHeap<u32>);
 
 impl PartialEq for BinaryHeapWrapper {
@@ -21,7 +22,7 @@ impl PartialEq for BinaryHeapWrapper {
 	}
 }
 
-#[derive(Encode, Decode, PartialEq, Debug)]
+#[derive(Encode, Decode, PartialEq, Debug, Arbitrary)]
 pub enum MockEnum {
 	Empty,
 	Unit(u32),

--- a/fuzzer/src/main.rs
+++ b/fuzzer/src/main.rs
@@ -164,7 +164,7 @@ macro_rules! fuzz_decoder {
 			let maybe_obj = <$parsed>::decode(&mut d);
 			match maybe_obj {
 				Ok(obj) => {
-					let mut d2 = obj.encode();
+					let d2 = obj.encode();
 					let mut raw2 = d2.clone();
 					// We are sorting here because we're in the "sorted" flow. Useful for container types
 					// which can have multiple valid encoded versions.

--- a/fuzzer/src/main.rs
+++ b/fuzzer/src/main.rs
@@ -11,8 +11,8 @@ pub struct MockStruct{
 	vec_u: Vec<u8>
 }
 
-#[derive(Encode, Decode, Clone, PartialEq, Debug)]
 /// Used for implementing the Arbitrary trait for a BitVec.
+#[derive(Encode, Decode, Clone, PartialEq, Debug)]
 pub struct BitVecWrapper<O: BitOrder, T: BitStore>(BitVec<O, T>);
 
 impl<O: 'static + BitOrder, T: 'static + BitStore + Arbitrary> Arbitrary for BitVecWrapper<O, T> {

--- a/fuzzer/src/main.rs
+++ b/fuzzer/src/main.rs
@@ -32,10 +32,7 @@ impl PartialEq for BinaryHeapWrapper {
 	// TODO: A better approach would be to use `into_iter_sorted` and compare both iterator, once
 	// https://doc.rust-lang.org/std/collections/struct.BinaryHeap.html#method.into_iter_sorted is stable.
 	fn eq(&self, other: &BinaryHeapWrapper) -> bool {
-		// Sort needed because the Iterator returns the value in arbitrary order.
-		let a = self.0.iter().cloned().collect::<Vec<u32>>().sort();
-		let b = other.0.iter().cloned().collect::<Vec<u32>>().sort();
-		a == b
+		self.clone().into_sorted_vec() == other.clone().into_sorted_vec()
 	}
 }
 

--- a/fuzzer/src/main.rs
+++ b/fuzzer/src/main.rs
@@ -164,12 +164,12 @@ macro_rules! fuzz_decoder {
 			let maybe_obj = <$parsed>::decode(&mut d);
 			match maybe_obj {
 				Ok(obj) => {
-					let mut d2: &[u8] = &obj.encode();
-					let mut raw2 = Vec::from(d2);
+					let mut d2 = obj.encode();
+					let mut raw2 = d2.clone();
 					// We are sorting here because we're in the "sorted" flow. Useful for container types
 					// which can have multiple valid encoded versions.
 					raw2.sort();
-					let exp_obj = <$parsed>::decode(&mut d2);
+					let exp_obj = <$parsed>::decode(&mut &d2[..]);
 					match exp_obj {
 						Ok(obj2) => {
 							if obj == obj2 {

--- a/fuzzer/src/main.rs
+++ b/fuzzer/src/main.rs
@@ -236,7 +236,7 @@ fn fuzz_decode(data: &[u8]) {
 		data;
 		BinaryHeapWrapper,
 	};
-	// Types which we only wish to decode.
+	// Types for which we only wish to decode.
 	fuzz_decoder! {
 		only_decode;
 		data;

--- a/fuzzer/src/main.rs
+++ b/fuzzer/src/main.rs
@@ -76,22 +76,23 @@ macro_rules! fuzz_decoder {
 	$(
 		if $data[0] % num == $index {
 			let mut d = &$data[1..];
+			let mut raw1 = &d.clone();
 			// Sorting here is necessary since:
 			// "The order of the elements is not fixed, depends on the container, and cannot be relied on at decoding."
 			// (see https://substrate.dev/docs/en/conceptual/core/codec).
-			let raw1 = d.clone().sort();
 			let maybe_obj = <$parsed>::decode(&mut d);
 			if let Ok(obj) = maybe_obj {
 				let mut d2: &[u8] = &obj.encode();
+				let mut raw2 = Vec::from(d2);
 				// Sorting here is necessary: see above comment.
-				let raw2 = d2.clone().sort();
+				raw2.sort();
 				let exp_obj = <$parsed>::decode(&mut d2);
 				match exp_obj {
 					Ok(obj2) => {
 						if obj == obj2 {
-							let raw1_trunc_to_obj_size = &raw1[..raw1.len() - d.len()];
+							let mut raw1_trunc_to_obj_size = Vec::from(&raw1[..raw1.len() - d.len()]);
+							raw1_trunc_to_obj_size.sort();
 							if raw1_trunc_to_obj_size != raw2 {
-								println!("Type: {}", std::any::type_name::<$parsed>());
 								println!("raw1 = {:?}", raw1);
 								println!("d (leftover/undecoded data) = {:?}", d);
 								println!("- Decoded data:");
@@ -100,6 +101,7 @@ macro_rules! fuzz_decoder {
 								println!("- Encoded objects:");
 								println!("obj1 = '{:?}'", obj);
 								println!("obj2 = '{:?}'", obj2);
+								println!("Type: {}", std::any::type_name::<$parsed>());
 								panic!("raw1 != raw2");
 							}
 						return

--- a/fuzzer/src/main.rs
+++ b/fuzzer/src/main.rs
@@ -152,38 +152,11 @@ fn fuzz_decode(data: &[u8]) {
 }
 
 macro_rules! fuzz_encoder {
-	(
-		$first:ty,
-		$( $rest:ty, )*
-	) => {
-		fuzz_encoder! {
-			@INTERNAL
-			1u8;
-			{ $first; 0u8 }
-			$( $rest, )*
-		}
-	};
-	(@INTERNAL
-		$counter:expr;
-		{ $( $parsed:ty; $index:expr ),* }
-		$current:ty,
-		$( $rest:ty, )*
-	) => {
-		fuzz_encoder! {
-			@INTERNAL
-			$counter + 1u8;
-			{ $current; $counter $(, $parsed; $index )* }
-			$( $rest, )*
-		}
-	};
-	(@INTERNAL
-		$counter:expr;
-		{ $( $parsed:ty; $index:expr ),* }
-	) => {
-	$(
-		fuzz!(|data: $parsed| { fuzz_encode(data) });
-	)*
-	};
+	() => {};
+	( $current:ty, $( $rest:ty, )*) => {
+			fuzz!(|data: $current| { fuzz_encode(data) });
+			fuzz_encoder!($( $rest, )*);
+		};
 }
 
 fn fuzz_encode<T: Encode + Decode + Clone + PartialEq + std::fmt::Debug> (data: T) {
@@ -205,35 +178,35 @@ fn fuzz_encode<T: Encode + Decode + Clone + PartialEq + std::fmt::Debug> (data: 
 	}
 }
 
-macro_rules! tmp {
+macro_rules! fuzz_encoding {
 	() => {
 		fuzz_encoder! {
-		u8,
-		u16,
-		u32,
-		u64,
-		u128,
-		Compact<u8>,
-		Compact<u16>,
-		Compact<u32>,
-		Compact<u64>,
-		Compact<u128>,
-		String,
-		Vec<u8>,
-		Vec<Vec<u8>>,
-		Option<Vec<u8>>,
-		Vec<u32>,
-		LinkedList<u8>,
-		BTreeMap<String, Vec<u8>>,
-		BTreeMap<u8, u8>,
-		BTreeSet<u32>,
-		VecDeque<u8>,
-		BinaryHeapWrapper,
-		MockStruct,
-		MockEnum,
-		// BitVec<BigEndian, u8>,
-		// BitVec<BigEndian, u32>,
-		Duration,
+			u8,
+			u16,
+			u32,
+			u64,
+			u128,
+			Compact<u8>,
+			Compact<u16>,
+			Compact<u32>,
+			Compact<u64>,
+			Compact<u128>,
+			String,
+			Vec<u8>,
+			Vec<Vec<u8>>,
+			Option<Vec<u8>>,
+			Vec<u32>,
+			LinkedList<u8>,
+			BTreeMap<String, Vec<u8>>,
+			BTreeMap<u8, u8>,
+			BTreeSet<u32>,
+			VecDeque<u8>,
+			BinaryHeapWrapper,
+			MockStruct,
+			MockEnum,
+			// BitVec<BigEndian, u8>,
+			// BitVec<BigEndian, u32>,
+			Duration,
 		}
 	};
 }
@@ -241,6 +214,6 @@ macro_rules! tmp {
 fn main() {
 	loop {
 		fuzz!(|data: &[u8]| { fuzz_decode(data); });
-		tmp!();
+		fuzz_encoding!();
 	}
 }

--- a/fuzzer/src/main.rs
+++ b/fuzzer/src/main.rs
@@ -153,10 +153,9 @@ fn fuzz_decode(data: &[u8]) {
 
 macro_rules! fuzz_encoder {
 	() => {};
-	( $current:ty, $( $rest:ty, )*) => {
-			fuzz!(|data: $current| { fuzz_encode(data) });
-			fuzz_encoder!($( $rest, )*);
-		};
+	($( $type:ty, )*) => {
+		$(fuzz!(|data: $type| { fuzz_encode(data) });)*
+	};
 }
 
 fn fuzz_encode<T: Encode + Decode + Clone + PartialEq + std::fmt::Debug> (data: T) {

--- a/fuzzer/src/main.rs
+++ b/fuzzer/src/main.rs
@@ -72,7 +72,7 @@ macro_rules! fuzz_decoder {
 		$counter:expr;
 		{ $( $parsed:ty; $index:expr ),* }
 	) => {
-	let num = $counter;
+		let num = $counter;
 	$(
 		if $data[0] % num == $index {
 			let mut d = &$data[1..];

--- a/fuzzer/src/main.rs
+++ b/fuzzer/src/main.rs
@@ -22,6 +22,12 @@ impl PartialEq for BinaryHeapWrapper {
 	}
 }
 
+// #[derive(Encode, Decode, PartialEq, Debug, Clone, Arbitrary, Cursor, BitStore)]
+// pub struct BigEndianWrapper(BigEndian);
+
+// #[derive(Encode, Decode, PartialEq, Debug, Clone, Arbitrary)]
+// pub struct BitVecWrapper<T: BitStore>(BitVec<BigEndianWrapper, T>);
+
 #[derive(Encode, Decode, Clone, PartialEq, Debug, Arbitrary)]
 pub enum MockEnum {
 	Empty,
@@ -202,16 +208,39 @@ fn fuzz_encode<T: Encode + Decode + Clone + PartialEq + std::fmt::Debug> (data: 
 macro_rules! tmp {
 	() => {
 		fuzz_encoder! {
-			u8,
-			u16,
-			MockEnum,
+		u8,
+		u16,
+		u32,
+		u64,
+		u128,
+		Compact<u8>,
+		Compact<u16>,
+		Compact<u32>,
+		Compact<u64>,
+		Compact<u128>,
+		String,
+		Vec<u8>,
+		Vec<Vec<u8>>,
+		Option<Vec<u8>>,
+		Vec<u32>,
+		LinkedList<u8>,
+		BTreeMap<String, Vec<u8>>,
+		BTreeMap<u8, u8>,
+		BTreeSet<u32>,
+		VecDeque<u8>,
+		BinaryHeapWrapper,
+		MockStruct,
+		MockEnum,
+		// BitVec<BigEndian, u8>,
+		// BitVec<BigEndian, u32>,
+		Duration,
 		}
 	};
 }
 
 fn main() {
 	loop {
-		// fuzz!(|data: &[u8]| { fuzz_decode(data); })
+		fuzz!(|data: &[u8]| { fuzz_decode(data); });
 		tmp!();
 	}
 }

--- a/fuzzer/src/main.rs
+++ b/fuzzer/src/main.rs
@@ -22,12 +22,6 @@ impl PartialEq for BinaryHeapWrapper {
 	}
 }
 
-// #[derive(Encode, Decode, PartialEq, Debug, Clone, Arbitrary, Cursor, BitStore)]
-// pub struct BigEndianWrapper(BigEndian);
-
-// #[derive(Encode, Decode, PartialEq, Debug, Clone, Arbitrary)]
-// pub struct BitVecWrapper<T: BitStore>(BitVec<BigEndianWrapper, T>);
-
 #[derive(Encode, Decode, Clone, PartialEq, Debug, Arbitrary)]
 pub enum MockEnum {
 	Empty,
@@ -203,8 +197,6 @@ macro_rules! fuzz_encoding {
 			BinaryHeapWrapper,
 			MockStruct,
 			MockEnum,
-			// BitVec<BigEndian, u8>,
-			// BitVec<BigEndian, u32>,
 			Duration,
 		}
 	};

--- a/fuzzer/src/main.rs
+++ b/fuzzer/src/main.rs
@@ -257,18 +257,19 @@ fn fuzz_encode<T: Encode + Decode + Clone + PartialEq + std::fmt::Debug> (data: 
 	let original = data.clone();
 	let mut obj: &[u8] = &data.encode();
 	let decoded = <T>::decode(&mut obj);
-	if let Ok(object) = decoded {
-		if object != original {
-			println!("original object: {:?}", original);
-			println!("decoded object: {:?}", object);
-			panic!("Original object differs from decoded object")
+	match decoded {
+		Ok(object) => {
+			if object != original {
+				println!("original object: {:?}", original);
+				println!("decoded object: {:?}", object);
+				panic!("Original object differs from decoded object")
+			}
 		}
-	} else {
-		// safe because we checked that object is not `Ok`
-		let e = decoded.unwrap_err();
-		println!("original object: {:?}", original);
-		println!("decoding error: {:?}", e);
-		panic!("Failed to decode the encoded object");
+		Err(e) => {
+			println!("original object: {:?}", original);
+			println!("decoding error: {:?}", e);
+			panic!("Failed to decode the encoded object");
+		}
 	}
 }
 

--- a/src/compact.rs
+++ b/src/compact.rs
@@ -19,6 +19,7 @@ use arrayvec::ArrayVec;
 use crate::alloc::vec::Vec;
 use crate::codec::{Encode, Decode, Input, Output, EncodeAsRef, Error};
 use crate::encode_like::EncodeLike;
+use arbitrary::Arbitrary;
 
 struct ArrayVecWrapper<T: arrayvec::Array>(ArrayVec<T>);
 
@@ -74,7 +75,7 @@ pub trait CompactLen<T> {
 }
 
 /// Compact-encoded variant of T. This is more space-efficient but less compute-efficient.
-#[derive(Eq, PartialEq, Clone, Copy, Ord, PartialOrd)]
+#[derive(Eq, PartialEq, Clone, Copy, Ord, PartialOrd, Arbitrary)]
 pub struct Compact<T>(pub T);
 
 impl<T> From<T> for Compact<T> {

--- a/src/compact.rs
+++ b/src/compact.rs
@@ -19,6 +19,7 @@ use arrayvec::ArrayVec;
 use crate::alloc::vec::Vec;
 use crate::codec::{Encode, Decode, Input, Output, EncodeAsRef, Error};
 use crate::encode_like::EncodeLike;
+#[cfg(feature = "fuzz")]
 use arbitrary::Arbitrary;
 
 struct ArrayVecWrapper<T: arrayvec::Array>(ArrayVec<T>);
@@ -75,7 +76,8 @@ pub trait CompactLen<T> {
 }
 
 /// Compact-encoded variant of T. This is more space-efficient but less compute-efficient.
-#[derive(Eq, PartialEq, Clone, Copy, Ord, PartialOrd, Arbitrary)]
+#[derive(Eq, PartialEq, Clone, Copy, Ord, PartialOrd)]
+#[cfg_attr(feature = "fuzz", derive(Arbitrary))]
 pub struct Compact<T>(pub T);
 
 impl<T> From<T> for Compact<T> {


### PR DESCRIPTION
Currently, the fuzzer only tries to decode arbitrary bytes.
This PR:
1. Modifies the current fuzzing technique by:
    1. Decoding the arbitrary bytes
    2. Encoding the object obtained from step i
    3. Decoding the bytes from step ii
    4. Making sure that the objects from steps iii and i are the same, and that the bytes of step 2 and the original bytes are the same.
2. Adds a new macro that tests encoding by:
    1. Generating an arbitrary object (among the list of fuzzed types)
    2. Encoding the object from step i
    3. Decoding the bytes from step ii
    4. Comparing the object from step iii with the original arbitrary object

Encoding is tested in (1), however it is only encoding structures that have already been decoded (we might have a bias here).
Decoding is tested in (2), but only from bytes that we have personally encoded.
That is why both functions / macros are needed.

I had to remove `BitVec<BigEndian, u8>` and `Bitvec<BigEndian, u32>` from the (2) Encoding fuzzer, because I could not implement the `Arbitrary` trait for them.

Ideas to further enhance the fuzzer:
- Add `encode_append()` tests
- Add `BitVec<BigEndia, u8>`  and `BitVec<BigEndian, u32>` back to the Encode tests.
- If we wish to improve speed, separate (1) Decoding into two separate macros: one which sorts bytes (for comparing BinaryHeaps, and BTreeSet), and another one for the rest, that does not sort the bytes. Code would run faster, but this would add code complexity.

cc @kirushik 