### PR TITLE
Improve macro hygiene of derives

### DIFF
--- a/derive/src/decode.rs
+++ b/derive/src/decode.rs
@@ -42,7 +42,7 @@ pub fn quote(
 			),
 			Fields::Unit => {
 				quote_spanned! { data.fields.span() =>
-					Ok(#type_name)
+					::core::result::Result::Ok(#type_name)
 				}
 			},
 		},
@@ -68,7 +68,7 @@ pub fn quote(
 				);
 
 				quote_spanned! { v.span() =>
-					__codec_x_edqy if __codec_x_edqy == #index as u8 => {
+					__codec_x_edqy if __codec_x_edqy == #index as ::core::primitive::u8 => {
 						#create
 					},
 				}
@@ -87,7 +87,7 @@ pub fn quote(
 					.map_err(|e| e.chain(#read_byte_err_msg))?
 				{
 					#( #recurse )*
-					_ => Err(#invalid_variant_err_msg.into()),
+					_ => ::core::result::Result::Err(#invalid_variant_err_msg.into()),
 				}
 			}
 
@@ -120,8 +120,8 @@ fn create_decode_expr(field: &Field, name: &str, input: &TokenStream) -> TokenSt
 					<#field_type as _parity_scale_codec::HasCompact>::Type as _parity_scale_codec::Decode
 				>::decode(#input);
 				match #res {
-					Err(e) => return Err(e.chain(#err_msg)),
-					Ok(#res) => #res.into(),
+					::core::result::Result::Err(e) => return ::core::result::Result::Err(e.chain(#err_msg)),
+					::core::result::Result::Ok(#res) => #res.into(),
 				}
 			}
 		}
@@ -130,21 +130,21 @@ fn create_decode_expr(field: &Field, name: &str, input: &TokenStream) -> TokenSt
 			{
 				let #res = <#encoded_as as _parity_scale_codec::Decode>::decode(#input);
 				match #res {
-					Err(e) => return Err(e.chain(#err_msg)),
-					Ok(#res) => #res.into(),
+					::core::result::Result::Err(e) => return ::core::result::Result::Err(e.chain(#err_msg)),
+					::core::result::Result::Ok(#res) => #res.into(),
 				}
 			}
 		}
 	} else if skip {
-		quote_spanned! { field.span() => Default::default() }
+		quote_spanned! { field.span() => ::core::default::Default::default() }
 	} else {
 		let field_type = &field.ty;
 		quote_spanned! { field.span() =>
 			{
 				let #res = <#field_type as _parity_scale_codec::Decode>::decode(#input);
 				match #res {
-					Err(e) => return Err(e.chain(#err_msg)),
-					Ok(#res) => #res,
+					::core::result::Result::Err(e) => return ::core::result::Result::Err(e.chain(#err_msg)),
+					::core::result::Result::Ok(#res) => #res,
 				}
 			}
 		}
@@ -173,7 +173,7 @@ fn create_instance(
 			});
 
 			quote_spanned! { fields.span() =>
-				Ok(#name {
+				::core::result::Result::Ok(#name {
 					#( #recurse, )*
 				})
 			}
@@ -186,14 +186,14 @@ fn create_instance(
 			});
 
 			quote_spanned! { fields.span() =>
-				Ok(#name (
+				::core::result::Result::Ok(#name (
 					#( #recurse, )*
 				))
 			}
 		},
 		Fields::Unit => {
 			quote_spanned! { fields.span() =>
-				Ok(#name)
+				::core::result::Result::Ok(#name)
 			}
 		},
 	}

--- a/derive/src/encode.rs
+++ b/derive/src/encode.rs
@@ -85,7 +85,7 @@ fn encode_single_field(
 				_parity_scale_codec::Encode::encode(&#final_field_variable)
 			}
 
-			fn using_encoded<R, F: FnOnce(&[u8]) -> R>(&#i_self, f: F) -> R {
+			fn using_encoded<R, F: ::core::ops::FnOnce(&[::core::primitive::u8]) -> R>(&#i_self, f: F) -> R {
 				_parity_scale_codec::Encode::using_encoded(&#final_field_variable, f)
 			}
 	}
@@ -240,7 +240,7 @@ fn impl_encode(data: &Data, type_name: &Ident) -> TokenStream {
 
 						quote_spanned! { f.span() =>
 							#type_name :: #name { #( ref #names, )* } => {
-								#dest.push_byte(#index as u8);
+								#dest.push_byte(#index as ::core::primitive::u8);
 								#encode_fields
 							}
 						}
@@ -265,7 +265,7 @@ fn impl_encode(data: &Data, type_name: &Ident) -> TokenStream {
 
 						quote_spanned! { f.span() =>
 							#type_name :: #name ( #( ref #names, )* ) => {
-								#dest.push_byte(#index as u8);
+								#dest.push_byte(#index as ::core::primitive::u8);
 								#encode_fields
 							}
 						}
@@ -273,7 +273,7 @@ fn impl_encode(data: &Data, type_name: &Ident) -> TokenStream {
 					Fields::Unit => {
 						quote_spanned! { f.span() =>
 							#type_name :: #name => {
-								#dest.push_byte(#index as u8);
+								#dest.push_byte(#index as ::core::primitive::u8);
 							}
 						}
 					},

--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -210,7 +210,7 @@ pub fn decode_derive(input: proc_macro::TokenStream) -> proc_macro::TokenStream 
 		impl #impl_generics _parity_scale_codec::Decode for #name #ty_generics #where_clause {
 			fn decode<__CodecInputEdqy: _parity_scale_codec::Input>(
 				#input_: &mut __CodecInputEdqy
-			) -> core::result::Result<Self, _parity_scale_codec::Error> {
+			) -> ::core::result::Result<Self, _parity_scale_codec::Error> {
 				#decoding
 			}
 		}
@@ -312,9 +312,9 @@ pub fn compact_as_derive(input: proc_macro::TokenStream) -> proc_macro::TokenStr
 				#inner_field
 			}
 			fn decode_from(x: #inner_ty)
-				-> core::result::Result<#name #ty_generics, _parity_scale_codec::Error>
+				-> ::core::result::Result<#name #ty_generics, _parity_scale_codec::Error>
 			{
-				Ok(#constructor)
+				::core::result::Result::Ok(#constructor)
 			}
 		}
 


### PR DESCRIPTION
Just a small PR to improve macro hygiene in some places where ambiguities are rare but existing.
It might be that I overlooked some code segments. Please check.

Also one question on my side: What do we need the `extern crate` code generation for exactly?