### PR TITLE
release 2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,29 @@
+# Changelog
+All notable changes to this crate will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this crate adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [2.0.0] - 2021-01-26
+
+### Added
+- `Decode::skip` is introduced, allowing to skip some encoded types.
+- `Decode::encoded_fixed_size` is introduced, allowing to get the fixed encoded size of a type.
+- `Error` now contains a chain of causes. This full error description can also be activated on
+  no std using the feature `chain-error`.
+- `Encode::encoded_size` is introduced, allowing to get the encoded size of a type more efficiently.
+
+### Changed
+- `CompactAs::decode_from` now returns result. This allow for decoding to fail from their compact
+  form.
+- derive macro use literal index e.g. `#[codec(index = 15)]` instead of `#[codec(index = "15")]`
+- Version of crates `bitvec` and `generic-array` is updated.
+- `Encode::encode_to` now bounds the generic `W: Output + ?Sized` instead of `W: Output`.
+- `Output` can now be used as a trait object.
+
+### Removed
+- `EncodeAppend::append` is removed in favor of `EncodeAppend::append_or_new`.
+- `Output::push` is removed in favor of `Encode::encode_to`.
+- Some bounds on `HasCompact::Type` are removed.
+- `Error::what` is removed in favor of `Error::to_string` (implemented through trait `Display`).
+- `Error::description` is removed in favor of `Error::to_string` (implemented through trait `Display`).

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "parity-scale-codec"
 description = "SCALE - Simple Concatenating Aggregated Little Endians"
-version = "1.3.0"
+version = "2.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "Apache-2.0"
 repository = "https://github.com/paritytech/parity-scale-codec"
@@ -11,7 +11,7 @@ edition = "2018"
 [dependencies]
 arrayvec = { version = "0.5.1", default-features = false, features = ["array-sizes-33-128", "array-sizes-129-255"] }
 serde = { version = "1.0.102", optional = true }
-parity-scale-codec-derive = { path = "derive", version = "1.2.0", default-features = false, optional = true }
+parity-scale-codec-derive = { path = "derive", version = "2.0.0", default-features = false, optional = true }
 bitvec = { version = "0.20.1", default-features = false, features = ["alloc"], optional = true }
 byte-slice-cast = { version = "1.0.0", default-features = false }
 generic-array = { version = "0.14.4", optional = true }
@@ -20,7 +20,7 @@ arbitrary = { version = "0.4.1", features = ["derive"], optional = true }
 [dev-dependencies]
 criterion = "0.3.0"
 serde_derive = { version = "1.0" }
-parity-scale-codec-derive = { path = "derive", version = "^1.0.2", default-features = false }
+parity-scale-codec-derive = { path = "derive", version = "2.0.0", default-features = false }
 quickcheck = "0.9"
 
 [[bench]]

--- a/derive/Cargo.toml
+++ b/derive/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "parity-scale-codec-derive"
 description = "Serialization and deserialization derive macro for Parity SCALE Codec"
-version = "1.2.0"
+version = "2.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "Apache-2.0"
 edition = "2018"
@@ -16,4 +16,4 @@ proc-macro2 = "1.0.6"
 proc-macro-crate = "0.1.4"
 
 [dev-dependencies]
-parity-scale-codec = { path = "..", version = "1.1.0" }
+parity-scale-codec = { path = "..", version = "2.0.0" }


### PR DESCRIPTION
I upgrade substrate in a branch and all test suite pass.
I didn't do for polkadot (but the bounds change on `HasCompact::Type` has been checked with polkadot in the past)

Once this is merged I release and put tags