### PR TITLE
Implement chaining error

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -47,21 +47,28 @@ workflow:
 
 #### stage:                        check
 
-check-rust-stable-no_derive_no_std_full:
+check-rust-stable-bit-vec-generic-array-full:
   stage:                           check
   <<:                              *docker-env
   script:
     - time cargo +stable check --verbose --no-default-features --features bit-vec,generic-array,full
     - sccache -s
 
-check-rust-stable-no_derive_no_std:
+check-rust-stable-bit-vec-generic-array:
   stage:                           check
   <<:                              *docker-env
   script:
     - time cargo +stable check --verbose --no-default-features --features bit-vec,generic-array
     - sccache -s
 
-check-rust-stable-no_derive_full:
+check-rust-stable-chain-error:
+  stage:                           check
+  <<:                              *docker-env
+  script:
+    - time cargo +stable check --verbose --no-default-features --features chain-error
+    - sccache -s
+
+check-rust-stable-std-bit-vec-generic-array-full:
   stage:                           check
   <<:                              *docker-env
   script:
@@ -70,18 +77,25 @@ check-rust-stable-no_derive_full:
 
 #### stage:                        test
 
-test-rust-stable:
+test-rust-stable-std-bit-vec-generic-array-derive:
   stage:                           test
   <<:                              *docker-env
   script:
     - time cargo +stable test --verbose --all --features bit-vec,generic-array,derive
     - sccache -s
 
-test-rust-stable-no_derive:
+test-rust-stable-std-bit-vec-generic-array:
   stage:                           test
   <<:                              *docker-env
   script:
     - time cargo +stable test --verbose --features bit-vec,generic-array
+    - sccache -s
+
+test-rust-stable-std-chain-error:
+  stage:                           test
+  <<:                              *docker-env
+  script:
+    - time cargo +stable test --verbose --features chain-error
     - sccache -s
 
 bench-rust-nightly:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -47,28 +47,28 @@ workflow:
 
 #### stage:                        check
 
-check-rust-stable-bit-vec-generic-array-full:
+check-rust-stable-no_derive_no_std_full:
   stage:                           check
   <<:                              *docker-env
   script:
     - time cargo +stable check --verbose --no-default-features --features bit-vec,generic-array,full
     - sccache -s
 
-check-rust-stable-bit-vec-generic-array:
+check-rust-stable-no_derive_no_std:
   stage:                           check
   <<:                              *docker-env
   script:
     - time cargo +stable check --verbose --no-default-features --features bit-vec,generic-array
     - sccache -s
 
-check-rust-stable-chain-error:
+check-rust-stable-no_std-chain-error:
   stage:                           check
   <<:                              *docker-env
   script:
     - time cargo +stable check --verbose --no-default-features --features chain-error
     - sccache -s
 
-check-rust-stable-std-bit-vec-generic-array-full:
+check-rust-stable-no_derive_full:
   stage:                           check
   <<:                              *docker-env
   script:
@@ -77,21 +77,21 @@ check-rust-stable-std-bit-vec-generic-array-full:
 
 #### stage:                        test
 
-test-rust-stable-std-bit-vec-generic-array-derive:
+test-rust-stable:
   stage:                           test
   <<:                              *docker-env
   script:
     - time cargo +stable test --verbose --all --features bit-vec,generic-array,derive
     - sccache -s
 
-test-rust-stable-std-bit-vec-generic-array:
+test-rust-stable-no_derive:
   stage:                           test
   <<:                              *docker-env
   script:
     - time cargo +stable test --verbose --features bit-vec,generic-array
     - sccache -s
 
-test-rust-stable-std-chain-error:
+test-rust-stable-chain-error:
   stage:                           test
   <<:                              *docker-env
   script:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -91,13 +91,6 @@ test-rust-stable-no_derive:
     - time cargo +stable test --verbose --features bit-vec,generic-array
     - sccache -s
 
-test-rust-stable-chain-error:
-  stage:                           test
-  <<:                              *docker-env
-  script:
-    - time cargo +stable test --verbose --features chain-error
-    - sccache -s
-
 bench-rust-nightly:
   stage:                           test
   <<:                              *docker-env

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ bit-vec = ["bitvec"]
 fuzz = ["std", "arbitrary"]
 
 # Make error fully descriptive with chaining error message.
-# Should not be used in constrained environment.
+# Should not be used in a constrained environment.
 chain-error = []
 
 # WARNING: DO _NOT_ USE THIS FEATURE IF YOU ARE WORKING ON CONSENSUS CODE!*

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ bench = false
 [features]
 default = ["std"]
 derive = ["parity-scale-codec-derive"]
-std = ["serde", "bitvec/std", "byte-slice-cast/std"]
+std = ["serde", "bitvec/std", "byte-slice-cast/std", "chain-error"]
 bit-vec = ["bitvec"]
 fuzz = ["std", "arbitrary"]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,10 @@ std = ["serde", "bitvec/std", "byte-slice-cast/std"]
 bit-vec = ["bitvec"]
 fuzz = ["std", "arbitrary"]
 
+# Make error fully descriptive with chaining error message.
+# Should not be used in constrained environment.
+chain-error = []
+
 # WARNING: DO _NOT_ USE THIS FEATURE IF YOU ARE WORKING ON CONSENSUS CODE!*
 #
 # Provides implementations for more data structures than just Vec and Box.

--- a/derive/src/decode.rs
+++ b/derive/src/decode.rs
@@ -151,7 +151,7 @@ fn create_instance(
 				let name_ident = &f.ident;
 				let field_name = match name_ident {
 					Some(a) => format!("{}::{}", name_str, a),
-					None => format!("{}", name), // Should never happen, fields are named.
+					None => format!("{}", name_str), // Should never happen, fields are named.
 				};
 				let decode = create_decode_expr(f, &field_name, input);
 

--- a/derive/src/decode.rs
+++ b/derive/src/decode.rs
@@ -150,7 +150,7 @@ fn create_instance(
 			let recurse = fields.named.iter().map(|f| {
 				let name_ident = &f.ident;
 				let field_name = match name_ident {
-					Some(a) => format!("{}.{}", name_str, a),
+					Some(a) => format!("{}::{}", name_str, a),
 					None => format!("{}", name_str), // Should never happen, fields are named.
 				};
 				let decode = create_decode_expr(f, &field_name, input);
@@ -168,7 +168,7 @@ fn create_instance(
 		},
 		Fields::Unnamed(ref fields) => {
 			let recurse = fields.unnamed.iter().enumerate().map(|(i, f) | {
-				let field_name = format!("{}.{}", name_str, i);
+				let field_name = format!("{}::{}", name_str, i);
 
 				create_decode_expr(f, &field_name, input)
 			});

--- a/derive/src/decode.rs
+++ b/derive/src/decode.rs
@@ -141,7 +141,7 @@ fn create_decode_expr(field: &Field, name: &str, input: &TokenStream) -> TokenSt
 
 fn create_instance(
 	name: TokenStream,
-	print_name: &str,
+	name_str: &str,
 	input: &TokenStream,
 	fields: &Fields
 ) -> TokenStream {
@@ -150,7 +150,7 @@ fn create_instance(
 			let recurse = fields.named.iter().map(|f| {
 				let name_ident = &f.ident;
 				let field_name = match name_ident {
-					Some(a) => format!("{}::{}", print_name, a),
+					Some(a) => format!("{}::{}", name_str, a),
 					None => format!("{}", name), // Should never happen, fields are named.
 				};
 				let decode = create_decode_expr(f, &field_name, input);
@@ -168,7 +168,7 @@ fn create_instance(
 		},
 		Fields::Unnamed(ref fields) => {
 			let recurse = fields.unnamed.iter().enumerate().map(|(i, f) | {
-				let field_name = format!("{}::{}", print_name, i);
+				let field_name = format!("{}::{}", name_str, i);
 
 				create_decode_expr(f, &field_name, input)
 			});

--- a/derive/src/decode.rs
+++ b/derive/src/decode.rs
@@ -150,7 +150,7 @@ fn create_instance(
 			let recurse = fields.named.iter().map(|f| {
 				let name_ident = &f.ident;
 				let field_name = match name_ident {
-					Some(a) => format!("{}::{}", name_str, a),
+					Some(a) => format!("{}.{}", name_str, a),
 					None => format!("{}", name_str), // Should never happen, fields are named.
 				};
 				let decode = create_decode_expr(f, &field_name, input);
@@ -168,7 +168,7 @@ fn create_instance(
 		},
 		Fields::Unnamed(ref fields) => {
 			let recurse = fields.unnamed.iter().enumerate().map(|(i, f) | {
-				let field_name = format!("{}::{}", name_str, i);
+				let field_name = format!("{}.{}", name_str, i);
 
 				create_decode_expr(f, &field_name, input)
 			});

--- a/derive/src/decode.rs
+++ b/derive/src/decode.rs
@@ -168,7 +168,7 @@ fn create_instance(
 		},
 		Fields::Unnamed(ref fields) => {
 			let recurse = fields.unnamed.iter().enumerate().map(|(i, f) | {
-				let field_name = format!("{}::{}", name_str, i);
+				let field_name = format!("{}.{}", name_str, i);
 
 				create_decode_expr(f, &field_name, input)
 			});

--- a/src/bit_vec.rs
+++ b/src/bit_vec.rs
@@ -17,9 +17,10 @@
 use bitvec::{
 	vec::BitVec, store::BitStore, order::BitOrder, slice::BitSlice, boxed::BitBox, mem::BitMemory
 };
-use crate::codec::{Encode, Decode, Input, Output, Error, decode_vec_with_len, encode_slice_no_len};
-use crate::compact::Compact;
-use crate::EncodeLike;
+use crate::{
+	EncodeLike, Encode, Decode, Input, Output, Error, Compact,
+	codec::{decode_vec_with_len, encode_slice_no_len},
+};
 
 impl<O: BitOrder, T: BitStore + Encode> Encode for BitSlice<O, T> {
 	fn encode_to<W: Output + ?Sized>(&self, dest: &mut W) {

--- a/src/codec.rs
+++ b/src/codec.rs
@@ -48,72 +48,10 @@ use crate::alloc::{
 };
 use crate::compact::Compact;
 use crate::encode_like::EncodeLike;
+use crate::Error;
 
 pub(crate) const MAX_PREALLOCATION: usize = 4 * 1024;
 const A_BILLION: u32 = 1_000_000_000;
-
-/// Descriptive error type
-#[cfg(feature = "std")]
-#[derive(PartialEq, Eq, Clone, Debug)]
-pub struct Error(&'static str);
-
-/// Undescriptive error type when compiled for no std
-#[cfg(not(feature = "std"))]
-#[derive(PartialEq, Eq, Clone, Debug)]
-pub struct Error;
-
-impl Error {
-	#[cfg(feature = "std")]
-	/// Error description
-	///
-	/// This function returns an actual error str when running in `std`
-	/// environment, but `""` on `no_std`.
-	pub fn what(&self) -> &'static str {
-		self.0
-	}
-
-	#[cfg(not(feature = "std"))]
-	/// Error description
-	///
-	/// This function returns an actual error str when running in `std`
-	/// environment, but `""` on `no_std`.
-	pub fn what(&self) -> &'static str {
-		""
-	}
-}
-
-#[cfg(feature = "std")]
-impl fmt::Display for Error {
-	fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-		write!(f, "{}", self.0)
-	}
-}
-
-#[cfg(not(feature = "std"))]
-impl fmt::Display for Error {
-	fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-		f.write_str("Error")
-	}
-}
-
-#[cfg(feature = "std")]
-impl std::error::Error for Error {
-	fn description(&self) -> &str {
-		self.0
-	}
-}
-
-impl From<&'static str> for Error {
-	#[cfg(feature = "std")]
-	fn from(s: &'static str) -> Error {
-		Error(s)
-	}
-
-	#[cfg(not(feature = "std"))]
-	fn from(_s: &'static str) -> Error {
-		Error
-	}
-}
 
 /// Trait that allows reading of data into a slice.
 pub trait Input {
@@ -490,9 +428,15 @@ where
 
 impl<T: Decode, E: Decode> Decode for Result<T, E> {
 	fn decode<I: Input>(input: &mut I) -> Result<Self, Error> {
-		match input.read_byte()? {
-			0 => Ok(Ok(T::decode(input)?)),
-			1 => Ok(Err(E::decode(input)?)),
+		match input.read_byte()
+			.map_err(|e| e.chain("Could not result variant byte for `Result`"))?
+		{
+			0 => Ok(
+				Ok(T::decode(input).map_err(|e| e.chain("Could not Decode `Result::Ok(T)`"))?)
+			),
+			1 => Ok(
+				Err(E::decode(input).map_err(|e| e.chain("Could not decode `Result::Error(E)`"))?)
+			),
 			_ => Err("unexpected first byte decoding Result".into()),
 		}
 	}
@@ -558,9 +502,13 @@ impl<T: Encode> Encode for Option<T> {
 
 impl<T: Decode> Decode for Option<T> {
 	fn decode<I: Input>(input: &mut I) -> Result<Self, Error> {
-		match input.read_byte()? {
+		match input.read_byte()
+			.map_err(|e| e.chain("Could not decode variant byte for `Option`"))?
+		{
 			0 => Ok(None),
-			1 => Ok(Some(T::decode(input)?)),
+			1 => Ok(
+				Some(T::decode(input).map_err(|e| e.chain("Could not decode `Option::Some(T)`"))?)
+			),
 			_ => Err("unexpected first byte decoding Option".into()),
 		}
 	}
@@ -1224,9 +1172,10 @@ impl Encode for Duration {
 
 impl Decode for Duration {
 	fn decode<I: Input>(input: &mut I) -> Result<Self, Error> {
-		let (secs, nanos) = <(u64, u32)>::decode(input)?;
+		let (secs, nanos) = <(u64, u32)>::decode(input)
+			.map_err(|e| e.chain("Could not decode `Duration(u64, u32)`"))?;
 		if nanos >= A_BILLION {
-			Err("Number of nanoseconds should not be higher than 10^9.".into())
+			Err("Could not decode `Duration`: Number of nanoseconds should not be higher than 10^9.".into())
 		} else {
 			Ok(Duration::new(secs, nanos))
 		}

--- a/src/codec.rs
+++ b/src/codec.rs
@@ -1440,7 +1440,7 @@ mod tests {
 
 		let i = Compact(len as u32).encode();
 		assert_eq!(
-			<Vec<u8>>::decode(&mut NoLimit(&i[..])).err().unwrap().what(),
+			<Vec<u8>>::decode(&mut NoLimit(&i[..])).err().unwrap().to_string(),
 			{
 				#[cfg(feature = "chain-error")]
 				{
@@ -1455,7 +1455,7 @@ mod tests {
 
 		let i = Compact(1000u32).encode();
 		assert_eq!(
-			<Vec<u8>>::decode(&mut NoLimit(&i[..])).err().unwrap().what(),
+			<Vec<u8>>::decode(&mut NoLimit(&i[..])).err().unwrap().to_string(),
 			{
 				#[cfg(feature = "chain-error")]
 				{

--- a/src/codec.rs
+++ b/src/codec.rs
@@ -1441,31 +1441,13 @@ mod tests {
 		let i = Compact(len as u32).encode();
 		assert_eq!(
 			<Vec<u8>>::decode(&mut NoLimit(&i[..])).err().unwrap().to_string(),
-			{
-				#[cfg(feature = "chain-error")]
-				{
-					"Not enough data to fill buffer\n"
-				}
-				#[cfg(not(feature = "chain-error"))]
-				{
-					"Not enough data to fill buffer"
-				}
-			},
+			"Not enough data to fill buffer",
 		);
 
 		let i = Compact(1000u32).encode();
 		assert_eq!(
 			<Vec<u8>>::decode(&mut NoLimit(&i[..])).err().unwrap().to_string(),
-			{
-				#[cfg(feature = "chain-error")]
-				{
-					"Not enough data to fill buffer\n"
-				}
-				#[cfg(not(feature = "chain-error"))]
-				{
-					"Not enough data to fill buffer"
-				}
-			},
+			"Not enough data to fill buffer",
 		);
 	}
 

--- a/src/codec.rs
+++ b/src/codec.rs
@@ -1588,4 +1588,3 @@ mod tests {
 		<[u32; 0]>::decode(&mut &encoded[..]).unwrap();
 	}
 }
-

--- a/src/codec.rs
+++ b/src/codec.rs
@@ -1588,3 +1588,4 @@ mod tests {
 		<[u32; 0]>::decode(&mut &encoded[..]).unwrap();
 	}
 }
+

--- a/src/codec.rs
+++ b/src/codec.rs
@@ -1439,10 +1439,34 @@ mod tests {
 		assert_eq!(<Vec<u8>>::decode(&mut NoLimit(&i[..])).unwrap(), vec![0u8; len]);
 
 		let i = Compact(len as u32).encode();
-		assert_eq!(<Vec<u8>>::decode(&mut NoLimit(&i[..])).err().unwrap().what(), "Not enough data to fill buffer");
+		assert_eq!(
+			<Vec<u8>>::decode(&mut NoLimit(&i[..])).err().unwrap().what(),
+			{
+				#[cfg(feature = "chain-error")]
+				{
+					"Not enough data to fill buffer\n"
+				}
+				#[cfg(not(feature = "chain-error"))]
+				{
+					"Not enough data to fill buffer"
+				}
+			},
+		);
 
 		let i = Compact(1000u32).encode();
-		assert_eq!(<Vec<u8>>::decode(&mut NoLimit(&i[..])).err().unwrap().what(), "Not enough data to fill buffer");
+		assert_eq!(
+			<Vec<u8>>::decode(&mut NoLimit(&i[..])).err().unwrap().what(),
+			{
+				#[cfg(feature = "chain-error")]
+				{
+					"Not enough data to fill buffer\n"
+				}
+				#[cfg(not(feature = "chain-error"))]
+				{
+					"Not enough data to fill buffer"
+				}
+			},
+		);
 	}
 
 	#[test]

--- a/src/compact.rs
+++ b/src/compact.rs
@@ -17,8 +17,9 @@
 use arrayvec::ArrayVec;
 
 use crate::alloc::vec::Vec;
-use crate::codec::{Encode, Decode, Input, Output, EncodeAsRef, Error};
+use crate::codec::{Encode, Decode, Input, Output, EncodeAsRef};
 use crate::encode_like::EncodeLike;
+use crate::Error;
 #[cfg(feature = "fuzz")]
 use arbitrary::Arbitrary;
 

--- a/src/decode_all.rs
+++ b/src/decode_all.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::codec::{Error, Decode};
+use crate::{Error, Decode};
 
 /// The error message returned when `decode_all` fails.
 pub(crate) const DECODE_ALL_ERR_MSG: &str = "Input buffer has still data left after decoding!";

--- a/src/decode_all.rs
+++ b/src/decode_all.rs
@@ -55,7 +55,19 @@ mod tests {
 					);
 
 					encoded.extend(&[1, 2, 3, 4, 5, 6]);
-					assert_eq!(<$type>::decode_all(&encoded).unwrap_err().what(), DECODE_ALL_ERR_MSG);
+					assert_eq!(
+						<$type>::decode_all(&encoded).unwrap_err().what(),
+						{
+							#[cfg(feature = "chain-error")]
+							{
+								"Input buffer has still data left after decoding!\n"
+							}
+							#[cfg(not(feature = "chain-error"))]
+							{
+								"Input buffer has still data left after decoding!"
+							}
+						},
+					);
 				}
 			)*
 		};

--- a/src/decode_all.rs
+++ b/src/decode_all.rs
@@ -57,16 +57,7 @@ mod tests {
 					encoded.extend(&[1, 2, 3, 4, 5, 6]);
 					assert_eq!(
 						<$type>::decode_all(&encoded).unwrap_err().to_string(),
-						{
-							#[cfg(feature = "chain-error")]
-							{
-								"Input buffer has still data left after decoding!\n"
-							}
-							#[cfg(not(feature = "chain-error"))]
-							{
-								"Input buffer has still data left after decoding!"
-							}
-						},
+						"Input buffer has still data left after decoding!",
 					);
 				}
 			)*

--- a/src/decode_all.rs
+++ b/src/decode_all.rs
@@ -56,7 +56,7 @@ mod tests {
 
 					encoded.extend(&[1, 2, 3, 4, 5, 6]);
 					assert_eq!(
-						<$type>::decode_all(&encoded).unwrap_err().what(),
+						<$type>::decode_all(&encoded).unwrap_err().to_string(),
 						{
 							#[cfg(feature = "chain-error")]
 							{

--- a/src/depth_limit.rs
+++ b/src/depth_limit.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::codec::{Error, Decode, Input};
+use crate::{Error, Decode, Input};
 
 /// The error message returned when depth limit is reached.
 const DECODE_MAX_DEPTH_MSG: &str = "Maximum recursion depth reached when decoding";

--- a/src/encode_append.rs
+++ b/src/encode_append.rs
@@ -15,7 +15,7 @@
 use core::{iter::ExactSizeIterator, mem};
 
 use crate::alloc::vec::Vec;
-use crate::codec::{Encode, Decode, Error};
+use crate::{Encode, Decode, Error};
 use crate::compact::{Compact, CompactLen};
 use crate::encode_like::EncodeLike;
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -16,7 +16,6 @@
 
 use crate::alloc::borrow::Cow;
 
-
 /// Error type.
 ///
 /// Descriptive on `std` environment, with chaining error on `chain-error` environment,

--- a/src/error.rs
+++ b/src/error.rs
@@ -15,6 +15,8 @@
 //! Error type, descriptive or undescriptive depending on features.
 
 use crate::alloc::borrow::Cow;
+#[cfg(feature = "chain-error")]
+use crate::alloc::boxed::Box;
 
 /// Error type.
 ///

--- a/src/error.rs
+++ b/src/error.rs
@@ -51,8 +51,8 @@ impl Error {
 	}
 
 	/// Display error with indentation.
+	#[cfg(feature = "chain-error")]
 	fn display_with_indent(&self, indent: u32, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-		#[cfg(feature = "chain-error")]
 		{
 			for _ in 0..indent {
 				f.write_str("\t")?;
@@ -63,32 +63,34 @@ impl Error {
 				f.write_str("\n")?;
 				cause.display_with_indent(indent + 1, f)
 			} else {
-				f.write_str("\n")?;
+				// Only return to new line if the error has been displayed with some indent,
+				// i.e. if the error has some causes.
+				if indent != 0 {
+					f.write_str("\n")?;
+				}
 				Ok(())
 			}
 		}
 
-		#[cfg(all(not(feature = "chain-error"), feature = "std"))]
-		{
-			for _ in 0..indent {
-				f.write_str("\t")?;
-			}
-			f.write_str(&self.desc)
-		}
-
-		#[cfg(all(not(feature = "chain-error"), not(feature = "std")))]
-		{
-			for _ in 0..indent {
-				f.write_str("\t")?;
-			}
-			f.write_str("Codec error")
-		}
 	}
 }
 
 impl core::fmt::Display for Error {
 	fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-		self.display_with_indent(0, f)
+		#[cfg(feature = "chain-error")]
+		{
+			self.display_with_indent(0, f)
+		}
+
+		#[cfg(all(not(feature = "chain-error"), feature = "std"))]
+		{
+			f.write_str(&self.desc)
+		}
+
+		#[cfg(all(not(feature = "chain-error"), not(feature = "std")))]
+		{
+			f.write_str("Codec error")
+		}
 	}
 }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,0 +1,161 @@
+// Copyright 2021 Parity Technologies
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Error type, descriptive or undescriptive depending on features.
+
+use crate::alloc::borrow::Cow;
+
+
+/// Error type.
+///
+/// Descriptive on `std` environment, with chaining error on `chain-error` environment,
+/// underscriptive otherwise.
+#[derive(PartialEq, Eq, Clone, Debug)]
+pub struct Error {
+	#[cfg(feature = "chain-error")]
+	cause: Option<Box<Error>>,
+	#[cfg(feature = "chain-error")]
+	desc: Cow<'static, str>,
+	#[cfg(all(not(feature = "chain-error"), feature = "std"))]
+	desc: &'static str,
+}
+
+impl Error {
+	/// Chain error message with description.
+	///
+	/// When compiled with `chain-error` feature, the description is chained, otherwise the
+	/// description is ditched.
+	pub fn chain(self, desc: impl Into<Cow<'static, str>>) -> Self {
+		#[cfg(feature = "chain-error")]
+		{
+			Self { desc: desc.into(), cause: Some(Box::new(self)) }
+		}
+
+		#[cfg(not(feature = "chain-error"))]
+		{
+			let _ = desc;
+			self
+		}
+	}
+
+	/// Display error with indentation.
+	fn display_with_indent(&self, indent: u32, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+		#[cfg(feature = "chain-error")]
+		{
+			for _ in 0..indent {
+				f.write_str("\t")?;
+			}
+			f.write_str(&self.desc)?;
+			if let Some(cause) = &self.cause {
+				f.write_str(":")?;
+				f.write_str("\n")?;
+				cause.display_with_indent(indent + 1, f)
+			} else {
+				f.write_str("\n")?;
+				Ok(())
+			}
+		}
+
+		#[cfg(all(not(feature = "chain-error"), feature = "std"))]
+		{
+			for _ in 0..indent {
+				f.write_str("\t")?;
+			}
+			f.write_str(&self.desc)
+		}
+
+		#[cfg(all(not(feature = "chain-error"), not(feature = "std")))]
+		{
+			for _ in 0..indent {
+				f.write_str("\t")?;
+			}
+			f.write_str("Codec error")
+		}
+	}
+
+	/// Error description
+	pub fn what(&self) -> Cow<'static, str> {
+		#[cfg(feature = "chain-error")]
+		{
+			format!("{}", self).into()
+		}
+
+		#[cfg(all(not(feature = "chain-error"), feature = "std"))]
+		{
+			self.desc.into()
+		}
+
+		#[cfg(all(not(feature = "chain-error"), not(feature = "std")))]
+		{
+			"Codec error".into()
+		}
+	}
+}
+
+impl core::fmt::Display for Error {
+	fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+		self.display_with_indent(0, f)
+	}
+}
+
+impl From<&'static str> for Error {
+	fn from(desc: &'static str) -> Error {
+		#[cfg(feature = "chain-error")]
+		{
+			Error { desc: desc.into(), cause: None }
+		}
+
+		#[cfg(all(not(feature = "chain-error"), feature = "std"))]
+		{
+			Error { desc }
+		}
+
+		#[cfg(all(not(feature = "chain-error"), not(feature = "std")))]
+		{
+			let _ = desc;
+			Error {}
+		}
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use crate::Error;
+
+	#[test]
+	fn test_full_error() {
+		let msg: &str = {
+			#[cfg(feature = "chain-error")]
+			{
+				"final type:\n\twrap cause:\n\t\troot cause\n"
+			}
+
+			#[cfg(all(not(feature = "chain-error"), feature = "std"))]
+			{
+				"root cause"
+			}
+
+			#[cfg(all(not(feature = "chain-error"), not(feature = "std")))]
+			{
+				""
+			}
+		};
+
+		let error = Error::from("root cause").chain("wrap cause").chain("final type");
+
+		assert_eq!(format!("{}", error), msg);
+
+		assert_eq!(error.what(), msg);
+	}
+}

--- a/src/error.rs
+++ b/src/error.rs
@@ -84,24 +84,6 @@ impl Error {
 			f.write_str("Codec error")
 		}
 	}
-
-	/// Error description
-	pub fn what(&self) -> Cow<'static, str> {
-		#[cfg(feature = "chain-error")]
-		{
-			format!("{}", self).into()
-		}
-
-		#[cfg(all(not(feature = "chain-error"), feature = "std"))]
-		{
-			self.desc.into()
-		}
-
-		#[cfg(all(not(feature = "chain-error"), not(feature = "std")))]
-		{
-			"Codec error".into()
-		}
-	}
 }
 
 impl core::fmt::Display for Error {
@@ -171,8 +153,6 @@ mod tests {
 		let error = Error::from("root cause").chain("wrap cause").chain("final type");
 
 		assert_eq!(&error.to_string(), msg);
-
-		assert_eq!(error.what(), msg);
 	}
 
 	#[test]

--- a/src/error.rs
+++ b/src/error.rs
@@ -51,23 +51,21 @@ impl Error {
 	/// Display error with indentation.
 	#[cfg(feature = "chain-error")]
 	fn display_with_indent(&self, indent: u32, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-		{
-			for _ in 0..indent {
-				f.write_str("\t")?;
-			}
-			f.write_str(&self.desc)?;
-			if let Some(cause) = &self.cause {
-				f.write_str(":")?;
+		for _ in 0..indent {
+			f.write_str("\t")?;
+		}
+		f.write_str(&self.desc)?;
+		if let Some(cause) = &self.cause {
+			f.write_str(":")?;
+			f.write_str("\n")?;
+			cause.display_with_indent(indent + 1, f)
+		} else {
+			// Only return to new line if the error has been displayed with some indent,
+			// i.e. if the error has some causes.
+			if indent != 0 {
 				f.write_str("\n")?;
-				cause.display_with_indent(indent + 1, f)
-			} else {
-				// Only return to new line if the error has been displayed with some indent,
-				// i.e. if the error has some causes.
-				if indent != 0 {
-					f.write_str("\n")?;
-				}
-				Ok(())
 			}
+			Ok(())
 		}
 	}
 }

--- a/src/generic_array.rs
+++ b/src/generic_array.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 use crate::alloc::vec::Vec;
-use crate::codec::{Encode, Decode, Input, Output, Error};
+use crate::{Encode, Decode, Input, Output, Error};
 use crate::encode_like::EncodeLike;
 
 impl<T: Encode, L: generic_array::ArrayLength<T>> Encode for generic_array::GenericArray<T, L> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -273,9 +273,11 @@ mod decode_all;
 mod depth_limit;
 mod encode_append;
 mod encode_like;
+mod error;
 
+pub use self::error::Error;
 pub use self::codec::{
-	Input, Output, Error, Decode, Encode, Codec, EncodeAsRef, WrapperTypeEncode, WrapperTypeDecode,
+	Input, Output, Decode, Encode, Codec, EncodeAsRef, WrapperTypeEncode, WrapperTypeDecode,
 	OptionBool, DecodeLength, FullCodec, FullEncode,
 };
 #[cfg(feature = "std")]

--- a/tests/chain-error.rs
+++ b/tests/chain-error.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#![cfg(feature = "chain-error")]
+
 #[cfg(not(feature="derive"))]
 use parity_scale_codec_derive::Decode;
 use parity_scale_codec::Decode;

--- a/tests/chain-error.rs
+++ b/tests/chain-error.rs
@@ -36,7 +36,7 @@ enum E {
 #[test]
 fn full_error_struct_named() {
 	let encoded = vec![0];
-	let err = r#"Could not decode `Wrapper::0`:
+	let err = r#"Could not decode `Wrapper.0`:
 	Could not decode `StructNamed::foo`:
 		Not enough data to fill buffer
 "#;
@@ -50,8 +50,8 @@ fn full_error_struct_named() {
 #[test]
 fn full_error_struct_unnamed() {
 	let encoded = vec![0];
-	let err = r#"Could not decode `Wrapper::0`:
-	Could not decode `StructUnnamed::0`:
+	let err = r#"Could not decode `Wrapper.0`:
+	Could not decode `StructUnnamed.0`:
 		Not enough data to fill buffer
 "#;
 
@@ -88,7 +88,7 @@ fn full_error_enum_named_field() {
 #[test]
 fn full_error_enum_unnamed_field() {
 	let encoded = vec![1, 0];
-	let err = r#"Could not decode `E::VariantUnnamed::0`:
+	let err = r#"Could not decode `E::VariantUnnamed.0`:
 	Not enough data to fill buffer
 "#;
 

--- a/tests/chain-error.rs
+++ b/tests/chain-error.rs
@@ -1,4 +1,4 @@
-// Copyright 2017, 2018 Parity Technologies
+// Copyright 2021 Parity Technologies
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/chain-error.rs
+++ b/tests/chain-error.rs
@@ -36,8 +36,8 @@ enum E {
 #[test]
 fn full_error_struct_named() {
 	let encoded = vec![0];
-	let err = r#"Could not decode `Wrapper::0`:
-	Could not decode `StructNamed::foo`:
+	let err = r#"Could not decode `Wrapper.0`:
+	Could not decode `StructNamed.foo`:
 		Not enough data to fill buffer
 "#;
 
@@ -50,8 +50,8 @@ fn full_error_struct_named() {
 #[test]
 fn full_error_struct_unnamed() {
 	let encoded = vec![0];
-	let err = r#"Could not decode `Wrapper::0`:
-	Could not decode `StructUnnamed::0`:
+	let err = r#"Could not decode `Wrapper.0`:
+	Could not decode `StructUnnamed.0`:
 		Not enough data to fill buffer
 "#;
 
@@ -75,7 +75,7 @@ fn full_error_enum_unknown_variant() {
 #[test]
 fn full_error_enum_named_field() {
 	let encoded = vec![0, 0];
-	let err = r#"Could not decode `E::VariantNamed::foo`:
+	let err = r#"Could not decode `E::VariantNamed.foo`:
 	Not enough data to fill buffer
 "#;
 
@@ -88,7 +88,7 @@ fn full_error_enum_named_field() {
 #[test]
 fn full_error_enum_unnamed_field() {
 	let encoded = vec![1, 0];
-	let err = r#"Could not decode `E::VariantUnnamed::0`:
+	let err = r#"Could not decode `E::VariantUnnamed.0`:
 	Not enough data to fill buffer
 "#;
 

--- a/tests/chain-error.rs
+++ b/tests/chain-error.rs
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#![cfg(feature = "chain-error")]
-
 #[cfg(not(feature="derive"))]
 use parity_scale_codec_derive::Decode;
 use parity_scale_codec::Decode;

--- a/tests/chain-error.rs
+++ b/tests/chain-error.rs
@@ -36,8 +36,8 @@ enum E {
 #[test]
 fn full_error_struct_named() {
 	let encoded = vec![0];
-	let err = r#"Could not decode `Wrapper.0`:
-	Could not decode `StructNamed.foo`:
+	let err = r#"Could not decode `Wrapper::0`:
+	Could not decode `StructNamed::foo`:
 		Not enough data to fill buffer
 "#;
 
@@ -50,8 +50,8 @@ fn full_error_struct_named() {
 #[test]
 fn full_error_struct_unnamed() {
 	let encoded = vec![0];
-	let err = r#"Could not decode `Wrapper.0`:
-	Could not decode `StructUnnamed.0`:
+	let err = r#"Could not decode `Wrapper::0`:
+	Could not decode `StructUnnamed::0`:
 		Not enough data to fill buffer
 "#;
 
@@ -75,7 +75,7 @@ fn full_error_enum_unknown_variant() {
 #[test]
 fn full_error_enum_named_field() {
 	let encoded = vec![0, 0];
-	let err = r#"Could not decode `E::VariantNamed.foo`:
+	let err = r#"Could not decode `E::VariantNamed::foo`:
 	Not enough data to fill buffer
 "#;
 
@@ -88,7 +88,7 @@ fn full_error_enum_named_field() {
 #[test]
 fn full_error_enum_unnamed_field() {
 	let encoded = vec![1, 0];
-	let err = r#"Could not decode `E::VariantUnnamed.0`:
+	let err = r#"Could not decode `E::VariantUnnamed::0`:
 	Not enough data to fill buffer
 "#;
 

--- a/tests/chain-error.rs
+++ b/tests/chain-error.rs
@@ -44,7 +44,7 @@ fn full_error_struct_named() {
 "#;
 
 	assert_eq!(
-		Wrapper::<StructNamed>::decode(&mut &encoded[..]).unwrap_err().what().to_owned(),
+		Wrapper::<StructNamed>::decode(&mut &encoded[..]).unwrap_err().to_string(),
 		String::from(err),
 	);
 }
@@ -58,7 +58,7 @@ fn full_error_struct_unnamed() {
 "#;
 
 	assert_eq!(
-		Wrapper::<StructUnnamed>::decode(&mut &encoded[..]).unwrap_err().what().to_owned(),
+		Wrapper::<StructUnnamed>::decode(&mut &encoded[..]).unwrap_err().to_string(),
 		String::from(err),
 	);
 }
@@ -70,7 +70,7 @@ fn full_error_enum_unknown_variant() {
 "#;
 
 	assert_eq!(
-		E::decode(&mut &encoded[..]).unwrap_err().what().to_owned(),
+		E::decode(&mut &encoded[..]).unwrap_err().to_string(),
 		String::from(err),
 	);
 }
@@ -83,7 +83,7 @@ fn full_error_enum_named_field() {
 "#;
 
 	assert_eq!(
-		E::decode(&mut &encoded[..]).unwrap_err().what().to_owned(),
+		E::decode(&mut &encoded[..]).unwrap_err().to_string(),
 		String::from(err),
 	);
 }
@@ -96,7 +96,7 @@ fn full_error_enum_unnamed_field() {
 "#;
 
 	assert_eq!(
-		E::decode(&mut &encoded[..]).unwrap_err().what().to_owned(),
+		E::decode(&mut &encoded[..]).unwrap_err().to_string(),
 		String::from(err),
 	);
 }

--- a/tests/chain-error.rs
+++ b/tests/chain-error.rs
@@ -66,8 +66,7 @@ fn full_error_struct_unnamed() {
 #[test]
 fn full_error_enum_unknown_variant() {
 	let encoded = vec![2];
-	let err = r#"Could not decode `E`, variant doesn't exist
-"#;
+	let err = r#"Could not decode `E`, variant doesn't exist"#;
 
 	assert_eq!(
 		E::decode(&mut &encoded[..]).unwrap_err().to_string(),

--- a/tests/full_error.rs
+++ b/tests/full_error.rs
@@ -1,0 +1,100 @@
+// Copyright 2017, 2018 Parity Technologies
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#[cfg(not(feature="derive"))]
+use parity_scale_codec_derive::Decode;
+use parity_scale_codec::Decode;
+
+#[derive(Decode, Debug)]
+struct Wrapper<T>(T);
+
+#[derive(Decode, Debug)]
+struct StructNamed {
+	foo: u16
+}
+
+#[derive(Decode, Debug)]
+struct StructUnnamed(u16);
+
+#[derive(Decode, Debug)]
+enum E {
+	VariantNamed { foo: u16, },
+	VariantUnnamed(u16),
+}
+
+#[test]
+fn full_error_struct_named() {
+	let encoded = vec![0];
+	let err = r#"Could not decode `Wrapper::0`:
+	Could not decode `StructNamed::foo`:
+		Not enough data to fill buffer
+"#;
+
+	assert_eq!(
+		Wrapper::<StructNamed>::decode(&mut &encoded[..]).unwrap_err().what().to_owned(),
+		String::from(err),
+	);
+}
+
+#[test]
+fn full_error_struct_unnamed() {
+	let encoded = vec![0];
+	let err = r#"Could not decode `Wrapper::0`:
+	Could not decode `StructUnnamed::0`:
+		Not enough data to fill buffer
+"#;
+
+	assert_eq!(
+		Wrapper::<StructUnnamed>::decode(&mut &encoded[..]).unwrap_err().what().to_owned(),
+		String::from(err),
+	);
+}
+
+#[test]
+fn full_error_enum_unknown_variant() {
+	let encoded = vec![2];
+	let err = r#"Could not decode `E`, variant doesn't exist
+"#;
+
+	assert_eq!(
+		E::decode(&mut &encoded[..]).unwrap_err().what().to_owned(),
+		String::from(err),
+	);
+}
+
+#[test]
+fn full_error_enum_named_field() {
+	let encoded = vec![0, 0];
+	let err = r#"Could not decode `E::VariantNamed::foo`:
+	Not enough data to fill buffer
+"#;
+
+	assert_eq!(
+		E::decode(&mut &encoded[..]).unwrap_err().what().to_owned(),
+		String::from(err),
+	);
+}
+
+#[test]
+fn full_error_enum_unnamed_field() {
+	let encoded = vec![1, 0];
+	let err = r#"Could not decode `E::VariantUnnamed::0`:
+	Not enough data to fill buffer
+"#;
+
+	assert_eq!(
+		E::decode(&mut &encoded[..]).unwrap_err().what().to_owned(),
+		String::from(err),
+	);
+}

--- a/tests/mod.rs
+++ b/tests/mod.rs
@@ -198,7 +198,6 @@ fn should_work_for_indexed() {
 
 #[test]
 #[should_panic(expected = "Not enough data to fill buffer")]
-#[cfg(not(feature = "chain-error"))]
 fn correct_error_for_indexed_0() {
 	let mut wrong: &[u8] = b"\x08";
 	Indexed::decode(&mut wrong).unwrap();
@@ -206,7 +205,6 @@ fn correct_error_for_indexed_0() {
 
 #[test]
 #[should_panic(expected = "Not enough data to fill buffer")]
-#[cfg(not(feature = "chain-error"))]
 fn correct_error_for_indexed_1() {
 	let mut wrong: &[u8] = b"\0\0\0\0\x01";
 	Indexed::decode(&mut wrong).unwrap();
@@ -214,7 +212,6 @@ fn correct_error_for_indexed_1() {
 
 #[test]
 #[should_panic(expected = "Not enough data to fill buffer")]
-#[cfg(not(feature = "chain-error"))]
 fn correct_error_for_enumtype() {
 	let mut wrong: &[u8] = b"\x01";
 	EnumType::decode(&mut wrong).unwrap();
@@ -222,7 +219,6 @@ fn correct_error_for_enumtype() {
 
 #[test]
 #[should_panic(expected = "Not enough data to fill buffer")]
-#[cfg(not(feature = "chain-error"))]
 fn correct_error_for_named_struct_1() {
 	let mut wrong: &[u8] = b"\x01";
 	Struct::<u32, u32, u32>::decode(&mut wrong).unwrap();
@@ -230,7 +226,6 @@ fn correct_error_for_named_struct_1() {
 
 #[test]
 #[should_panic(expected = "Not enough data to fill buffer")]
-#[cfg(not(feature = "chain-error"))]
 fn correct_error_for_named_struct_2() {
 	let mut wrong: &[u8] = b"\0\0\0\0\x01";
 	Struct::<u32, u32, u32>::decode(&mut wrong).unwrap();
@@ -524,31 +519,18 @@ fn recursive_type() {
 fn crafted_input_for_vec_u8() {
 	assert_eq!(
 		Vec::<u8>::decode(&mut &Compact(u32::max_value()).encode()[..]).err().unwrap().to_string(),
-		{
-			#[cfg(feature = "chain-error")]
-			{
-				"Not enough data to decode vector\n"
-			}
-			#[cfg(not(feature = "chain-error"))]
-			{
-				"Not enough data to decode vector"
-			}
-		},
+		"Not enough data to decode vector",
 	);
 }
 
 #[test]
 fn crafted_input_for_vec_t() {
-	let mut msg: String = if cfg!(target_endian = "big") {
+	let msg: String = if cfg!(target_endian = "big") {
 		// use unoptimize decode
 		"Not enough data to fill buffer".into()
 	} else {
 		"Not enough data to decode vector".into()
 	};
-	if cfg!(feature = "chain-error") {
-		msg.push('\n');
-	}
-
 
 	assert_eq!(
 		Vec::<u32>::decode(&mut &Compact(u32::max_value()).encode()[..]).err().unwrap().to_string(),

--- a/tests/mod.rs
+++ b/tests/mod.rs
@@ -197,6 +197,7 @@ fn should_work_for_indexed() {
 }
 
 #[test]
+#[should_panic(expected = "Not enough data to fill buffer")]
 fn correct_error_for_indexed_0() {
 	let mut wrong: &[u8] = b"\x08";
 	Indexed::decode(&mut wrong).unwrap();

--- a/tests/mod.rs
+++ b/tests/mod.rs
@@ -523,7 +523,7 @@ fn recursive_type() {
 #[test]
 fn crafted_input_for_vec_u8() {
 	assert_eq!(
-		Vec::<u8>::decode(&mut &Compact(u32::max_value()).encode()[..]).err().unwrap().what(),
+		Vec::<u8>::decode(&mut &Compact(u32::max_value()).encode()[..]).err().unwrap().to_string(),
 		{
 			#[cfg(feature = "chain-error")]
 			{
@@ -551,7 +551,7 @@ fn crafted_input_for_vec_t() {
 
 
 	assert_eq!(
-		Vec::<u32>::decode(&mut &Compact(u32::max_value()).encode()[..]).err().unwrap().what(),
+		Vec::<u32>::decode(&mut &Compact(u32::max_value()).encode()[..]).err().unwrap().to_string(),
 		msg,
 	);
 }

--- a/tests/mod.rs
+++ b/tests/mod.rs
@@ -197,7 +197,6 @@ fn should_work_for_indexed() {
 }
 
 #[test]
-#[should_panic(expected = "Not enough data to fill buffer")]
 fn correct_error_for_indexed_0() {
 	let mut wrong: &[u8] = b"\x08";
 	Indexed::decode(&mut wrong).unwrap();


### PR DESCRIPTION
fix https://github.com/paritytech/parity-scale-codec/issues/238

## Breaking change:

* `fn description` is removed on std
* `fn what` returns a `Cow<'static, str>` instead of `&'static str` and contains:
  * `"Codec error"` on no_std (whereas it was returning `""` before)
  * the root cause on std
  * the full error on chain-error

## Description

* implement chaining error
* the crate has a new features "chain-error".
* `fn description` is removed from `Error`, (it was available only on std, and ppl should rather use `fn what`). the reason to remove it s that if `std` and `chain-error` are both activated then I can't return a `&'static str`. I think ppl should use `fn what` or `Display` implementation.

## Other possible implementation

Another implementation would be to have `fn what` returning a `&'static str`. and would never contains the chained error. the chained error would only be available in `Display` implementation.
But I think it is better to have `fn what` containing all error information.

All in all it is:
* either we make `fn what` only returns the root cause and return a `&static str`
* or we make `fn what` returning the complete message (which is only root cause in `std` and full error error in `chain-error`). But then it returns a `Cow<'static, str>`