### PR TITLE
Use marker trait StrictCodec to indicate strict one-to-one correspondance

### DIFF
--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -321,3 +321,36 @@ pub fn compact_as_derive(input: proc_macro::TokenStream) -> proc_macro::TokenStr
 
 	wrap_with_dummy_const(impl_block)
 }
+
+/// Derive marker trait `parity_scale_codec::StrictCodec` for struct and enum.
+#[proc_macro_derive(Strict, attributes(codec))]
+pub fn strict_derive(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
+	let mut input: DeriveInput = match syn::parse(input) {
+		Ok(input) => input,
+		Err(e) => return e.to_compile_error().into(),
+	};
+
+	if let Err(e) = utils::check_attributes(&input) {
+		return e.to_compile_error().into();
+	}
+
+	if let Err(e) = trait_bounds::add(
+		&input.ident,
+		&mut input.generics,
+		&input.data,
+		parse_quote!(_parity_scale_codec::StrictCodec),
+		None,
+		utils::has_dumb_trait_bound(&input.attrs),
+	) {
+		return e.to_compile_error().into();
+	}
+
+	let name = &input.ident;
+	let (impl_generics, ty_generics, where_clause) = input.generics.split_for_impl();
+
+	let impl_block = quote! {
+		impl #impl_generics _parity_scale_codec::StrictCodec for #name #ty_generics #where_clause {}
+	};
+
+	wrap_with_dummy_const(impl_block)
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -278,7 +278,7 @@ mod error;
 pub use self::error::Error;
 pub use self::codec::{
 	Input, Output, Decode, Encode, Codec, EncodeAsRef, WrapperTypeEncode, WrapperTypeDecode,
-	OptionBool, DecodeLength, FullCodec, FullEncode,
+	OptionBool, DecodeLength, FullCodec, FullEncode, StrictCodec,
 };
 #[cfg(feature = "std")]
 pub use self::codec::IoReader;

--- a/tests/single_field_struct_encoding.rs
+++ b/tests/single_field_struct_encoding.rs
@@ -2,10 +2,10 @@
 use parity_scale_codec_derive::{Encode, Decode, CompactAs};
 #[cfg(feature="derive")]
 use parity_scale_codec::CompactAs;
-use parity_scale_codec::{Compact, Decode, Encode, HasCompact};
+use parity_scale_codec::{Compact, Decode, Encode, HasCompact, Strict};
 use serde_derive::{Serialize, Deserialize};
 
-#[derive(Debug, PartialEq, Encode, Decode)]
+#[derive(Debug, PartialEq, Encode, Decode, Strict)]
 struct S {
 	x: u32,
 }


### PR DESCRIPTION
This is related to #251. I'd like to put this out for discussions first to see if we like this approach before writing tests and other stuff.

This introduces a marker trait `StrictCodec` (together with `derive(Strict)`). Any type implementing `StrictCodec` are supposed to have strict one-to-one correspondence. This avoids accidentally introducing those non-strict types when it matters -- for example, when we need to handle user inputs and want to have peace of mind that we can freely decode and encode stuff.