### PR TITLE
Bump bitvec, byte slice cast, and refactor a bit

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,9 +12,9 @@ edition = "2018"
 arrayvec = { version = "0.5.1", default-features = false, features = ["array-sizes-33-128", "array-sizes-129-255"] }
 serde = { version = "1.0.102", optional = true }
 parity-scale-codec-derive = { path = "derive", version = "1.2.0", default-features = false, optional = true }
-bitvec = { version = "0.17.4", default-features = false, features = ["alloc"], optional = true }
-byte-slice-cast = { version = "0.3.4", default-features = false, features = ["alloc"] }
-generic-array = { version = "0.13.2", optional = true }
+bitvec = { version = "0.20.1", default-features = false, features = ["alloc"], optional = true }
+byte-slice-cast = { version = "1.0.0", default-features = false }
+generic-array = { version = "0.14.4", optional = true }
 arbitrary = { version = "0.4.1", features = ["derive"], optional = true }
 
 [dev-dependencies]

--- a/benches/benches.rs
+++ b/benches/benches.rs
@@ -15,7 +15,7 @@
 use std::{time::Duration, any::type_name, convert::{TryFrom, TryInto}};
 
 #[cfg(feature = "bit-vec")]
-use bitvec::vec::BitVec;
+use bitvec::{vec::BitVec, order::Lsb0};
 use criterion::{Criterion, black_box, Bencher, criterion_group, criterion_main};
 use parity_scale_codec::*;
 use parity_scale_codec_derive::{Encode, Decode};
@@ -203,7 +203,7 @@ fn encode_decode_bitvec_u8(c: &mut Criterion) {
 
 	#[cfg(feature = "bit-vec")]
 	c.bench_function_over_inputs("bitvec_u8_encode - BitVec<u8>", |b, &size| {
-		let vec: BitVec = [true, false]
+		let vec: BitVec<Lsb0, u8> = [true, false]
 			.iter()
 			.cloned()
 			.cycle()
@@ -216,7 +216,7 @@ fn encode_decode_bitvec_u8(c: &mut Criterion) {
 
 	#[cfg(feature = "bit-vec")]
 	c.bench_function_over_inputs("bitvec_u8_decode - BitVec<u8>", |b, &size| {
-		let vec: BitVec = [true, false]
+		let vec: BitVec<Lsb0, u8> = [true, false]
 			.iter()
 			.cloned()
 			.cycle()
@@ -227,7 +227,7 @@ fn encode_decode_bitvec_u8(c: &mut Criterion) {
 
 		let vec = black_box(vec);
 		b.iter(|| {
-			let _: BitVec = Decode::decode(&mut &vec[..]).unwrap();
+			let _: BitVec<Lsb0, u8> = Decode::decode(&mut &vec[..]).unwrap();
 		})
 	}, vec![1, 2, 5, 32, 1024]);
 }

--- a/fuzzer/Cargo.toml
+++ b/fuzzer/Cargo.toml
@@ -9,4 +9,4 @@ publish = false
 parity-scale-codec = { path = "../", features = [ "derive", "bit-vec", "fuzz" ] }
 honggfuzz = "0.5.47"
 arbitrary = { version = "0.4.1", features = ["derive"] }
-bitvec = { version = "0.17.4", features = ["alloc"] }
+bitvec = { version = "0.20.1", features = ["alloc"] }

--- a/src/bit_vec.rs
+++ b/src/bit_vec.rs
@@ -63,7 +63,7 @@ impl<O: BitOrder, T: BitStore + Decode> Decode for BitVec<O, T> {
 
 			let mut result = Self::try_from_vec(vec)
 				.map_err(|_| {
-					Error::from("UNEXPECTED ERROR: `bits` is less than
+					Error::from("UNEXPECTED ERROR: `bits` is less or equal to
 					`ARCH32BIT_BITSLICE_MAX_BITS`; So BitVec must be able to handle the number of
 					segment needed for `bits` to be represented; qed")
 				})?;

--- a/src/bit_vec.rs
+++ b/src/bit_vec.rs
@@ -30,8 +30,9 @@ impl<O: BitOrder, T: BitStore + Encode> Encode for BitSlice<O, T> {
 		);
 		Compact(len as u32).encode_to(dest);
 
-		// NOTE: from `BitSlice::as_slice`: "The returned slice handle views all elements touched
-		// by self"
+		// NOTE: doc of `BitSlice::as_slice`:
+		// > The returned slice handle views all elements touched by self
+		//
 		// Thus we are sure the slice doesn't contain unused elements at the end.
 		let slice = self.as_slice();
 

--- a/src/bit_vec.rs
+++ b/src/bit_vec.rs
@@ -69,7 +69,7 @@ impl<O: BitOrder, T: BitStore + Decode> Decode for BitVec<O, T> {
 				})?;
 
 			assert!(bits as usize <= result.len());
-			unsafe { result.set_len(bits as usize); }
+			result.truncate(bits as usize);
 			Ok(result)
 		})
 	}

--- a/src/bit_vec.rs
+++ b/src/bit_vec.rs
@@ -15,51 +15,12 @@
 //! `BitVec` specific serialization.
 
 use core::mem;
-use crate::alloc::vec::Vec;
-
 use bitvec::{vec::BitVec, store::BitStore, order::BitOrder, slice::BitSlice, boxed::BitBox};
-use byte_slice_cast::{AsByteSlice, ToByteSlice, FromByteSlice, Error as FromByteSliceError};
-
-use crate::codec::{Encode, Decode, Input, Output, Error, read_vec_from_u8s};
+use crate::codec::{Encode, Decode, Input, Output, Error, decode_vec_with_len, encode_slice_no_len};
 use crate::compact::Compact;
 use crate::EncodeLike;
 
-impl From<FromByteSliceError> for Error {
-	fn from(e: FromByteSliceError) -> Error {
-		match e {
-			FromByteSliceError::AlignmentMismatch {..} =>
-				"failed to cast from byte slice: alignment mismatch".into(),
-			FromByteSliceError::LengthMismatch {..} =>
-				"failed to cast from byte slice: length mismatch".into(),
-			FromByteSliceError::CapacityMismatch {..} =>
-				"failed to cast from byte slice: capacity mismatch".into(),
-		}
-	}
-}
-
-impl<O: BitOrder, T: BitStore + ToByteSlice> Encode for BitSlice<O, T> {
-	fn encode_to<W: Output>(&self, dest: &mut W) {
-		self.to_vec().encode_to(dest)
-	}
-}
-
-/// Reverse bytes of element for element of size `size_of_t`.
-///
-/// E.g. if size is 2 `[1, 2, 3, 4]` is changed to `[2, 1, 4, 3]`.
-fn reverse_endian(vec_u8: &mut [u8], size_of_t: usize) {
-	for i in 0..vec_u8.len() / size_of_t {
-		for j in 0..size_of_t / 2 {
-			vec_u8.swap(i * size_of_t + j, i * size_of_t + (size_of_t - 1) - j);
-		}
-	}
-}
-
-/// # WARNING
-///
-/// In bitvec v0.17.4 the only implementations of BitStore are u8, u16, u32, u64, and usize.
-/// This implementation actually only support u8, u16, u32 and u64, as encoding of uszie
-/// is inconsistent between platforms.
-impl<O: BitOrder, T: BitStore + ToByteSlice> Encode for BitVec<O, T> {
+impl<O: BitOrder, T: BitStore + Encode> Encode for BitSlice<O, T> {
 	fn encode_to<W: Output>(&self, dest: &mut W) {
 		let len = self.len();
 		assert!(
@@ -68,47 +29,38 @@ impl<O: BitOrder, T: BitStore + ToByteSlice> Encode for BitVec<O, T> {
 		);
 		Compact(len as u32).encode_to(dest);
 
-		let byte_slice: &[u8] = self.as_slice().as_byte_slice();
+		let slice = self.as_slice();
 
-		if cfg!(target_endian = "big") && mem::size_of::<T>() > 1 {
-			let mut vec_u8: Vec<u8> = byte_slice.into();
-			reverse_endian(&mut vec_u8[..], mem::size_of::<T>());
-			dest.write(&vec_u8);
-		} else {
-			dest.write(byte_slice);
-		}
+		// NOTE: `BitSlice::as_slice` seems to always return the exact number of necessary
+		// element `T`, but doc doesn't seem to ensure that it will never contained any
+		// useless element `T` at the end.
+		// To be safer we cap with the required_items function.
+		let slice = &slice[..slice.len().min(required_items::<T>(len))];
+
+		encode_slice_no_len(slice, dest)
 	}
 }
 
-impl<O: BitOrder, T: BitStore + ToByteSlice> EncodeLike for BitVec<O, T> {}
+impl<O: BitOrder, T: BitStore + Encode> Encode for BitVec<O, T> {
+	fn encode_to<W: Output>(&self, dest: &mut W) {
+		self.as_bitslice().encode_to(dest)
+	}
+}
 
-/// # WARNING
-///
-/// In bitvec v0.17.4 the only implementations of BitStore are u8, u16, u32, u64, and usize.
-/// This implementation actually only support u8, u16, u32 and u64, as encoding of usize
-/// is inconsistent between platforms.
-impl<O: BitOrder, T: BitStore + FromByteSlice> Decode for BitVec<O, T> {
+impl<O: BitOrder, T: BitStore + Encode> EncodeLike for BitVec<O, T> {}
+
+impl<O: BitOrder, T: BitStore + Decode> Decode for BitVec<O, T> {
 	fn decode<I: Input>(input: &mut I) -> Result<Self, Error> {
 		<Compact<u32>>::decode(input).and_then(move |Compact(bits)| {
 			let bits = bits as usize;
-			let required_bytes = required_bytes::<T>(bits);
+			let required_items = required_items::<T>(bits);
+			let vec = decode_vec_with_len(input, required_items)?;
 
-			let mut vec_u8 = read_vec_from_u8s::<I, u8>(input, required_bytes)?;
-
-			if cfg!(target_endian = "big") && mem::size_of::<T>() > 1 {
-				reverse_endian(&mut vec_u8[..], mem::size_of::<T>());
+			// Otherwise `from_vec` panics.
+			if bits > BitSlice::<O, T>::MAX_BITS {
+				return Err("Attempt to decode a bitvec with too many bits".into());
 			}
-
-			let mut aligned_vec: Vec<T> = vec![0u8.into(); required_bytes / mem::size_of::<T>()];
-
-			unsafe {
-				let aligned_u8_ptr = aligned_vec.as_mut_ptr() as *mut u8;
-				for (i, v) in vec_u8.iter().enumerate() {
-					*aligned_u8_ptr.add(i) = *v;
-				}
-			}
-
-			let mut result = Self::from_vec(aligned_vec);
+			let mut result = Self::from_vec(vec);
 			assert!(bits <= result.len());
 			unsafe { result.set_len(bits); }
 			Ok(result)
@@ -116,24 +68,25 @@ impl<O: BitOrder, T: BitStore + FromByteSlice> Decode for BitVec<O, T> {
 	}
 }
 
-impl<O: BitOrder, T: BitStore + ToByteSlice> Encode for BitBox<O, T> {
+impl<O: BitOrder, T: BitStore + Encode> Encode for BitBox<O, T> {
 	fn encode_to<W: Output>(&self, dest: &mut W) {
 		self.as_bitslice().encode_to(dest)
 	}
 }
 
-impl<O: BitOrder, T: BitStore + ToByteSlice> EncodeLike for BitBox<O, T> {}
+impl<O: BitOrder, T: BitStore + Encode> EncodeLike for BitBox<O, T> {}
 
-impl<O: BitOrder, T: BitStore + FromByteSlice> Decode for BitBox<O, T> {
+impl<O: BitOrder, T: BitStore + Decode> Decode for BitBox<O, T> {
 	fn decode<I: Input>(input: &mut I) -> Result<Self, Error> {
 		Ok(Self::from_bitslice(BitVec::<O, T>::decode(input)?.as_bitslice()))
 	}
 }
 
-// Calculates bytes required to store given amount of `bits` as if they were stored in the array of `T`.
-fn required_bytes<T>(bits: usize) -> usize {
+/// Calculates the number of item `T` required to store given amount of `bits` as if they were
+/// stored in the array of `T`.
+fn required_items<T>(bits: usize) -> usize {
 	let element_bits = mem::size_of::<T>() * 8;
-	(bits + element_bits - 1) / element_bits * mem::size_of::<T>()
+	(bits + element_bits - 1) / element_bits
 }
 
 #[cfg(test)]
@@ -177,34 +130,33 @@ mod tests {
 	}
 
 	#[test]
-	fn required_bytes_test() {
-		assert_eq!(0, required_bytes::<u8>(0));
-		assert_eq!(1, required_bytes::<u8>(1));
-		assert_eq!(1, required_bytes::<u8>(7));
-		assert_eq!(1, required_bytes::<u8>(8));
-		assert_eq!(2, required_bytes::<u8>(9));
+	fn required_items_test() {
+		assert_eq!(0, required_items::<u8>(0));
+		assert_eq!(1, required_items::<u8>(1));
+		assert_eq!(1, required_items::<u8>(7));
+		assert_eq!(1, required_items::<u8>(8));
+		assert_eq!(2, required_items::<u8>(9));
 
-		assert_eq!(0, required_bytes::<u16>(0));
-		assert_eq!(2, required_bytes::<u16>(1));
-		assert_eq!(2, required_bytes::<u16>(15));
-		assert_eq!(2, required_bytes::<u16>(16));
-		assert_eq!(4, required_bytes::<u16>(17));
+		assert_eq!(0, required_items::<u16>(0));
+		assert_eq!(1, required_items::<u16>(1));
+		assert_eq!(1, required_items::<u16>(15));
+		assert_eq!(1, required_items::<u16>(16));
+		assert_eq!(2, required_items::<u16>(17));
 
-		assert_eq!(0, required_bytes::<u32>(0));
-		assert_eq!(4, required_bytes::<u32>(1));
-		assert_eq!(4, required_bytes::<u32>(31));
-		assert_eq!(4, required_bytes::<u32>(32));
-		assert_eq!(8, required_bytes::<u32>(33));
+		assert_eq!(0, required_items::<u32>(0));
+		assert_eq!(1, required_items::<u32>(1));
+		assert_eq!(1, required_items::<u32>(31));
+		assert_eq!(1, required_items::<u32>(32));
+		assert_eq!(2, required_items::<u32>(33));
 
-		assert_eq!(0, required_bytes::<u64>(0));
-		assert_eq!(8, required_bytes::<u64>(1));
-		assert_eq!(8, required_bytes::<u64>(63));
-		assert_eq!(8, required_bytes::<u64>(64));
-		assert_eq!(16, required_bytes::<u64>(65));
+		assert_eq!(0, required_items::<u64>(0));
+		assert_eq!(1, required_items::<u64>(1));
+		assert_eq!(1, required_items::<u64>(63));
+		assert_eq!(1, required_items::<u64>(64));
+		assert_eq!(2, required_items::<u64>(65));
 	}
 
 	#[test]
-	#[cfg_attr(miri, ignore)] // BitVec error due to outdated version of bitvec
 	fn bitvec_u8() {
 		for v in &test_data!(u8) {
 			let encoded = v.encode();
@@ -213,7 +165,6 @@ mod tests {
 	}
 
 	#[test]
-	#[cfg_attr(miri, ignore)] // BitVec error due to outdated version of bitvec
 	fn bitvec_u16() {
 		for v in &test_data!(u16) {
 			let encoded = v.encode();
@@ -222,7 +173,6 @@ mod tests {
 	}
 
 	#[test]
-	#[cfg_attr(miri, ignore)] // BitVec error due to outdated version of bitvec
 	fn bitvec_u32() {
 		for v in &test_data!(u32) {
 			let encoded = v.encode();
@@ -231,7 +181,6 @@ mod tests {
 	}
 
 	#[test]
-	#[cfg_attr(miri, ignore)] // BitVec error due to outdated version of bitvec
 	fn bitvec_u64() {
 		for v in &test_data!(u64) {
 			let encoded = dbg!(v.encode());
@@ -240,10 +189,9 @@ mod tests {
 	}
 
 	#[test]
-	#[cfg_attr(miri, ignore)] // BitVec error due to outdated version of bitvec
 	fn bitslice() {
 		let data: &[u8] = &[0x69];
-		let slice = BitSlice::<Msb0, u8>::from_slice(data);
+		let slice = BitSlice::<Msb0, u8>::from_slice(data).unwrap();
 		let encoded = slice.encode();
 		let decoded = BitVec::<Msb0, u8>::decode(&mut &encoded[..]).unwrap();
 		assert_eq!(slice, decoded.as_bitslice());
@@ -252,30 +200,10 @@ mod tests {
 	#[test]
 	fn bitbox() {
 		let data: &[u8] = &[5, 10];
-		let bb = BitBox::<Msb0, u8>::from_slice(data);
+		let slice = BitSlice::<Msb0, u8>::from_slice(data).unwrap();
+		let bb = BitBox::<Msb0, u8>::from_bitslice(slice);
 		let encoded = bb.encode();
 		let decoded = BitBox::<Msb0, u8>::decode(&mut &encoded[..]).unwrap();
 		assert_eq!(bb, decoded);
-	}
-
-	#[test]
-	fn reverse_endian_works() {
-		let data = vec![1, 2, 3, 4, 5, 6, 7, 8];
-
-		let mut data_to_u8 = data.clone();
-		reverse_endian(&mut data_to_u8[..], mem::size_of::<u8>());
-		assert_eq!(data_to_u8, data);
-
-		let mut data_to_u16 = data.clone();
-		reverse_endian(&mut data_to_u16[..], mem::size_of::<u16>());
-		assert_eq!(data_to_u16, vec![2, 1, 4, 3, 6, 5, 8, 7]);
-
-		let mut data_to_u32 = data.clone();
-		reverse_endian(&mut data_to_u32[..], mem::size_of::<u32>());
-		assert_eq!(data_to_u32, vec![4, 3, 2, 1, 8, 7, 6, 5]);
-
-		let mut data_to_u64 = data.clone();
-		reverse_endian(&mut data_to_u64[..], mem::size_of::<u64>());
-		assert_eq!(data_to_u64, vec![8, 7, 6, 5, 4, 3, 2, 1]);
 	}
 }

--- a/src/codec.rs
+++ b/src/codec.rs
@@ -640,7 +640,7 @@ pub(crate) fn encode_slice_no_len<T: Encode, W: Output>(slice: &[T], dest: &mut 
 	}
 }
 
-/// Encode the slice without prepending the len.
+/// Decode the slice (without prepended the len).
 ///
 /// This is equivalent to decode all elements one by one, but it is optimized in some
 /// situation.

--- a/src/codec.rs
+++ b/src/codec.rs
@@ -642,7 +642,7 @@ pub(crate) fn encode_slice_no_len<T: Encode, W: Output>(slice: &[T], dest: &mut 
 
 /// Encode the slice without prepending the len.
 ///
-/// This is equivalent to encoding all the element one by one, but it is optimized in some
+/// This is equivalent to decode all elements one by one, but it is optimized in some
 /// situation.
 pub(crate) fn decode_vec_with_len<T: Decode, I: Input>(
 	input: &mut I,

--- a/src/encode_append.rs
+++ b/src/encode_append.rs
@@ -213,7 +213,7 @@ mod tests {
 	#[test]
 	fn append_non_copyable() {
 		#[derive(Eq, PartialEq, Debug)]
-		struct NoCopy { data: u32 };
+		struct NoCopy { data: u32 }
 
 		impl EncodeLike for NoCopy {}
 

--- a/tests/mod.rs
+++ b/tests/mod.rs
@@ -520,9 +520,16 @@ fn crafted_input_for_vec_u8() {
 
 #[test]
 fn crafted_input_for_vec_t() {
+	let msg = if cfg!(target_endian = "big") {
+		// use unoptimize decode
+		"Not enough data to fill buffer"
+	} else {
+		"Not enough data to decode vector"
+	};
+
 	assert_eq!(
 		Vec::<u32>::decode(&mut &Compact(u32::max_value()).encode()[..]).err().unwrap().what(),
-		"Not enough data to decode vector",
+		msg,
 	);
 }
 


### PR DESCRIPTION
status: Reviewable

I'm a bit unsure yet, if it is a good idea to implement Codec on `BitVec<_, T>` when `T` (`BitStore`) implements Codec.
We have the method `required_elements` (previously `required_bytes`) which computes for a type `T` the number of element `T` needed to store N `bits`. But I wonder if some unexpected implementation of BitStore would break assumption of `required_elements`.

I tried to find a method in BitStore to have the equivalent of `required_elements` but couldn't fine for now.

One possibility could be to implement for specific BitStore types: i.e. `u8, u16, u32, u64, Cell<u8>, ...` so that no unexpected implementation can happen. (this is trivial to do, but maybe annoying for user not to have it automatically implemented)

EDIT: I see we can use `<T as BitMemory>::BITS` to get the size of a segment. So I refactored `required_elements` to make use of it.