### PR TITLE
impl return error for decode_from in CompactAs trait

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ assert_eq!(<Test1CompactHasCompact<u64>>::decode(&mut &encoded[..]).unwrap().bar
 ```rust
 
 use serde_derive::{Serialize, Deserialize};
-use parity_scale_codec::{Encode, Decode, Compact, HasCompact, CompactAs};
+use parity_scale_codec::{Encode, Decode, Compact, HasCompact, CompactAs, Error};
 
 #[cfg_attr(feature = "std", derive(Serialize, Deserialize, Debug))]
 #[derive(PartialEq, Eq, Clone)]
@@ -155,8 +155,8 @@ impl CompactAs for StructHasCompact {
         &12
     }
 
-    fn decode_from(_: Self::As) -> Self {
-        StructHasCompact(12)
+    fn decode_from(_: Self::As) -> Result<Self, Error> {
+        Ok(StructHasCompact(12))
     }
 }
 

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ The compact encoding is described [here](https://substrate.dev/docs/en/overview/
 
 * `encode_as(&self) -> &Self::As`: Encodes the type (self) as a compact type.
 The type `As` is defined in the same trait and its implementation should be compact encode-able.
-* `decode_from(_: Self::As) -> Self`: Decodes the type (self) from a compact encode-able type.
+* `decode_from(_: Self::As) -> Result<Self, Error>`: Decodes the type (self) from a compact encode-able type.
 
 ### HasCompact
 

--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -299,12 +299,16 @@ pub fn compact_as_derive(input: proc_macro::TokenStream) -> proc_macro::TokenStr
 			fn encode_as(&self) -> &#inner_ty {
 				#inner_field
 			}
-			fn decode_from(x: #inner_ty) -> #name #ty_generics {
-				#constructor
+			fn decode_from(x: #inner_ty)
+				-> core::result::Result<#name #ty_generics, _parity_scale_codec::Error>
+			{
+				Ok(#constructor)
 			}
 		}
 
-		impl #impl_generics From<_parity_scale_codec::Compact<#name #ty_generics>> for #name #ty_generics #where_clause {
+		impl #impl_generics From<_parity_scale_codec::Compact<#name #ty_generics>>
+			for #name #ty_generics #where_clause
+		{
 			fn from(x: _parity_scale_codec::Compact<#name #ty_generics>) -> #name #ty_generics {
 				x.0
 			}

--- a/src/compact.rs
+++ b/src/compact.rs
@@ -90,11 +90,11 @@ pub trait CompactAs: From<Compact<Self>> {
 	/// A compact-encodable type that should be used as the encoding.
 	type As;
 
-	/// Returns the encodable type.
+	/// Returns the compact-encodable type.
 	fn encode_as(&self) -> &Self::As;
 
-	/// Create `Self` from the decodable type.
-	fn decode_from(_: Self::As) -> Self;
+	/// Decode `Self` from the compact-decoded type.
+	fn decode_from(_: Self::As) -> Result<Self, Error>;
 }
 
 impl<T> EncodeLike for Compact<T>
@@ -157,8 +157,8 @@ where
 	Compact<T::As>: Decode,
 {
 	fn decode<I: Input>(input: &mut I) -> Result<Self, Error> {
-		Compact::<T::As>::decode(input)
-			.map(|x| Compact(<T as CompactAs>::decode_from(x.0)))
+		let as_ = Compact::<T::As>::decode(input)?;
+		Ok(Compact(<T as CompactAs>::decode_from(as_.0)?))
 	}
 }
 
@@ -769,8 +769,8 @@ mod tests {
 		fn encode_as(&self) -> &u8 {
 			&self.0
 		}
-		fn decode_from(x: u8) -> Wrapper {
-			Wrapper(x)
+		fn decode_from(x: u8) -> Result<Wrapper, Error> {
+			Ok(Wrapper(x))
 		}
 	}
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -64,7 +64,7 @@
 //!
 //! * `encode_as(&self) -> &Self::As`: Encodes the type (self) as a compact type.
 //! The type `As` is defined in the same trait and its implementation should be compact encode-able.
-//! * `decode_from(_: Self::As) -> Self`: Decodes the type (self) from a compact encode-able type.
+//! * `decode_from(_: Self::As) -> Result<Self, Error>`: Decodes the type (self) from a compact encode-able type.
 //!
 //! ### HasCompact
 //!
@@ -168,7 +168,7 @@
 //! # use parity_scale_codec_derive::{Encode, Decode};
 //!
 //! use serde_derive::{Serialize, Deserialize};
-//! use parity_scale_codec::{Encode, Decode, Compact, HasCompact, CompactAs};
+//! use parity_scale_codec::{Encode, Decode, Compact, HasCompact, CompactAs, Error};
 //!
 //! #[cfg_attr(feature = "std", derive(Serialize, Deserialize, Debug))]
 //! #[derive(PartialEq, Eq, Clone)]
@@ -181,8 +181,8 @@
 //!         &12
 //!     }
 //!
-//!     fn decode_from(_: Self::As) -> Self {
-//!         StructHasCompact(12)
+//!     fn decode_from(_: Self::As) -> Result<Self, Error> {
+//!         Ok(StructHasCompact(12))
 //!     }
 //! }
 //!

--- a/tests/mod.rs
+++ b/tests/mod.rs
@@ -14,7 +14,7 @@
 
 #[cfg(not(feature="derive"))]
 use parity_scale_codec_derive::{Encode, Decode};
-use parity_scale_codec::{Encode, Decode, HasCompact, Compact, EncodeAsRef, CompactAs};
+use parity_scale_codec::{Encode, Decode, HasCompact, Compact, EncodeAsRef, CompactAs, Error};
 use serde_derive::{Serialize, Deserialize};
 
 #[derive(Debug, PartialEq, Encode, Decode)]
@@ -376,8 +376,8 @@ fn generic_bound_hascompact() {
 		fn encode_as(&self) -> &Self::As {
 			&0
 		}
-		fn decode_from(_: Self::As) -> Self {
-			StructHasCompact(0)
+		fn decode_from(_: Self::As) -> Result<Self, Error> {
+			Ok(StructHasCompact(0))
 		}
 	}
 


### PR DESCRIPTION
Fix https://github.com/paritytech/parity-scale-codec/issues/196

I'm not sure about how we can include such change without breaking compatibility.
About substrate I think we never use this type directly thus this PR won't break anything (I will double check).