### PR TITLE
Allow lint attributes to be passed through to the impl block

### DIFF
--- a/derive/src/utils.rs
+++ b/derive/src/utils.rs
@@ -221,6 +221,14 @@ pub fn check_attributes(input: &DeriveInput) -> syn::Result<()> {
 	Ok(())
 }
 
+// Check if the attribute is `#[allow(..)]`, `#[deny(..)]`, `#[forbid(..)]` or `#[warn(..)]`.
+pub fn is_lint_attribute(attr: &Attribute) -> bool {
+	attr.path.is_ident("allow")
+		|| attr.path.is_ident("deny")
+		|| attr.path.is_ident("forbid")
+		|| attr.path.is_ident("warn")
+}
+
 // Ensure a field is decorated only with the following attributes:
 // * `#[codec(skip)]`
 // * `#[codec(compact)]`


### PR DESCRIPTION
This change would make it so that lint attributes like `#[allow(..)]` can be passed through the derive macro and be put on top of the impl block.

Stdlib's derive macros such as `Clone` already does this, so it would be weird for us to not have a similar functionality.