### PR TITLE
IoReader suppose Seek impl to be of fixed len, substrate usage is otherwise

### DIFF
--- a/src/codec.rs
+++ b/src/codec.rs
@@ -184,22 +184,7 @@ pub struct IoReader<R: std::io::Read + std::io::Seek>(pub R);
 #[cfg(feature = "std")]
 impl<R: std::io::Read + std::io::Seek> Input for IoReader<R> {
 	fn remaining_len(&mut self) -> Result<Option<usize>, Error> {
-		use std::convert::TryInto;
-		use std::io::SeekFrom;
-
-		let old_pos = self.0.seek(SeekFrom::Current(0))?;
-		let len = self.0.seek(SeekFrom::End(0))?;
-
-		// Avoid seeking a third time when we were already at the end of the
-		// stream. The branch is usually way cheaper than a seek operation.
-		if old_pos != len {
-			self.0.seek(SeekFrom::Start(old_pos))?;
-		}
-
-		len.saturating_sub(old_pos)
-			.try_into()
-			.map_err(|_| "Input cannot fit into usize length".into())
-			.map(Some)
+		Ok(None)
 	}
 
 	fn read(&mut self, into: &mut [u8]) -> Result<(), Error> {


### PR DESCRIPTION
In our code we expect remaining_len implementation to give the exact remaining_length (or an upper bound actually).

for instance:
https://github.com/paritytech/parity-scale-codec/blob/353db2cf1e417e1d0216e882dc0fb74c769f4a56/src/codec.rs#L777-L784


but IoReader use Seek trait to get the len, and Seek doesn't guarantee to return the final length, length of Seek implementation can change over time.

### Usage in substrate

in substrate, ioreader is used for a generic `Seek + Read` https://github.com/paritytech/substrate/blob/master/client/service/src/chain_ops.rs

(If I read correctly it is used inside a future context, I guess that means that Read will wait when reaching the end. Thus Seek implementation gives varying len of stream.)

### Additional notes

if wanted we could extend Input trait to return a custom max_preallocation.