### PR TITLE
make `Output` trait object and encode_to allowed on not sized `Output`

### DIFF
--- a/src/bit_vec.rs
+++ b/src/bit_vec.rs
@@ -22,7 +22,7 @@ use crate::compact::Compact;
 use crate::EncodeLike;
 
 impl<O: BitOrder, T: BitStore + Encode> Encode for BitSlice<O, T> {
-	fn encode_to<W: Output>(&self, dest: &mut W) {
+	fn encode_to<W: Output + ?Sized>(&self, dest: &mut W) {
 		let len = self.len();
 		assert!(
 			len <= u32::max_value() as usize,
@@ -41,7 +41,7 @@ impl<O: BitOrder, T: BitStore + Encode> Encode for BitSlice<O, T> {
 }
 
 impl<O: BitOrder, T: BitStore + Encode> Encode for BitVec<O, T> {
-	fn encode_to<W: Output>(&self, dest: &mut W) {
+	fn encode_to<W: Output + ?Sized>(&self, dest: &mut W) {
 		self.as_bitslice().encode_to(dest)
 	}
 }
@@ -76,7 +76,7 @@ impl<O: BitOrder, T: BitStore + Decode> Decode for BitVec<O, T> {
 }
 
 impl<O: BitOrder, T: BitStore + Encode> Encode for BitBox<O, T> {
-	fn encode_to<W: Output>(&self, dest: &mut W) {
+	fn encode_to<W: Output + ?Sized>(&self, dest: &mut W) {
 		self.as_bitslice().encode_to(dest)
 	}
 }

--- a/src/codec.rs
+++ b/src/codec.rs
@@ -219,6 +219,15 @@ pub trait Output {
 	fn push_byte(&mut self, byte: u8) {
 		self.write(&[byte]);
 	}
+
+	/// Write encoding of given value to the output.
+	///
+	/// NOTE: this is only available when `Self` is `Sized`, thus it is not available in
+	/// `Encode::encode_to`. If you need it when `Self` is not `Sized` consider using
+	/// `Encode::encode_to` directly.
+	fn push<V: Encode + ?Sized>(&mut self, value: &V) where Self: Sized {
+		value.encode_to(self);
+	}
 }
 
 #[cfg(not(feature = "std"))]

--- a/src/codec.rs
+++ b/src/codec.rs
@@ -219,15 +219,6 @@ pub trait Output {
 	fn push_byte(&mut self, byte: u8) {
 		self.write(&[byte]);
 	}
-
-	/// Write encoding of given value to the output.
-	///
-	/// NOTE: this is only available when `Self` is `Sized`, thus it is not available in
-	/// `Encode::encode_to`. If you need it when `Self` is not `Sized` consider using
-	/// `Encode::encode_to` directly.
-	fn push<V: Encode + ?Sized>(&mut self, value: &V) where Self: Sized {
-		value.encode_to(self);
-	}
 }
 
 #[cfg(not(feature = "std"))]

--- a/src/compact.rs
+++ b/src/compact.rs
@@ -113,7 +113,7 @@ where
 		CompactRef(&self.0).size_hint()
 	}
 
-	fn encode_to<W: Output>(&self, dest: &mut W) {
+	fn encode_to<W: Output + ?Sized>(&self, dest: &mut W) {
 		CompactRef(&self.0).encode_to(dest)
 	}
 
@@ -141,7 +141,7 @@ where
 		CompactRef(self.0.encode_as()).size_hint()
 	}
 
-	fn encode_to<Out: Output>(&self, dest: &mut Out) {
+	fn encode_to<Out: Output + ?Sized>(&self, dest: &mut Out) {
 		CompactRef(self.0.encode_as()).encode_to(dest)
 	}
 
@@ -234,7 +234,7 @@ impl<T: 'static> HasCompact for T where
 }
 
 impl<'a> Encode for CompactRef<'a, ()> {
-	fn encode_to<W: Output>(&self, _dest: &mut W) {
+	fn encode_to<W: Output + ?Sized>(&self, _dest: &mut W) {
 	}
 
 	fn using_encoded<R, F: FnOnce(&[u8]) -> R>(&self, f: F) -> R {
@@ -251,7 +251,7 @@ impl<'a> Encode for CompactRef<'a, u8> {
 		Compact::compact_len(self.0)
 	}
 
-	fn encode_to<W: Output>(&self, dest: &mut W) {
+	fn encode_to<W: Output + ?Sized>(&self, dest: &mut W) {
 		match self.0 {
 			0..=0b0011_1111 => dest.push_byte(self.0 << 2),
 			_ => ((u16::from(*self.0) << 2) | 0b01).encode_to(dest),
@@ -279,7 +279,7 @@ impl<'a> Encode for CompactRef<'a, u16> {
 		Compact::compact_len(self.0)
 	}
 
-	fn encode_to<W: Output>(&self, dest: &mut W) {
+	fn encode_to<W: Output + ?Sized>(&self, dest: &mut W) {
 		match self.0 {
 			0..=0b0011_1111 => dest.push_byte((*self.0 as u8) << 2),
 			0..=0b0011_1111_1111_1111 => ((*self.0 << 2) | 0b01).encode_to(dest),
@@ -309,7 +309,7 @@ impl<'a> Encode for CompactRef<'a, u32> {
 		Compact::compact_len(self.0)
 	}
 
-	fn encode_to<W: Output>(&self, dest: &mut W) {
+	fn encode_to<W: Output + ?Sized>(&self, dest: &mut W) {
 		match self.0 {
 			0..=0b0011_1111 => dest.push_byte((*self.0 as u8) << 2),
 			0..=0b0011_1111_1111_1111 => (((*self.0 as u16) << 2) | 0b01).encode_to(dest),
@@ -344,7 +344,7 @@ impl<'a> Encode for CompactRef<'a, u64> {
 		Compact::compact_len(self.0)
 	}
 
-	fn encode_to<W: Output>(&self, dest: &mut W) {
+	fn encode_to<W: Output + ?Sized>(&self, dest: &mut W) {
 		match self.0 {
 			0..=0b0011_1111 => dest.push_byte((*self.0 as u8) << 2),
 			0..=0b0011_1111_1111_1111 => (((*self.0 as u16) << 2) | 0b01).encode_to(dest),
@@ -388,7 +388,7 @@ impl<'a> Encode for CompactRef<'a, u128> {
 		Compact::compact_len(self.0)
 	}
 
-	fn encode_to<W: Output>(&self, dest: &mut W) {
+	fn encode_to<W: Output + ?Sized>(&self, dest: &mut W) {
 		match self.0 {
 			0..=0b0011_1111 => dest.push_byte((*self.0 as u8) << 2),
 			0..=0b0011_1111_1111_1111 => (((*self.0 as u16) << 2) | 0b01).encode_to(dest),

--- a/src/generic_array.rs
+++ b/src/generic_array.rs
@@ -17,7 +17,7 @@ use crate::codec::{Encode, Decode, Input, Output, Error};
 use crate::encode_like::EncodeLike;
 
 impl<T: Encode, L: generic_array::ArrayLength<T>> Encode for generic_array::GenericArray<T, L> {
-	fn encode_to<W: Output>(&self, dest: &mut W) {
+	fn encode_to<W: Output + ?Sized>(&self, dest: &mut W) {
 		for item in self.iter() {
 			item.encode_to(dest);
 		}

--- a/tests/mod.rs
+++ b/tests/mod.rs
@@ -14,7 +14,9 @@
 
 #[cfg(not(feature="derive"))]
 use parity_scale_codec_derive::{Encode, Decode};
-use parity_scale_codec::{Encode, Decode, HasCompact, Compact, EncodeAsRef, CompactAs, Error};
+use parity_scale_codec::{
+	Encode, Decode, HasCompact, Compact, EncodeAsRef, CompactAs, Error, Output,
+};
 use serde_derive::{Serialize, Deserialize};
 
 #[derive(Debug, PartialEq, Encode, Decode)]
@@ -547,4 +549,9 @@ fn weird_derive() {
     }
 
     make_struct!(#[derive(Encode, Decode)]);
+}
+
+#[test]
+fn output_trait_object() {
+	let _: Box<dyn Output>;
 }


### PR DESCRIPTION
### breaking change:

#### `Output::push` is no longer available, use `Encode::encode_to` instead.

### PR description:

This won't allow us to have `Output` not trait object in the future.

I'm not sure how much needed this is. But having a trait object Output seems valuable.