### PR TITLE
Hackfix for funty breaking change

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,8 @@ bitvec = { version = "0.20.1", default-features = false, features = ["alloc"], o
 byte-slice-cast = { version = "1.0.0", default-features = false }
 generic-array = { version = "0.14.4", optional = true }
 arbitrary = { version = "0.4.1", features = ["derive"], optional = true }
+# Work-around for https://github.com/myrrlyn/funty/issues/3
+funty = "=1.1"
 
 [dev-dependencies]
 criterion = "0.3.0"


### PR DESCRIPTION
Closes #249

The latest `funty` release seems to be backwards incompatible and as `bitvec` imports `functy = "1"` projects can start to break without notice. This PR doesn't address the issue but can work as a temporary solution.﻿
