### PR TITLE
Improve Decode trait, without improving implementations

### DIFF
--- a/src/codec.rs
+++ b/src/codec.rs
@@ -314,11 +314,11 @@ pub trait Decode: Sized {
 		Self::decode(input).map(|_| ())
 	}
 
-	/// Return the fix length of the encoded type.
+	/// Return the fix size of the encoded type, if any.
 	///
-	/// If it returns some length then it is the length of any encoded value of the type.
-	/// Otherwise the type may or may not have fixed encoded length.
-	fn fix_encoded_len() -> Option<usize> {
+	/// If it returns some size then it is the size of any encoded value of the type.
+	/// Otherwise the type may or may not have fixed encoded size.
+	fn fix_encoded_size() -> Option<usize> {
 		None
 	}
 }

--- a/src/codec.rs
+++ b/src/codec.rs
@@ -317,7 +317,7 @@ pub trait Decode: Sized {
 		Self::decode(input).map(|_| ())
 	}
 
-	/// Allows to return the fixed encoded size of the type.
+	/// Allows to return the fixed codec size of the type.
 	///
 	/// If it returns `Some(size)` then any possible value of this
 	/// type has the given size (in bytes) when being encoded.

--- a/src/codec.rs
+++ b/src/codec.rs
@@ -317,11 +317,13 @@ pub trait Decode: Sized {
 		Self::decode(input).map(|_| ())
 	}
 
-	/// Return the fix size of the encoded type, if any.
+	/// Allows to return the fixed encoded size of the type.
 	///
-	/// If it returns some size then it is the size of any encoded value of the type.
-	/// Otherwise the type encoding may or may not have fixed size.
-	fn fix_encoded_size() -> Option<usize> {
+	/// If it returns `Some(size)` then any possible value of this
+	/// type has the given size (in bytes) when being encoded.
+	///
+	/// NOTE: A type with a fixed encoded size may return `None`.
+	fn encoded_fixed_size() -> Option<usize> {
 		None
 	}
 }

--- a/src/codec.rs
+++ b/src/codec.rs
@@ -307,7 +307,20 @@ pub trait Decode: Sized {
 	const TYPE_INFO: TypeInfo = TypeInfo::Unknown;
 
 	/// Attempt to deserialise the value from input.
-	fn decode<I: Input>(value: &mut I) -> Result<Self, Error>;
+	fn decode<I: Input>(input: &mut I) -> Result<Self, Error>;
+
+	/// Attempt to skip the encoded value from input.
+	fn skip<I: Input>(input: &mut I) -> Result<(), Error> {
+		Self::decode(input).map(|_| ())
+	}
+
+	/// Return the fix length of the encoded type.
+	///
+	/// If it returns some length then it is the length of any encoded value of the type.
+	/// Otherwise the type may or may not have fixed encoded length.
+	fn fix_encoded_len() -> Option<usize> {
+		None
+	}
 }
 
 /// Trait that allows zero-copy read/write of value-references to/from slices in LE format.

--- a/src/codec.rs
+++ b/src/codec.rs
@@ -317,7 +317,7 @@ pub trait Decode: Sized {
 	/// Return the fix size of the encoded type, if any.
 	///
 	/// If it returns some size then it is the size of any encoded value of the type.
-	/// Otherwise the type may or may not have fixed encoded size.
+	/// Otherwise the type encoding may or may not have fixed size.
 	fn fix_encoded_size() -> Option<usize> {
 		None
 	}

--- a/src/codec.rs
+++ b/src/codec.rs
@@ -310,6 +310,9 @@ pub trait Decode: Sized {
 	fn decode<I: Input>(input: &mut I) -> Result<Self, Error>;
 
 	/// Attempt to skip the encoded value from input.
+	///
+	/// The default implementation of this function is just calling [`Decode::decode`].
+	/// When possible, an implementation should provided a specialized implementation.
 	fn skip<I: Input>(input: &mut I) -> Result<(), Error> {
 		Self::decode(input).map(|_| ())
 	}

--- a/src/codec.rs
+++ b/src/codec.rs
@@ -317,10 +317,10 @@ pub trait Decode: Sized {
 		Self::decode(input).map(|_| ())
 	}
 
-	/// Allows to return the fixed codec size of the type.
+	/// Returns the fixed encoded size of the type.
 	///
-	/// If it returns `Some(size)` then any possible value of this
-	/// type has the given size (in bytes) when being encoded.
+	/// If it returns `Some(size)` then all possible values of this
+	/// type have the given size (in bytes) when encoded.
 	///
 	/// NOTE: A type with a fixed encoded size may return `None`.
 	fn encoded_fixed_size() -> Option<usize> {


### PR DESCRIPTION
related https://github.com/paritytech/parity-scale-codec/issues/241
related https://github.com/paritytech/parity-scale-codec/issues/201

This introduces 2 new methods on Decode trait, with default implementations.

Their optimization for the "primitive" types will be done in later PR, and maybe later minor version.