### PR TITLE
Docs and cleanup for utils

### DIFF
--- a/derive/src/decode.rs
+++ b/derive/src/decode.rs
@@ -35,7 +35,7 @@ pub fn quote(data: &Data, type_name: &Ident, input: &TokenStream) -> TokenStream
 			},
 		},
 		Data::Enum(ref data) => {
-			let data_variants = || data.variants.iter().filter(|variant| crate::utils::get_skip(&variant.attrs).is_none());
+			let data_variants = || data.variants.iter().filter(|variant| !utils::should_skip(&variant.attrs));
 
 			if data_variants().count() > 256 {
 				return Error::new(
@@ -76,8 +76,8 @@ pub fn quote(data: &Data, type_name: &Ident, input: &TokenStream) -> TokenStream
 
 fn create_decode_expr(field: &Field, name: &str, input: &TokenStream) -> TokenStream {
 	let encoded_as = utils::get_encoded_as_type(field);
-	let compact = utils::get_enable_compact(field);
-	let skip = utils::get_skip(&field.attrs).is_some();
+	let compact = utils::is_compact(field);
+	let skip = utils::should_skip(&field.attrs);
 
 	let res = quote!(__codec_res_edqy);
 

--- a/derive/src/decode.rs
+++ b/derive/src/decode.rs
@@ -46,7 +46,7 @@ pub fn quote(data: &Data, type_name: &Ident, input: &TokenStream) -> TokenStream
 
 			let recurse = data_variants().enumerate().map(|(i, v)| {
 				let name = &v.ident;
-				let index = utils::index(v, i);
+				let index = utils::get_variant_index(v, i);
 
 				let create = create_instance(
 					quote! { #type_name :: #name },

--- a/derive/src/decode.rs
+++ b/derive/src/decode.rs
@@ -46,7 +46,7 @@ pub fn quote(data: &Data, type_name: &Ident, input: &TokenStream) -> TokenStream
 
 			let recurse = data_variants().enumerate().map(|(i, v)| {
 				let name = &v.ident;
-				let index = utils::get_variant_index(v, i);
+				let index = utils::variant_index(v, i);
 
 				let create = create_instance(
 					quote! { #type_name :: #name },

--- a/derive/src/encode.rs
+++ b/derive/src/encode.rs
@@ -216,7 +216,7 @@ fn impl_encode(data: &Data, type_name: &Ident) -> TokenStream {
 
 			let recurse = data_variants().enumerate().map(|(i, f)| {
 				let name = &f.ident;
-				let index = utils::get_variant_index(f, i);
+				let index = utils::variant_index(f, i);
 
 				match f.fields {
 					Fields::Named(ref fields) => {

--- a/derive/src/encode.rs
+++ b/derive/src/encode.rs
@@ -216,7 +216,7 @@ fn impl_encode(data: &Data, type_name: &Ident) -> TokenStream {
 
 			let recurse = data_variants().enumerate().map(|(i, f)| {
 				let name = &f.ident;
-				let index = utils::index(f, i);
+				let index = utils::get_variant_index(f, i);
 
 				match f.fields {
 					Fields::Named(ref fields) => {

--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -146,7 +146,7 @@ pub fn encode_derive(input: proc_macro::TokenStream) -> proc_macro::TokenStream 
 		&input.data,
 		parse_quote!(_parity_scale_codec::Encode),
 		None,
-		utils::get_dumb_trait_bound(&input.attrs),
+		utils::has_dumb_trait_bound(&input.attrs),
 	) {
 		return e.to_compile_error().into();
 	}
@@ -187,7 +187,7 @@ pub fn decode_derive(input: proc_macro::TokenStream) -> proc_macro::TokenStream 
 		&input.data,
 		parse_quote!(_parity_scale_codec::Decode),
 		Some(parse_quote!(Default)),
-		utils::get_dumb_trait_bound(&input.attrs),
+		utils::has_dumb_trait_bound(&input.attrs),
 	) {
 		return e.to_compile_error().into();
 	}
@@ -242,7 +242,7 @@ pub fn compact_as_derive(input: proc_macro::TokenStream) -> proc_macro::TokenStr
 		&input.data,
 		parse_quote!(_parity_scale_codec::CompactAs),
 		None,
-		utils::get_dumb_trait_bound(&input.attrs),
+		utils::has_dumb_trait_bound(&input.attrs),
 	) {
 		return e.to_compile_error().into();
 	}

--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -251,7 +251,7 @@ pub fn compact_as_derive(input: proc_macro::TokenStream) -> proc_macro::TokenStr
 	let (impl_generics, ty_generics, where_clause) = input.generics.split_for_impl();
 
 	fn val_or_default(field: &Field) -> proc_macro2::TokenStream {
-		let skip = utils::get_skip(&field.attrs).is_some();
+		let skip = utils::should_skip(&field.attrs);
 		if skip {
 			quote_spanned!(field.span()=> Default::default())
 		} else {

--- a/derive/src/trait_bounds.rs
+++ b/derive/src/trait_bounds.rs
@@ -120,14 +120,15 @@ pub fn add(
 
 	let codec_types = get_types_to_add_trait_bound(input_ident, data, &ty_params, dumb_trait_bounds)?;
 
-	let compact_types = collect_types(&data, needs_has_compact_bound, variant_not_skipped)?
+	let compact_types = collect_types(&data, utils::is_compact)?
 		.into_iter()
 		// Only add a bound if the type uses a generic
 		.filter(|ty| type_contain_idents(ty, &ty_params))
 		.collect::<Vec<_>>();
 
 	let skip_types = if codec_skip_bound.is_some() {
-		collect_types(&data, needs_default_bound, variant_not_skipped)?
+		let needs_default_bound = |f: &syn::Field| utils::should_skip(&f.attrs);
+		collect_types(&data, needs_default_bound)?
 			.into_iter()
 			// Only add a bound if the type uses a generic
 			.filter(|ty| type_contain_idents(ty, &ty_params))
@@ -173,11 +174,14 @@ fn get_types_to_add_trait_bound(
 	if dumb_trait_bound {
 		Ok(ty_params.iter().map(|t| parse_quote!( #t )).collect())
 	} else {
-		let res = collect_types(&data, needs_codec_bound, variant_not_skipped)?
+		let needs_codec_bound = |f: &syn::Field| !utils::is_compact(f)
+				&& utils::get_encoded_as_type(f).is_none()
+				&& !utils::should_skip(&f.attrs);
+		let res = collect_types(&data, needs_codec_bound)?
 			.into_iter()
 			// Only add a bound if the type uses a generic
 			.filter(|ty| type_contain_idents(ty, &ty_params))
-			// If a struct is cotaining itself as field type, we can not add this type into the where clause.
+			// If a struct contains itself as field type, we can not add this type into the where clause.
 			// This is required to work a round the following compiler bug: https://github.com/rust-lang/rust/issues/47032
 			.flat_map(|ty| {
 				find_type_paths_not_start_or_contain_ident(&ty, input_ident)
@@ -185,7 +189,7 @@ fn get_types_to_add_trait_bound(
 					.map(|ty| Type::Path(ty.clone()))
 					// Remove again types that do not contain any of our generic parameters
 					.filter(|ty| type_contain_idents(ty, &ty_params))
-					// Add back the original type, as we don't want to loose him.
+					// Add back the original type, as we don't want to loose it.
 					.chain(iter::once(ty))
 			})
 			// Remove all remaining types that start/contain the input ident to not have them in the where clause.
@@ -196,29 +200,9 @@ fn get_types_to_add_trait_bound(
 	}
 }
 
-fn needs_codec_bound(field: &syn::Field) -> bool {
-	!utils::is_compact(field)
-		&& utils::get_encoded_as_type(field).is_none()
-		&& !utils::should_skip(&field.attrs)
-}
-
-// TODO: dp these looks like they should go
-fn needs_has_compact_bound(field: &syn::Field) -> bool {
-	utils::is_compact(field)
-}
-
-fn needs_default_bound(field: &syn::Field) -> bool {
-	utils::should_skip(&field.attrs)
-}
-
-fn variant_not_skipped(variant: &syn::Variant) -> bool {
-	!utils::should_skip(&variant.attrs)
-}
-
 fn collect_types(
 	data: &syn::Data,
 	type_filter: fn(&syn::Field) -> bool,
-	variant_filter: fn(&syn::Variant) -> bool,
 ) -> Result<Vec<syn::Type>> {
 	use syn::*;
 
@@ -236,7 +220,7 @@ fn collect_types(
 		},
 
 		Data::Enum(ref data) => data.variants.iter()
-			.filter(|variant| variant_filter(variant))
+			.filter(|variant| !utils::should_skip(&variant.attrs))
 			.flat_map(|variant| {
 				match &variant.fields {
 					| Fields::Named(FieldsNamed { named: fields , .. })

--- a/derive/src/trait_bounds.rs
+++ b/derive/src/trait_bounds.rs
@@ -21,6 +21,8 @@ use syn::{
 	Generics, Result, Type, TypePath,
 };
 
+use crate::utils;
+
 /// Visits the ast and checks if one of the given idents is found.
 struct ContainIdents<'a> {
 	result: bool,
@@ -195,21 +197,22 @@ fn get_types_to_add_trait_bound(
 }
 
 fn needs_codec_bound(field: &syn::Field) -> bool {
-	!crate::utils::get_enable_compact(field)
-		&& crate::utils::get_encoded_as_type(field).is_none()
-		&& crate::utils::get_skip(&field.attrs).is_none()
+	!utils::is_compact(field)
+		&& utils::get_encoded_as_type(field).is_none()
+		&& !utils::should_skip(&field.attrs)
 }
 
+// TODO: dp these looks like they should go
 fn needs_has_compact_bound(field: &syn::Field) -> bool {
-	crate::utils::get_enable_compact(field)
+	utils::is_compact(field)
 }
 
 fn needs_default_bound(field: &syn::Field) -> bool {
-	crate::utils::get_skip(&field.attrs).is_some()
+	utils::should_skip(&field.attrs)
 }
 
 fn variant_not_skipped(variant: &syn::Variant) -> bool {
-	crate::utils::get_skip(&variant.attrs).is_none()
+	!utils::should_skip(&variant.attrs)
 }
 
 fn collect_types(

--- a/derive/src/utils.rs
+++ b/derive/src/utils.rs
@@ -91,7 +91,6 @@ pub fn get_encoded_as_type(field: &Field) -> Option<TokenStream> {
 }
 
 /// Look for a `#[codec(compact)]` outer attribute on the given `Field`.
-/// Returns true or false.
 pub fn is_compact(field: &Field) -> bool {
 	find_meta_item(field.attrs.iter(), |meta| {
 		if let NestedMeta::Meta(Meta::Path(ref path)) = meta {

--- a/derive/src/utils.rs
+++ b/derive/src/utils.rs
@@ -46,7 +46,7 @@ fn find_meta_item<'a, F, R, I>(itr: I, pred: F) -> Option<R> where
 /// Look for a `#[scale(index = $int)]` attribute on a variant. If no attribute
 /// is found, fall back to the discriminant or just the variant index.
 /// Returns a `TokenStream`.
-pub fn index(v: &Variant, i: usize) -> TokenStream {
+pub fn get_variant_index(v: &Variant, i: usize) -> TokenStream {
 	// first look for an attribute
 	let index = find_meta_item(v.attrs.iter(), |meta| {
 		if let NestedMeta::Meta(Meta::NameValue(ref nv)) = meta {
@@ -120,7 +120,7 @@ pub fn should_skip(attrs: &[Attribute]) -> bool {
 
 /// Look for a `#[codec(dumb_trait_bound)]`in the given attributes.
 /// Returns true or false.
-pub fn get_dumb_trait_bound(attrs: &[Attribute]) -> bool {
+pub fn has_dumb_trait_bound(attrs: &[Attribute]) -> bool {
 	find_meta_item(attrs.iter(), |meta| {
 		if let NestedMeta::Meta(Meta::Path(ref path)) = meta {
 			if path.is_ident("dumb_trait_bound") {

--- a/derive/src/utils.rs
+++ b/derive/src/utils.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 Parity Technologies
+// Copyright 2018-2020 Parity Technologies
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/derive/src/utils.rs
+++ b/derive/src/utils.rs
@@ -105,7 +105,6 @@ pub fn is_compact(field: &Field) -> bool {
 }
 
 /// Look for a `#[codec(skip)]` in the given attributes.
-/// Returns true or false.
 pub fn should_skip(attrs: &[Attribute]) -> bool {
 	find_meta_item(attrs.iter(), |meta| {
 		if let NestedMeta::Meta(Meta::Path(ref path)) = meta {

--- a/derive/src/utils.rs
+++ b/derive/src/utils.rs
@@ -119,7 +119,6 @@ pub fn should_skip(attrs: &[Attribute]) -> bool {
 }
 
 /// Look for a `#[codec(dumb_trait_bound)]`in the given attributes.
-/// Returns true or false.
 pub fn has_dumb_trait_bound(attrs: &[Attribute]) -> bool {
 	find_meta_item(attrs.iter(), |meta| {
 		if let NestedMeta::Meta(Meta::Path(ref path)) = meta {

--- a/derive/src/utils.rs
+++ b/derive/src/utils.rs
@@ -45,7 +45,6 @@ fn find_meta_item<'a, F, R, I>(itr: I, pred: F) -> Option<R> where
 
 /// Look for a `#[scale(index = $int)]` attribute on a variant. If no attribute
 /// is found, fall back to the discriminant or just the variant index.
-/// Returns a `TokenStream`.
 pub fn get_variant_index(v: &Variant, i: usize) -> TokenStream {
 	// first look for an attribute
 	let index = find_meta_item(v.attrs.iter(), |meta| {

--- a/derive/src/utils.rs
+++ b/derive/src/utils.rs
@@ -45,7 +45,7 @@ fn find_meta_item<'a, F, R, I>(itr: I, pred: F) -> Option<R> where
 
 /// Look for a `#[scale(index = $int)]` attribute on a variant. If no attribute
 /// is found, fall back to the discriminant or just the variant index.
-pub fn get_variant_index(v: &Variant, i: usize) -> TokenStream {
+pub fn variant_index(v: &Variant, i: usize) -> TokenStream {
 	// first look for an attribute
 	let index = find_meta_item(v.attrs.iter(), |meta| {
 		if let NestedMeta::Meta(Meta::NameValue(ref nv)) = meta {

--- a/derive/src/utils.rs
+++ b/derive/src/utils.rs
@@ -1,4 +1,4 @@
-// Copyright 2018 Parity Technologies
+// Copyright 2020 Parity Technologies
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -14,11 +14,12 @@
 
 //! Various internal utils.
 //!
-//! NOTE: attributes finder must be checked using check_attribute first, otherwise macro can panic.
+//! NOTE: attributes finder must be checked using check_attribute first,
+//! otherwise the macro can panic.
 
 use std::str::FromStr;
 
-use proc_macro2::{TokenStream, Span};
+use proc_macro2::TokenStream;
 use syn::{
 	spanned::Spanned,
 	Meta, NestedMeta, Lit, Attribute, Variant, Field, DeriveInput, Fields, Data, FieldsUnnamed,
@@ -42,8 +43,11 @@ fn find_meta_item<'a, F, R, I>(itr: I, pred: F) -> Option<R> where
 	}).next()
 }
 
+/// Look for a `#[scale(index = $int)]` attribute on a variant. If no attribute
+/// is found, fall back to the discriminant or just the variant index.
+/// Returns a `TokenStream`.
 pub fn index(v: &Variant, i: usize) -> TokenStream {
-	// look for an index in attributes
+	// first look for an attribute
 	let index = find_meta_item(v.attrs.iter(), |meta| {
 		if let NestedMeta::Meta(Meta::NameValue(ref nv)) = meta {
 			if nv.path.is_ident("index") {
@@ -67,9 +71,10 @@ pub fn index(v: &Variant, i: usize) -> TokenStream {
 		)
 }
 
-pub fn get_encoded_as_type(field_entry: &Field) -> Option<TokenStream> {
-	// look for an encoded_as in attributes
-	find_meta_item(field_entry.attrs.iter(), |meta| {
+/// Look for a `#[codec(encoded_as = "SomeType")]` outer attribute on the given
+/// `Field`.
+pub fn get_encoded_as_type(field: &Field) -> Option<TokenStream> {
+	find_meta_item(field.attrs.iter(), |meta| {
 		if let NestedMeta::Meta(Meta::NameValue(ref nv)) = meta {
 			if nv.path.is_ident("encoded_as") {
 				if let Lit::Str(ref s) = nv.lit {
@@ -85,9 +90,10 @@ pub fn get_encoded_as_type(field_entry: &Field) -> Option<TokenStream> {
 	})
 }
 
-pub fn get_enable_compact(field_entry: &Field) -> bool {
-	// look for `encode(compact)` in the attributes
-	find_meta_item(field_entry.attrs.iter(), |meta| {
+/// Look for a `#[codec(compact)]` outer attribute on the given `Field`.
+/// Returns true or false.
+pub fn is_compact(field: &Field) -> bool {
+	find_meta_item(field.attrs.iter(), |meta| {
 		if let NestedMeta::Meta(Meta::Path(ref path)) = meta {
 			if path.is_ident("compact") {
 				return Some(());
@@ -98,9 +104,9 @@ pub fn get_enable_compact(field_entry: &Field) -> bool {
 	}).is_some()
 }
 
-// return span of skip if found
-pub fn get_skip(attrs: &[Attribute]) -> Option<Span> {
-	// look for `skip` in the attributes
+/// Look for a `#[codec(skip)]` in the given attributes.
+/// Returns true or false.
+pub fn should_skip(attrs: &[Attribute]) -> bool {
 	find_meta_item(attrs.iter(), |meta| {
 		if let NestedMeta::Meta(Meta::Path(ref path)) = meta {
 			if path.is_ident("skip") {
@@ -109,10 +115,11 @@ pub fn get_skip(attrs: &[Attribute]) -> Option<Span> {
 		}
 
 		None
-	})
+	}).is_some()
 }
 
-/// Returns if the `dumb_trait_bound` attribute is given in `attrs`.
+/// Look for a `#[codec(dumb_trait_bound)]`in the given attributes.
+/// Returns true or false.
 pub fn get_dumb_trait_bound(attrs: &[Attribute]) -> bool {
 	find_meta_item(attrs.iter(), |meta| {
 		if let NestedMeta::Meta(Meta::Path(ref path)) = meta {
@@ -125,17 +132,32 @@ pub fn get_dumb_trait_bound(attrs: &[Attribute]) -> bool {
 	}).is_some()
 }
 
+/// Given a set of named fields, return an iterator of `Field` where all fields
+/// marked `#[codec(skip)]` are filtered out.
 pub fn filter_skip_named<'a>(fields: &'a syn::FieldsNamed) -> impl Iterator<Item=&Field> + 'a {
 	fields.named.iter()
-		.filter(|f| get_skip(&f.attrs).is_none())
+		.filter(|f| !should_skip(&f.attrs))
 }
 
+/// Given a set of unnamed fields, return an iterator of `(index, Field)` where all fields
+/// marked `#[codec(skip)]` are filtered out.
 pub fn filter_skip_unnamed<'a>(fields: &'a syn::FieldsUnnamed) -> impl Iterator<Item=(usize, &Field)> + 'a {
 	fields.unnamed.iter()
 		.enumerate()
-		.filter(|(_, f)| get_skip(&f.attrs).is_none())
+		.filter(|(_, f)| !should_skip(&f.attrs))
 }
 
+/// Ensure attributes are correctly applied. This *must* be called before using
+/// any of the attribute finder methods or the macro may panic if it encounters
+/// misapplied attributes.
+/// `#[codec(dumb_trait_bound)]` is the only accepted top attribute.
+/// Fields can have the following attributes:
+/// * `#[codec(skip)]`
+/// * `#[codec(compact)]`
+/// * `#[codec(encoded_as = "$EncodeAs")]` with $EncodedAs a valid TokenStream
+/// Variants can have the following attributes:
+/// * `#[codec(skip)]`
+/// * `#[codec(index = $int)]`
 pub fn check_attributes(input: &DeriveInput) -> syn::Result<()> {
 	for attr in &input.attrs {
 		check_top_attribute(attr)?;
@@ -170,7 +192,7 @@ pub fn check_attributes(input: &DeriveInput) -> syn::Result<()> {
 	Ok(())
 }
 
-// Is accepted only:
+// Ensure a field is decorated only with the following attributes:
 // * `#[codec(skip)]`
 // * `#[codec(compact)]`
 // * `#[codec(encoded_as = "$EncodeAs")]` with $EncodedAs a valid TokenStream
@@ -181,7 +203,7 @@ fn check_field_attribute(attr: &Attribute) -> syn::Result<()> {
 	if attr.path.is_ident("codec") {
 		match attr.parse_meta()? {
 			Meta::List(ref meta_list) if meta_list.nested.len() == 1 => {
-				match meta_list.nested.first().unwrap() {
+				match meta_list.nested.first().expect("Just checked that there is one item; qed") {
 					NestedMeta::Meta(Meta::Path(path))
 						if path.get_ident().map_or(false, |i| i == "skip") => Ok(()),
 
@@ -203,7 +225,7 @@ fn check_field_attribute(attr: &Attribute) -> syn::Result<()> {
 	}
 }
 
-// Is accepted only:
+// Ensure a field is decorated only with the following attributes:
 // * `#[codec(skip)]`
 // * `#[codec(index = $int)]`
 fn check_variant_attribute(attr: &Attribute) -> syn::Result<()> {
@@ -213,7 +235,7 @@ fn check_variant_attribute(attr: &Attribute) -> syn::Result<()> {
 	if attr.path.is_ident("codec") {
 		match attr.parse_meta()? {
 			Meta::List(ref meta_list) if meta_list.nested.len() == 1 => {
-				match meta_list.nested.first().unwrap() {
+				match meta_list.nested.first().expect("Just checked that there is one item; qed") {
 					NestedMeta::Meta(Meta::Path(path))
 						if path.get_ident().map_or(false, |i| i == "skip") => Ok(()),
 
@@ -239,7 +261,7 @@ fn check_top_attribute(attr: &Attribute) -> syn::Result<()> {
 	if attr.path.is_ident("codec") {
 		match attr.parse_meta()? {
 			Meta::List(ref meta_list) if meta_list.nested.len() == 1 => {
-				match meta_list.nested.first().unwrap() {
+				match meta_list.nested.first().expect("Just checked that there is one item; qed") {
 					NestedMeta::Meta(Meta::Path(path))
 						if path.get_ident().map_or(false, |i| i == "dumb_trait_bound") => Ok(()),
 


### PR DESCRIPTION
Document public items and rename a few utility methods. Simplifies the signature of `collect_types` a little bit to remove the variant filter (was always the same) and related changes to the type filters.
