### PR TITLE
Add check for attribute and modify index attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,12 +190,13 @@ The derive implementation supports the following attributes:
   fall back to just use the type parameters of the type. This can be useful for situation where
   the algorithm includes private types in the public interface. By using this attribute, you should
   not get this error/warning again.
-- `codec(skip)`: Needs to be placed above a field and makes the field to be skipped while encoding/decoding.
+- `codec(skip)`: Needs to be placed above a field  or variant and makes it to be skipped while
+  encoding/decoding.
 - `codec(compact)`: Needs to be placed above a field and makes the field use compact encoding.
   (The type needs to support compact encoding.)
-- `codec(encoded_as(OtherType))`: Needs to be placed above a field and makes the field being encoded
+- `codec(encoded_as = "OtherType")`: Needs to be placed above a field and makes the field being encoded
   by using `OtherType`.
-- `codec(index("0"))`: Needs to be placed above an enum variant to make the variant use the given
+- `codec(index = 0)`: Needs to be placed above an enum variant to make the variant use the given
   index when encoded. By default the index is determined by counting from `0` beginning wth the
   first variant.
 

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ use parity_scale_codec::{Encode, Decode};
 
 #[derive(Debug, PartialEq, Encode, Decode)]
 enum EnumType {
-	#[codec(index = "15")]
+	#[codec(index = 15)]
 	A,
 	B(u32, u64),
 	C {

--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -135,9 +135,9 @@ pub fn encode_derive(input: proc_macro::TokenStream) -> proc_macro::TokenStream 
 		Ok(input) => input,
 		Err(e) => return e.to_compile_error().into(),
 	};
-	if let Some(span) = utils::get_skip(&input.attrs) {
-		return Error::new(span, "invalid attribute `skip` on root input")
-			.to_compile_error().into();
+
+	if let Err(e) = utils::check_attributes(&input) {
+		return e.to_compile_error().into();
 	}
 
 	if let Err(e) = trait_bounds::add(
@@ -176,9 +176,9 @@ pub fn decode_derive(input: proc_macro::TokenStream) -> proc_macro::TokenStream 
 		Ok(input) => input,
 		Err(e) => return e.to_compile_error().into(),
 	};
-	if let Some(span) = utils::get_skip(&input.attrs) {
-		return Error::new(span, "invalid attribute `skip` on root input")
-			.to_compile_error().into();
+
+	if let Err(e) = utils::check_attributes(&input) {
+		return e.to_compile_error().into();
 	}
 
 	if let Err(e) = trait_bounds::add(
@@ -231,6 +231,10 @@ pub fn compact_as_derive(input: proc_macro::TokenStream) -> proc_macro::TokenStr
 		Ok(input) => input,
 		Err(e) => return e.to_compile_error().into(),
 	};
+
+	if let Err(e) = utils::check_attributes(&input) {
+		return e.to_compile_error().into();
+	}
 
 	if let Err(e) = trait_bounds::add(
 		&input.ident,

--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -116,7 +116,7 @@ fn wrap_with_dummy_const(impl_block: proc_macro2::TokenStream) -> proc_macro::To
 /// # use parity_scale_codec::Encode as _;
 /// #[derive(Encode)]
 /// enum EnumType {
-/// 	#[codec(index = "15")]
+/// 	#[codec(index = 15)]
 /// 	A,
 /// 	#[codec(skip)]
 /// 	B,

--- a/derive/src/utils.rs
+++ b/derive/src/utils.rs
@@ -12,12 +12,17 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//! Various internal utils.
+//!
+//! NOTE: attributes finder must be checked using check_attribute first, otherwise macro can panic.
+
 use std::str::FromStr;
 
 use proc_macro2::{TokenStream, Span};
 use syn::{
 	spanned::Spanned,
-	Meta, NestedMeta, Lit, Attribute, Variant, Field,
+	Meta, NestedMeta, Lit, Attribute, Variant, Field, DeriveInput, Fields, Data, FieldsUnnamed,
+	FieldsNamed, MetaNameValue
 };
 
 fn find_meta_item<'a, F, R, I>(itr: I, pred: F) -> Option<R> where
@@ -26,7 +31,9 @@ fn find_meta_item<'a, F, R, I>(itr: I, pred: F) -> Option<R> where
 {
 	itr.filter_map(|attr| {
 		if attr.path.is_ident("codec") {
-			if let Ok(Meta::List(ref meta_list)) = attr.parse_meta() {
+			if let Meta::List(ref meta_list) = attr.parse_meta()
+				.expect("Internal error, parse_meta must have been checked")
+			{
 				return meta_list.nested.iter().filter_map(pred.clone()).next();
 			}
 		}
@@ -40,8 +47,9 @@ pub fn index(v: &Variant, i: usize) -> TokenStream {
 	let index = find_meta_item(v.attrs.iter(), |meta| {
 		if let NestedMeta::Meta(Meta::NameValue(ref nv)) = meta {
 			if nv.path.is_ident("index") {
-				if let Lit::Str(ref s) = nv.lit {
-					let byte: u8 = s.value().parse().expect("Numeric index expected.");
+				if let Lit::Int(ref v) = nv.lit {
+					let byte = v.base10_parse::<u8>()
+						.expect("Internal error, index attribute must have been checked");
 					return Some(byte)
 				}
 			}
@@ -67,7 +75,7 @@ pub fn get_encoded_as_type(field_entry: &Field) -> Option<TokenStream> {
 				if let Lit::Str(ref s) = nv.lit {
 					return Some(
 						TokenStream::from_str(&s.value())
-							.expect("`encoded_as` should be a valid rust type!")
+							.expect("Internal error, encoded_as attribute must have been checked")
 					);
 				}
 			}
@@ -126,4 +134,121 @@ pub fn filter_skip_unnamed<'a>(fields: &'a syn::FieldsUnnamed) -> impl Iterator<
 	fields.unnamed.iter()
 		.enumerate()
 		.filter(|(_, f)| get_skip(&f.attrs).is_none())
+}
+
+pub fn check_attributes(input: &DeriveInput) -> syn::Result<()> {
+	// Check top attribute
+	for attr in &input.attrs {
+		check_top_attribute(attr)?;
+	}
+
+	match input.data {
+		Data::Struct(ref data) => match &data.fields {
+			| Fields::Named(FieldsNamed { named: fields , .. })
+			| Fields::Unnamed(FieldsUnnamed { unnamed: fields, .. }) => {
+				for field in fields {
+					for attr in &field.attrs {
+						check_field_attribute(attr)?;
+					}
+				}
+			}
+			Fields::Unit => (),
+		}
+		Data::Enum(ref data) => {
+			for variant in data.variants.iter() {
+				for attr in &variant.attrs {
+					check_variant_attribute(attr)?;
+				}
+				for field in &variant.fields {
+					for attr in &field.attrs {
+						check_field_attribute(attr)?;
+					}
+				}
+			}
+		},
+		Data::Union(_) => (),
+	}
+	Ok(())
+}
+
+// Is accepted only:
+// * `#[codec(skip)]`
+// * `#[codec(compact)]`
+// * `#[codec(encoded_as = "$EncodeAs")]` with $EncodedAs a valid TokenStream
+fn check_field_attribute(attr: &Attribute) -> syn::Result<()> {
+	let field_error = "Invalid attribute on field, only `#[codec(skip)]`, `#[codec(compact)]` and \
+		`#[codec(encoded_as = \"$EncodeAs\")]` are accepted.";
+
+	if attr.path.is_ident("codec") {
+		match attr.parse_meta()? {
+			Meta::List(ref meta_list) if meta_list.nested.len() == 1 => {
+				match meta_list.nested.first().unwrap() {
+					NestedMeta::Meta(Meta::Path(path))
+						if path.get_ident().map_or(false, |i| i == "skip") => Ok(()),
+
+					NestedMeta::Meta(Meta::Path(path))
+						if path.get_ident().map_or(false, |i| i == "compact") => Ok(()),
+
+					NestedMeta::Meta(Meta::NameValue(MetaNameValue { path, lit: Lit::Str(lit_str), .. }))
+						if path.get_ident().map_or(false, |i| i == "encoded_as")
+					=> TokenStream::from_str(&lit_str.value()).map(|_| ())
+						.map_err(|_e| syn::Error::new(lit_str.span(), "Invalid token stream")),
+
+					elt @ _ => Err(syn::Error::new(elt.span(), field_error)),
+				}
+			},
+			meta @ _ => Err(syn::Error::new(meta.span(), field_error)),
+		}
+	} else {
+		Ok(())
+	}
+}
+
+// Is accepted only:
+// * `#[codec(skip)]`
+// * `#[codec(index = $int)]`
+fn check_variant_attribute(attr: &Attribute) -> syn::Result<()> {
+	let variant_error = "Invalid attribute on variant, only `#[codec(skip)]` and \
+		`#[codec(index = $u8)]` are accepted.";
+
+	if attr.path.is_ident("codec") {
+		match attr.parse_meta()? {
+			Meta::List(ref meta_list) if meta_list.nested.len() == 1 => {
+				match meta_list.nested.first().unwrap() {
+					NestedMeta::Meta(Meta::Path(path))
+						if path.get_ident().map_or(false, |i| i == "skip") => Ok(()),
+
+					NestedMeta::Meta(Meta::NameValue(MetaNameValue { path, lit: Lit::Int(lit_int), .. }))
+						if path.get_ident().map_or(false, |i| i == "index")
+					=> lit_int.base10_parse::<u8>().map(|_| ()),
+
+					elt @ _ => Err(syn::Error::new(elt.span(), variant_error)),
+				}
+			},
+			meta @ _ => Err(syn::Error::new(meta.span(), variant_error)),
+		}
+	} else {
+		Ok(())
+	}
+}
+
+// Only `#[codec(dumb_trait_bound)]` is accepted as top attribute
+fn check_top_attribute(attr: &Attribute) -> syn::Result<()> {
+	let top_error = "Invalid attribute only `#[codec(dumb_trait_bound)]` is accepted as top \
+		attribute";
+	if attr.path.is_ident("codec") {
+		match attr.parse_meta()? {
+			Meta::List(ref meta_list) if meta_list.nested.len() == 1 => {
+				match meta_list.nested.first().unwrap() {
+					NestedMeta::Meta(Meta::Path(path))
+						if path.get_ident().map_or(false, |i| i == "dumb_trait_bound") => Ok(()),
+
+					elt @ _ => Err(syn::Error::new(elt.span(), top_error)),
+				}
+			},
+			meta @ _ => Err(syn::Error::new(meta.span(), top_error)),
+		}
+	} else {
+		Ok(())
+	}
 }

--- a/derive/src/utils.rs
+++ b/derive/src/utils.rs
@@ -219,7 +219,8 @@ fn check_variant_attribute(attr: &Attribute) -> syn::Result<()> {
 
 					NestedMeta::Meta(Meta::NameValue(MetaNameValue { path, lit: Lit::Int(lit_int), .. }))
 						if path.get_ident().map_or(false, |i| i == "index")
-					=> lit_int.base10_parse::<u8>().map(|_| ()),
+					=> lit_int.base10_parse::<u8>().map(|_| ())
+						.map_err(|_| syn::Error::new(lit_int.span(), "Index must be in 0..255")),
 
 					elt @ _ => Err(syn::Error::new(elt.span(), variant_error)),
 				}

--- a/derive/src/utils.rs
+++ b/derive/src/utils.rs
@@ -137,7 +137,6 @@ pub fn filter_skip_unnamed<'a>(fields: &'a syn::FieldsUnnamed) -> impl Iterator<
 }
 
 pub fn check_attributes(input: &DeriveInput) -> syn::Result<()> {
-	// Check top attribute
 	for attr in &input.attrs {
 		check_top_attribute(attr)?;
 	}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -91,7 +91,7 @@
 //!
 //! #[derive(Debug, PartialEq, Encode, Decode)]
 //! enum EnumType {
-//! 	#[codec(index = "15")]
+//! 	#[codec(index = 15)]
 //! 	A,
 //! 	B(u32, u64),
 //! 	C {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -217,12 +217,13 @@
 //!   fall back to just use the type parameters of the type. This can be useful for situation where
 //!   the algorithm includes private types in the public interface. By using this attribute, you should
 //!   not get this error/warning again.
-//! - `codec(skip)`: Needs to be placed above a field and makes the field to be skipped while encoding/decoding.
+//! - `codec(skip)`: Needs to be placed above a field  or variant and makes it to be skipped while
+//!   encoding/decoding.
 //! - `codec(compact)`: Needs to be placed above a field and makes the field use compact encoding.
 //!   (The type needs to support compact encoding.)
-//! - `codec(encoded_as(OtherType))`: Needs to be placed above a field and makes the field being encoded
+//! - `codec(encoded_as = "OtherType")`: Needs to be placed above a field and makes the field being encoded
 //!   by using `OtherType`.
-//! - `codec(index("0"))`: Needs to be placed above an enum variant to make the variant use the given
+//! - `codec(index = 0)`: Needs to be placed above an enum variant to make the variant use the given
 //!   index when encoded. By default the index is determined by counting from `0` beginning wth the
 //!   first variant.
 //!

--- a/tests/mod.rs
+++ b/tests/mod.rs
@@ -47,7 +47,7 @@ impl <A, B, C> Struct<A, B, C> {
 
 #[derive(Debug, PartialEq, Encode, Decode)]
 enum EnumType {
-	#[codec(index = "15")]
+	#[codec(index = 15)]
 	A,
 	B(u32, u64),
 	C {

--- a/tests/variant_number.rs
+++ b/tests/variant_number.rs
@@ -31,7 +31,7 @@ fn skipped_variant_not_counted_in_default_index() {
 fn index_attr_variant_counted_and_reused_in_default_index() {
 	#[derive(Encode)]
 	enum T {
-		#[codec(index = "1")]
+		#[codec(index = 1)]
 		A,
 		B,
 	}


### PR DESCRIPTION
Fix https://github.com/paritytech/parity-scale-codec/issues/200

Previously incorrect attributes were mostly not checked or were panicking the macro.

So attribute like `#[codec(index = "15")]` would simply be ignored because not following the syntax.

I first tried to change the code to make the attribute finder return a Result but because they are used for filtering it is very not convenient.

Instead I just created a global attribute checker which checks that the attributes are correct.