### PR TITLE
Backport: fix type inference in derive decode

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "parity-scale-codec"
 description = "SCALE - Simple Concatenating Aggregated Little Endians"
-version = "1.3.6"
+version = "1.3.7"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "Apache-2.0"
 repository = "https://github.com/paritytech/parity-scale-codec"
@@ -11,7 +11,7 @@ edition = "2018"
 [dependencies]
 arrayvec = { version = "0.5.1", default-features = false, features = ["array-sizes-33-128", "array-sizes-129-255"] }
 serde = { version = "1.0.102", optional = true }
-parity-scale-codec-derive = { path = "derive", version = "^1.2.2", default-features = false, optional = true }
+parity-scale-codec-derive = { path = "derive", version = "^1.2.3", default-features = false, optional = true }
 bitvec = { version = "0.17.4", default-features = false, features = ["alloc"], optional = true }
 byte-slice-cast = { version = "0.3.4", default-features = false, features = ["alloc"] }
 generic-array = { version = "0.13.2", optional = true }

--- a/derive/Cargo.toml
+++ b/derive/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "parity-scale-codec-derive"
 description = "Serialization and deserialization derive macro for Parity SCALE Codec"
-version = "1.2.2"
+version = "1.2.3"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "Apache-2.0"
 edition = "2018"

--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -194,9 +194,10 @@ pub fn decode_derive(input: proc_macro::TokenStream) -> proc_macro::TokenStream 
 
 	let name = &input.ident;
 	let (impl_generics, ty_generics, where_clause) = input.generics.split_for_impl();
+	let ty_gen_turbofish = ty_generics.as_turbofish();
 
 	let input_ = quote!(__codec_input_edqy);
-	let decoding = decode::quote(&input.data, name, &input_);
+	let decoding = decode::quote(&input.data, name, &quote!(#ty_gen_turbofish), &input_);
 
 	let impl_block = quote! {
 		impl #impl_generics _parity_scale_codec::Decode for #name #ty_generics #where_clause {

--- a/tests/type_inference.rs
+++ b/tests/type_inference.rs
@@ -1,0 +1,35 @@
+// Copyright 2021 Parity Technologies
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Test for type inference issue in decode.
+
+#[cfg(not(feature = "derive"))]
+use parity_scale_codec_derive::Decode;
+use parity_scale_codec::Decode;
+
+pub trait Trait {
+	type Value;
+	type AccountId: Decode;
+}
+
+#[derive(Decode)]
+pub enum A<T: Trait> {
+	_C(
+		(T::AccountId, T::AccountId),
+		Vec<(T::Value, T::Value)>,
+	),
+}
+
+#[derive(Decode)]
+pub struct B<T: Trait>((T::AccountId, T::AccountId), Vec<(T::Value, T::Value)>);


### PR DESCRIPTION
for now branch 1.3.7-release is exactly 1.3.6-release.

This PR will add the backport of inference fix. Then I'll publish 1.3.7 (and derive macro 1.2.3)

I executed all CI test locally and all green