### PR TITLE
Upgrade bitvec to 0.21 to unbreak the build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,14 +4,18 @@ All notable changes to this crate are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this crate adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+- [Fixing build with latest `bitvec`/`funty`](https://github.com/paritytech/parity-scale-codec/pull/253). If you are using the `bitvec` make sure to upgrade it to `0.21.0` to for the correct traits to be implemented.
+
 ## [2.0.0] - 2021-01-26
 
 ### Added
 - `Decode::skip` allows to skip some encoded types. Pr #243
 - `Decode::encoded_fixed_size` allows to get the fixed encoded size of a type. PR #243
 - `Error` now contains a chain of causes. This full error description can also be activated on
-  no std using the feature `chain-error`. PR #242 
-- `Encode::encoded_size` allows to get the encoded size of a type more efficiently. PR #245 
+  no std using the feature `chain-error`. PR #242
+- `Encode::encoded_size` allows to get the encoded size of a type more efficiently. PR #245
 
 ### Changed
 - `CompactAs::decode_from` now returns result. This allow for decoding to fail from their compact

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ arrayvec = { version = "0.5.1", default-features = false, features = ["array-siz
 serde = { version = "1.0.102", optional = true }
 parity-scale-codec-derive = { path = "derive", version = "2.0.0", default-features = false, optional = true }
 bitvec = { version = "0.21.0", default-features = false, features = ["alloc"], optional = true }
+funty  = { version = "1.2.0", default-features = false, optional = true}
 byte-slice-cast = { version = "1.0.0", default-features = false }
 generic-array = { version = "0.14.4", optional = true }
 arbitrary = { version = "0.4.1", features = ["derive"], optional = true }
@@ -34,7 +35,7 @@ bench = false
 default = ["std"]
 derive = ["parity-scale-codec-derive"]
 std = ["serde", "bitvec/std", "byte-slice-cast/std", "chain-error"]
-bit-vec = ["bitvec"]
+bit-vec = ["bitvec", "funty"]
 fuzz = ["std", "arbitrary"]
 
 # Make error fully descriptive with chaining error message.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ edition = "2018"
 arrayvec = { version = "0.5.1", default-features = false, features = ["array-sizes-33-128", "array-sizes-129-255"] }
 serde = { version = "1.0.102", optional = true }
 parity-scale-codec-derive = { path = "derive", version = "2.0.0", default-features = false, optional = true }
-bitvec = { version = "0.20.1", default-features = false, features = ["alloc"], optional = true }
+bitvec = { version = "0.21.0", default-features = false, features = ["alloc"], optional = true }
 byte-slice-cast = { version = "1.0.0", default-features = false }
 generic-array = { version = "0.14.4", optional = true }
 arbitrary = { version = "0.4.1", features = ["derive"], optional = true }

--- a/fuzzer/Cargo.toml
+++ b/fuzzer/Cargo.toml
@@ -9,4 +9,4 @@ publish = false
 parity-scale-codec = { path = "../", features = [ "derive", "bit-vec", "fuzz" ] }
 honggfuzz = "0.5.47"
 arbitrary = { version = "0.4.1", features = ["derive"] }
-bitvec = { version = "0.20.1", features = ["alloc"] }
+bitvec = { version = "0.21.0", features = ["alloc"] }

--- a/src/bit_vec.rs
+++ b/src/bit_vec.rs
@@ -15,8 +15,10 @@
 //! `BitVec` specific serialization.
 
 use bitvec::{
-	vec::BitVec, store::BitStore, order::BitOrder, slice::BitSlice, boxed::BitBox, mem::BitMemory
+	vec::BitVec, store::BitStore, order::BitOrder, slice::BitSlice, boxed::BitBox,
 };
+use bitvec::macros::internal::funty::IsNumber;
+
 use crate::{
 	EncodeLike, Encode, Decode, Input, Output, Error, Compact,
 	codec::{decode_vec_with_len, encode_slice_no_len},
@@ -35,7 +37,7 @@ impl<O: BitOrder, T: BitStore + Encode> Encode for BitSlice<O, T> {
 		// > The returned slice handle views all elements touched by self
 		//
 		// Thus we are sure the slice doesn't contain unused elements at the end.
-		let slice = self.as_slice();
+		let slice = self.as_raw_slice();
 
 		encode_slice_no_len(slice, dest)
 	}

--- a/src/bit_vec.rs
+++ b/src/bit_vec.rs
@@ -17,7 +17,7 @@
 use bitvec::{
 	vec::BitVec, store::BitStore, order::BitOrder, slice::BitSlice, boxed::BitBox,
 };
-use bitvec::macros::internal::funty::IsNumber;
+use funty::IsNumber;
 
 use crate::{
 	EncodeLike, Encode, Decode, Input, Output, Error, Compact,


### PR DESCRIPTION
alternative to #250 .
Closes #249 .

bitvec (the reason we have funty in the dependency tree in the first place) has meanwhile released an upgraded version that solves the fix without pinning.