### PR TITLE
Docs: Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ Following are some examples to demonstrate usage of the codec.
 ```rust
 
 use parity_scale_codec::{Encode, Decode};
+use parity_scale_codec_derive::{Encode, Decode};
 
 #[derive(Debug, PartialEq, Encode, Decode)]
 enum EnumType {
@@ -117,6 +118,7 @@ assert_eq!(EnumType::decode(&mut dz).ok(), None);
 ```rust
 
 use parity_scale_codec::{Encode, Decode, Compact, HasCompact};
+use parity_scale_codec_derive::{Encode, Decode};
 
 #[derive(Debug, PartialEq, Encode, Decode)]
 struct Test1CompactHasCompact<T: HasCompact> {


### PR DESCRIPTION
Examples did not build out of the box because derivation was not defined.