### PR TITLE
Extract derive utilities to own crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,4 +48,5 @@ full = []
 members = [
 	"derive",
 	"fuzzer",
+	"derive-utils",
 ]

--- a/derive-utils/Cargo.toml
+++ b/derive-utils/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "parity-scale-codec-derive-utils"
+version = "0.1.0"
+authors = ["Parity Technologies <admin@parity.io>"]
+license = "Apache-2.0"
+repository = "https://github.com/paritytech/parity-scale-codec"
+categories = ["encoding"]
+edition = "2018"
+
+[dependencies]
+syn = { version = "1" }
+quote = "1"
+proc-macro2 = "1"

--- a/derive/Cargo.toml
+++ b/derive/Cargo.toml
@@ -14,6 +14,7 @@ syn = { version = "1.0.8", features = [ "full", "visit" ] }
 quote = "1.0.2"
 proc-macro2 = "1.0.6"
 proc-macro-crate = "0.1.4"
+utils = { package = "parity-scale-codec-derive-utils", version = "0.1", path = "../derive-utils" }
 
 [dev-dependencies]
 parity-scale-codec = { path = "..", version = "1.1.0" }

--- a/derive/src/decode.rs
+++ b/derive/src/decode.rs
@@ -18,8 +18,6 @@ use syn::{
 	Data, Fields, Field, Error,
 };
 
-use crate::utils;
-
 pub fn quote(data: &Data, type_name: &Ident, input: &TokenStream) -> TokenStream {
 	match *data {
 		Data::Struct(ref data) => match data.fields {
@@ -35,7 +33,7 @@ pub fn quote(data: &Data, type_name: &Ident, input: &TokenStream) -> TokenStream
 			},
 		},
 		Data::Enum(ref data) => {
-			let data_variants = || data.variants.iter().filter(|variant| crate::utils::get_skip(&variant.attrs).is_none());
+			let data_variants = || data.variants.iter().filter(|variant| utils::get_skip(&variant.attrs).is_none());
 
 			if data_variants().count() > 256 {
 				return Error::new(

--- a/derive/src/encode.rs
+++ b/derive/src/encode.rs
@@ -22,8 +22,6 @@ use syn::{
 	Data, Field, Fields, Error,
 };
 
-use crate::utils;
-
 type FieldsList = Punctuated<Field, Comma>;
 
 // Encode a signle field by using using_encoded, must not have skip attribute
@@ -200,7 +198,7 @@ fn impl_encode(data: &Data, type_name: &Ident) -> TokenStream {
 			}
 		},
 		Data::Enum(ref data) => {
-			let data_variants = || data.variants.iter().filter(|variant| crate::utils::get_skip(&variant.attrs).is_none());
+			let data_variants = || data.variants.iter().filter(|variant| utils::get_skip(&variant.attrs).is_none());
 
 			if data_variants().count() > 256 {
 				return Error::new(

--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -30,7 +30,6 @@ use syn::{Data, Field, Fields, DeriveInput, Error};
 
 mod decode;
 mod encode;
-mod utils;
 mod trait_bounds;
 
 /// Include the `parity-scale-codec` crate under a known name (`_parity_scale_codec`).

--- a/derive/src/trait_bounds.rs
+++ b/derive/src/trait_bounds.rs
@@ -195,21 +195,21 @@ fn get_types_to_add_trait_bound(
 }
 
 fn needs_codec_bound(field: &syn::Field) -> bool {
-	!crate::utils::get_enable_compact(field)
-		&& crate::utils::get_encoded_as_type(field).is_none()
-		&& crate::utils::get_skip(&field.attrs).is_none()
+	!utils::get_enable_compact(field)
+		&& utils::get_encoded_as_type(field).is_none()
+		&& utils::get_skip(&field.attrs).is_none()
 }
 
 fn needs_has_compact_bound(field: &syn::Field) -> bool {
-	crate::utils::get_enable_compact(field)
+	utils::get_enable_compact(field)
 }
 
 fn needs_default_bound(field: &syn::Field) -> bool {
-	crate::utils::get_skip(&field.attrs).is_some()
+	utils::get_skip(&field.attrs).is_some()
 }
 
 fn variant_not_skipped(variant: &syn::Variant) -> bool {
-	crate::utils::get_skip(&variant.attrs).is_none()
+	utils::get_skip(&variant.attrs).is_none()
 }
 
 fn collect_types(


### PR DESCRIPTION
Extract the `utils` module into it's own crate, `parity-scale-codec-derive-utils`, so it can be used by `scale-info` to avoid duplicating code when handling attributes.

It would have been nicer to just make the `utils` module public but proc-macro crates can't export anything that isn't a proc macro. :/

This can be backported to the `1.3.*` series.