### PR TITLE
Fix name conflict in derive macros

### DIFF
--- a/derive/src/decode.rs
+++ b/derive/src/decode.rs
@@ -55,7 +55,7 @@ pub fn quote(data: &Data, type_name: &Ident, input: &TokenStream) -> TokenStream
 				);
 
 				quote_spanned! { v.span() =>
-					x if x == #index as u8 => {
+					__codec_x_edqy if __codec_x_edqy == #index as u8 => {
 						#create
 					},
 				}
@@ -65,7 +65,7 @@ pub fn quote(data: &Data, type_name: &Ident, input: &TokenStream) -> TokenStream
 			quote! {
 				match #input.read_byte()? {
 					#( #recurse )*
-					x => Err(#err_msg.into()),
+					_ => Err(#err_msg.into()),
 				}
 			}
 
@@ -78,6 +78,8 @@ fn create_decode_expr(field: &Field, name: &str, input: &TokenStream) -> TokenSt
 	let encoded_as = utils::get_encoded_as_type(field);
 	let compact = utils::get_enable_compact(field);
 	let skip = utils::get_skip(&field.attrs).is_some();
+
+	let res = quote!(__codec_res_edqy);
 
 	if encoded_as.is_some() as u8 + compact as u8 + skip as u8 > 1 {
 		return Error::new(
@@ -92,22 +94,22 @@ fn create_decode_expr(field: &Field, name: &str, input: &TokenStream) -> TokenSt
 		let field_type = &field.ty;
 		quote_spanned! { field.span() =>
 			{
-				let res = <
+				let #res = <
 					<#field_type as _parity_scale_codec::HasCompact>::Type as _parity_scale_codec::Decode
 				>::decode(#input);
-				match res {
+				match #res {
 					Err(_) => return Err(#err_msg.into()),
-					Ok(a) => a.into(),
+					Ok(#res) => #res.into(),
 				}
 			}
 		}
 	} else if let Some(encoded_as) = encoded_as {
 		quote_spanned! { field.span() =>
 			{
-				let res = <#encoded_as as _parity_scale_codec::Decode>::decode(#input);
-				match res {
+				let #res = <#encoded_as as _parity_scale_codec::Decode>::decode(#input);
+				match #res {
 					Err(_) => return Err(#err_msg.into()),
-					Ok(a) => a.into(),
+					Ok(#res) => #res.into(),
 				}
 			}
 		}
@@ -116,10 +118,10 @@ fn create_decode_expr(field: &Field, name: &str, input: &TokenStream) -> TokenSt
 	} else {
 		quote_spanned! { field.span() =>
 			{
-				let res = _parity_scale_codec::Decode::decode(#input);
-				match res {
+				let #res = _parity_scale_codec::Decode::decode(#input);
+				match #res {
 					Err(_) => return Err(#err_msg.into()),
-					Ok(a) => a,
+					Ok(#res) => #res,
 				}
 			}
 		}

--- a/derive/src/encode.rs
+++ b/derive/src/encode.rs
@@ -74,8 +74,11 @@ fn encode_single_field(
 	let i_self = quote! { self };
 
 	quote_spanned! { field.span() =>
-			fn encode_to<EncOut: _parity_scale_codec::Output>(&#i_self, dest: &mut EncOut) {
-				_parity_scale_codec::Encode::encode_to(&#final_field_variable, dest)
+			fn encode_to<__CodecOutputEdqy: _parity_scale_codec::Output>(
+				&#i_self,
+				__codec_dest_edqy: &mut __CodecOutputEdqy
+			) {
+				_parity_scale_codec::Encode::encode_to(&#final_field_variable, __codec_dest_edqy)
 			}
 
 			fn encode(&#i_self) -> _parity_scale_codec::alloc::vec::Vec<u8> {
@@ -176,7 +179,7 @@ fn try_impl_encode_single_field_optimisation(data: &Data) -> Option<TokenStream>
 
 fn impl_encode(data: &Data, type_name: &Ident) -> TokenStream {
 	let self_ = quote!(self);
-	let dest = &quote!(dest);
+	let dest = &quote!(__codec_dest_edqy);
 	let encoding = match *data {
 		Data::Struct(ref data) => {
 			match data.fields {
@@ -285,7 +288,7 @@ fn impl_encode(data: &Data, type_name: &Ident) -> TokenStream {
 	};
 
 	quote! {
-		fn encode_to<EncOut: _parity_scale_codec::Output>(&#self_, #dest: &mut EncOut) {
+		fn encode_to<__CodecOutputEdqy: _parity_scale_codec::Output>(&#self_, #dest: &mut __CodecOutputEdqy) {
 			#encoding
 		}
 	}

--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -195,13 +195,13 @@ pub fn decode_derive(input: proc_macro::TokenStream) -> proc_macro::TokenStream 
 	let name = &input.ident;
 	let (impl_generics, ty_generics, where_clause) = input.generics.split_for_impl();
 
-	let input_ = quote!(input);
+	let input_ = quote!(__codec_input_edqy);
 	let decoding = decode::quote(&input.data, name, &input_);
 
 	let impl_block = quote! {
 		impl #impl_generics _parity_scale_codec::Decode for #name #ty_generics #where_clause {
-			fn decode<DecIn: _parity_scale_codec::Input>(
-				#input_: &mut DecIn
+			fn decode<__CodecInputEdqy: _parity_scale_codec::Input>(
+				#input_: &mut __CodecInputEdqy
 			) -> core::result::Result<Self, _parity_scale_codec::Error> {
 				#decoding
 			}


### PR DESCRIPTION
This is the fix for name conflicts for master (no difference with the backport fix)

additional note: when we do:
```rust
match foo {
Foo::Variant { foo } => ...
}
```
the match conflicts if foo is defined as a const in scope
but when we do:
```rust
match foo {
Foo::Variant { ref foo } => ...
}
```
the conflicts result in rust error.

see https://play.rust-lang.org/?version=stable&mode=debug&edition=2018&gist=be416a1e0828637dfb31f18e9161af33

Currently in our code all the match is done with ref so we are fine, though maybe we should prefer doing like `foo: $unique_name` instead ?