### PR TITLE
Add Encode and Decode impls for NonZero* types

### DIFF
--- a/src/codec.rs
+++ b/src/codec.rs
@@ -581,7 +581,7 @@ const _: () = {
 				impl Decode for $name {
 					fn decode<I: Input>(input: &mut I) -> Result<Self, Error> {
 						let value = <$wrapped as Decode>::decode(input)?;
-						Self::new(value).ok_or_else(|| Error("cannot create non-zero number from 0"))
+						Self::new(value).ok_or_else(|| Error::from("cannot create non-zero number from 0"))
 					}
 				}
 			)*


### PR DESCRIPTION
Adds `Encode` and `Decode` impls for

- `NonZeroI8`
- `NonZeroI16`
- `NonZeroI32`
- `NonZeroI64`
- `NonZeroI128`
- `NonZeroU8`
- `NonZeroU16`
- `NonZeroU32`
- `NonZeroU64`
- `NonZeroU128`

Does not use the `WrapperTypeEncode` and `WrapperTypeDecode` facilities since they require the `Deref` super trait which is not applicable to these types.

These impls have not been put behind a crate feature since they are very useful for performance critical applications (as ours) as they provide the compiler with optimization opportunities in some use cases.

As soon as specialization is a thing in Rust we could provide specializations for `Option<NonZero*>` as well.