### PR TITLE
Update version for substrate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ edition = "2018"
 arrayvec = { version = "0.5.1", default-features = false, features = ["array-sizes-33-128", "array-sizes-129-255"] }
 serde = { version = "1.0.102", optional = true }
 parity-scale-codec-derive = { path = "derive", version = "1.2.0", default-features = false, optional = true }
-bitvec = { version = "0.15", default-features = false, features = ["alloc"], optional = true }
+bitvec = { version = "0.17.4", default-features = false, features = ["alloc"], optional = true }
 byte-slice-cast = { version = "0.3.4", default-features = false, features = ["alloc"] }
 generic-array = { version = "0.13.2", optional = true }
 

--- a/fuzzer/Cargo.toml
+++ b/fuzzer/Cargo.toml
@@ -8,4 +8,4 @@ publish = false
 [dependencies]
 parity-scale-codec = { path = "../", features = [ "derive", "bit-vec" ] }
 honggfuzz = "0.5.47"
-bitvec = { version = "0.15.2", features = ["alloc"] }
+bitvec = { version = "0.17.4", features = ["alloc"] }


### PR DESCRIPTION
Substrate master throws a build error for bitvec in this package afaik. 

When running cargo update
```
error: failed to select a version for the requirement `bitvec = "^0.15"`
  candidate versions found which didn't match: 0.17.4
  location searched: crates.io index
required by package `parity-scale-codec v1.2.0`
```