### PR TITLE
Backport fix decode vec

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "parity-scale-codec"
 description = "SCALE - Simple Concatenating Aggregated Little Endians"
-version = "1.3.5"
+version = "1.3.6"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "Apache-2.0"
 repository = "https://github.com/paritytech/parity-scale-codec"

--- a/src/generic_array.rs
+++ b/src/generic_array.rs
@@ -44,7 +44,7 @@ impl<T: Decode, L: generic_array::ArrayLength<T>> Decode for generic_array::Gene
 #[cfg(test)]
 mod tests {
 	use super::*;
-	use generic_array::{typenum, GenericArray, arr, arr_impl};
+	use generic_array::{typenum, GenericArray, arr};
 
 	#[test]
 	fn generic_array() {


### PR DESCRIPTION
1.3.6-release is branch I just created to the incorming release, for now 1.3.6-release = 1.3.5-release.

In this PR I cherry picked https://github.com/paritytech/parity-scale-codec/pull/231 with no changes

CI tests on my computer are green