### PR TITLE
CI: add miri test; chore

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -98,7 +98,7 @@ miri:
     RUST_BACKTRACE:                1
     MIRIFLAGS:                     "-Zmiri-disable-isolation"
   script:
-    - cargo +nightly test
+    -  time cargo +nightly miri test --features bit-vec,generic-array,arbitrary --release
 
 #### stage:                        build
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -2,13 +2,13 @@
 #
 
 stages:
+  - check
   - test
   - build
 
 variables:
   GIT_STRATEGY:                    fetch
   GIT_DEPTH:                       "100"
-  CARGO_HOME:                      "/ci-cache/${CI_PROJECT_NAME}/cargo/${CI_COMMIT_REF_NAME}/${CI_JOB_NAME}"
   CARGO_TARGET_DIR:                "/ci-cache/${CI_PROJECT_NAME}/targets/${CI_COMMIT_REF_NAME}/${CI_JOB_NAME}"
   CARGO_INCREMENTAL:               0
   CI_SERVER_NAME:                  "GitLab CI"
@@ -19,7 +19,7 @@ workflow:
     - if: $CI_COMMIT_BRANCH
 
 .docker-env:                       &docker-env
-  image:                           paritytech/ci-linux:production
+  image:                           paritytech/ink-ci-linux:production
   before_script:
     - cargo -vV
     - rustc -vV
@@ -45,41 +45,43 @@ workflow:
   tags:
     - linux-docker
 
+#### stage:                        check
+
+check-rust-stable-no_derive_no_std_full:
+  stage:                           check
+  <<:                              *docker-env
+  script:
+    - time cargo +stable check --verbose --no-default-features --features bit-vec,generic-array,full
+    - sccache -s
+
+check-rust-stable-no_derive_no_std:
+  stage:                           check
+  <<:                              *docker-env
+  script:
+    - time cargo +stable check --verbose --no-default-features --features bit-vec,generic-array
+    - sccache -s
+
+check-rust-stable-no_derive_full:
+  stage:                           check
+  <<:                              *docker-env
+  script:
+    - time cargo +stable check --verbose --features bit-vec,generic-array,full
+    - sccache -s
+
 #### stage:                        test
 
 test-rust-stable:
   stage:                           test
   <<:                              *docker-env
   script:
-    - time cargo test --verbose --all --features bit-vec,generic-array,derive
+    - time cargo +stable test --verbose --all --features bit-vec,generic-array,derive
     - sccache -s
 
 test-rust-stable-no_derive:
   stage:                           test
   <<:                              *docker-env
   script:
-    - time cargo test --verbose --features bit-vec,generic-array
-    - sccache -s
-
-check-rust-stable-no_derive_no_std_full:
-  stage:                           test
-  <<:                              *docker-env
-  script:
-    - time cargo check --verbose --no-default-features --features bit-vec,generic-array,full
-    - sccache -s
-
-check-rust-stable-no_derive_no_std:
-  stage:                           test
-  <<:                              *docker-env
-  script:
-    - time cargo check --verbose --no-default-features --features bit-vec,generic-array
-    - sccache -s
-
-check-rust-stable-no_derive_full:
-  stage:                           test
-  <<:                              *docker-env
-  script:
-    - time cargo check --verbose --features bit-vec,generic-array,full
+    - time cargo +stable test --verbose --features bit-vec,generic-array
     - sccache -s
 
 bench-rust-nightly:
@@ -88,6 +90,15 @@ bench-rust-nightly:
   script:
     - time cargo +nightly bench --features bit-vec,generic-array,derive
     - sccache -s
+
+miri:
+  stage:                           test
+  <<:                              *docker-env
+  variables:
+    RUST_BACKTRACE:                1
+    MIRIFLAGS:                     "-Zmiri-disable-isolation"
+  script:
+    - cargo +nightly test
 
 #### stage:                        build
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -98,7 +98,7 @@ miri:
     RUST_BACKTRACE:                1
     MIRIFLAGS:                     "-Zmiri-disable-isolation"
   script:
-    -  time cargo +nightly miri test --features bit-vec,generic-array,arbitrary --release
+    - time cargo +nightly miri test --features bit-vec,generic-array,arbitrary --release
 
 #### stage:                        build
 

--- a/scripts/pre_cache.sh
+++ b/scripts/pre_cache.sh
@@ -6,7 +6,7 @@ set -u
 # create such directory and
 # copy recursively all the files from the newest dir which has $CI_JOB_NAME, if it exists
 
-# caches are in /ci-cache/${CI_PROJECT_NAME}/${2}/${CI_COMMIT_REF_NAME}/${CI_JOB_NAME}
+# cache lives in /ci-cache/${CI_PROJECT_NAME}/${2}/${CI_COMMIT_REF_NAME}/${CI_JOB_NAME}
 
 function prepopulate {
   if [[ ! -d $1 ]]; then
@@ -24,8 +24,4 @@ function prepopulate {
   fi
 }
 
-# CARGO_HOME cache was moved to the same "project/cache_type/branch_name/job_name" level as
-# CARGO_TARGET_DIR because of frequent weird data-race issues. This just means that the same cache that 
-# would have been used for the entire pipeline will be duplicated for the each job.
-prepopulate "$CARGO_HOME" cargo
 prepopulate "$CARGO_TARGET_DIR" targets


### PR DESCRIPTION
- [new CI image](https://github.com/paritytech/ci_cd/issues/87): `paritytech/ink-ci-linux:production`. It [has](https://github.com/paritytech/scripts/blob/master/dockerfiles/ink-ci-linux/Dockerfile#L42-L43) miri and `+nightly` by default. Also it's tested against `ink` nightly.
- explicitly write the compiler version
- add miri test; 
- new `check` phase; 
- remove CARGO_HOME cache;