### PR TITLE
add EncodedSize that calculates the encoded size more efficiently.

### DIFF
--- a/src/codec.rs
+++ b/src/codec.rs
@@ -291,7 +291,14 @@ pub trait Encode {
 		f(&self.encode())
 	}
 
-	/// Calculates the encoded size, used when the encoded bytes are not interesting.
+	/// Calculates the encoded size.
+	///
+	/// Should be used when the encoded data isn't required.
+	///
+	/// # Note
+	///
+	/// This works by using a special [`Output`] that only tracks the size. So, there are no allocations inside the 
+	/// output. However, this can not prevent allocations that some types are doing inside their own encoding. 
 	fn encoded_size(&self) -> usize {
 		let mut size_tracker = SizeTracker { written: 0 };
 		self.encode_to(&mut size_tracker);

--- a/src/codec.rs
+++ b/src/codec.rs
@@ -291,25 +291,26 @@ pub trait Encode {
 		f(&self.encode())
 	}
 
-	/// Calculates the encoded size, used when the encoded bytes is not interested.
+	/// Calculates the encoded size, used when the encoded bytes are not interesting.
 	fn encoded_size(&self) -> usize {
-		let mut size_tracker = SizeTracker { writen: 0 };
+		let mut size_tracker = SizeTracker { written: 0 };
 		self.encode_to(&mut size_tracker);
-		size_tracker.writen
+		size_tracker.written
 	}
 }
 
+// Implements `Output` and only keeps track of the number of written bytes
 struct SizeTracker {
-	writen: usize,
+	written: usize,
 }
 
 impl Output for SizeTracker {
 	fn write(&mut self, bytes: &[u8]) {
-		self.writen += bytes.len();
+		self.written += bytes.len();
 	}
 
 	fn push_byte(&mut self, _byte: u8) {
-		self.writen += 1;
+		self.written += 1;
 	}
 }
 


### PR DESCRIPTION
used when the encoded bytes is not interested.
This could replace `Encode::using_encoded(|v| v.len())` used in substrate to avoid unnecessary memory allocation and data copy.