### PR TITLE
Remove unrequired bounds in HasCompact

### DIFF
--- a/src/compact.rs
+++ b/src/compact.rs
@@ -191,6 +191,20 @@ impl<T> core::fmt::Debug for Compact<T> where T: core::fmt::Debug {
 	}
 }
 
+#[cfg(feature = "std")]
+impl<T> serde::Serialize for Compact<T> where T: serde::Serialize {
+	fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error> where S: serde::Serializer {
+		T::serialize(&self.0, serializer)
+	}
+}
+
+#[cfg(feature = "std")]
+impl<'de, T> serde::Deserialize<'de> for Compact<T> where T: serde::Deserialize<'de> {
+	fn deserialize<D>(deserializer: D) -> Result<Self, D::Error> where D: serde::Deserializer<'de> {
+		T::deserialize(deserializer).map(Compact)
+	}
+}
+
 /// Trait that tells you if a given type can be encoded/decoded in a compact way.
 pub trait HasCompact: Sized {
 	/// The compact type; this can be

--- a/src/compact.rs
+++ b/src/compact.rs
@@ -191,35 +191,10 @@ impl<T> core::fmt::Debug for Compact<T> where T: core::fmt::Debug {
 	}
 }
 
-#[cfg(feature = "std")]
-impl<T> serde::Serialize for Compact<T> where T: serde::Serialize {
-	fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error> where S: serde::Serializer {
-		T::serialize(&self.0, serializer)
-	}
-}
-
-#[cfg(feature = "std")]
-impl<'de, T> serde::Deserialize<'de> for Compact<T> where T: serde::Deserialize<'de> {
-	fn deserialize<D>(deserializer: D) -> Result<Self, D::Error> where D: serde::Deserializer<'de> {
-		T::deserialize(deserializer).map(Compact)
-	}
-}
-
-#[cfg(feature = "std")]
-pub trait MaybeDebugSerde: core::fmt::Debug + serde::Serialize + for<'a> serde::Deserialize<'a> {}
-#[cfg(feature = "std")]
-impl<T> MaybeDebugSerde for T where T: core::fmt::Debug + serde::Serialize + for<'a> serde::Deserialize<'a> {}
-
-#[cfg(not(feature = "std"))]
-pub trait MaybeDebugSerde {}
-#[cfg(not(feature = "std"))]
-impl<T> MaybeDebugSerde for T {}
-
 /// Trait that tells you if a given type can be encoded/decoded in a compact way.
 pub trait HasCompact: Sized {
 	/// The compact type; this can be
-	type Type: for<'a> EncodeAsRef<'a, Self> + Decode + From<Self> + Into<Self> + Clone +
-		PartialEq + Eq + MaybeDebugSerde;
+	type Type: for<'a> EncodeAsRef<'a, Self> + Decode + From<Self> + Into<Self>;
 }
 
 impl<'a, T: 'a> EncodeAsRef<'a, T> for Compact<T> where CompactRef<'a, T>: Encode + From<&'a T> {
@@ -227,8 +202,7 @@ impl<'a, T: 'a> EncodeAsRef<'a, T> for Compact<T> where CompactRef<'a, T>: Encod
 }
 
 impl<T: 'static> HasCompact for T where
-	Compact<T>: for<'a> EncodeAsRef<'a, T> + Decode + From<Self> + Into<Self> + Clone +
-		PartialEq + Eq + MaybeDebugSerde,
+	Compact<T>: for<'a> EncodeAsRef<'a, T> + Decode + From<Self> + Into<Self>
 {
 	type Type = Compact<T>;
 }


### PR DESCRIPTION
the trait HasCompact doesn't need to bound Clone, Eq, PartialEq, MaybeDebugSerde.

Also MaybeDebugSerde is not used by scale-codec in any way.

I think trait makes more sense know, also this is ok as master contains some few breaking change already.