### PR TITLE
publish new codec and codec-derive version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "parity-scale-codec"
 description = "SCALE - Simple Concatenating Aggregated Little Endians"
-version = "1.3.0"
+version = "1.4.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "Apache-2.0"
 repository = "https://github.com/paritytech/parity-scale-codec"
@@ -11,7 +11,7 @@ edition = "2018"
 [dependencies]
 arrayvec = { version = "0.5.1", default-features = false, features = ["array-sizes-33-128", "array-sizes-129-255"] }
 serde = { version = "1.0.102", optional = true }
-parity-scale-codec-derive = { path = "derive", version = "1.2.0", default-features = false, optional = true }
+parity-scale-codec-derive = { path = "derive", version = "1.3.0", default-features = false, optional = true }
 bitvec = { version = "0.17.4", default-features = false, features = ["alloc"], optional = true }
 byte-slice-cast = { version = "0.3.4", default-features = false, features = ["alloc"] }
 generic-array = { version = "0.13.2", optional = true }

--- a/derive/Cargo.toml
+++ b/derive/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "parity-scale-codec-derive"
 description = "Serialization and deserialization derive macro for Parity SCALE Codec"
-version = "1.2.0"
+version = "1.3.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "Apache-2.0"
 edition = "2018"


### PR DESCRIPTION
polkadot, substrate and its dependency currently never implement CompactAs by hand, thus updating scale-codec won't break anything.

if this PR is accepted I will put the two tags and publish them on crate-io.

(note that codec-derive:1.3.0 won't be usable with codec:1.3.0 but only with codec:1.4.0)