### PR TITLE
Bump version to 2.1.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this crate are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this crate adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [2.1.2] - 2021-06-14
+## [2.1.3] - 2021-06-14
 
 ### Changed
 - Lint attributes now pass through to the derived impls of `Encode`, `Decode` and `CompactAs`. PR #272

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -435,7 +435,7 @@ checksum = "0ab1bc2a289d34bd04a330323ac98a1b4bc82c9d9fcb1e66b63caa84da26b575"
 
 [[package]]
 name = "parity-scale-codec"
-version = "2.1.1"
+version = "2.1.3"
 dependencies = [
  "arbitrary",
  "arrayvec",
@@ -451,7 +451,7 @@ dependencies = [
 
 [[package]]
 name = "parity-scale-codec-derive"
-version = "2.1.0"
+version = "2.1.3"
 dependencies = [
  "parity-scale-codec",
  "proc-macro-crate",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "parity-scale-codec"
 description = "SCALE - Simple Concatenating Aggregated Little Endians"
-version = "2.1.2"
+version = "2.1.3"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "Apache-2.0"
 repository = "https://github.com/paritytech/parity-scale-codec"
@@ -11,7 +11,7 @@ edition = "2018"
 [dependencies]
 arrayvec = { version = "0.7", default-features = false }
 serde = { version = "1.0.102", optional = true }
-parity-scale-codec-derive = { path = "derive", version = "2.1.0", default-features = false, optional = true }
+parity-scale-codec-derive = { path = "derive", version = "2.1.3", default-features = false, optional = true }
 bitvec = { version = "0.20.1", default-features = false, features = ["alloc"], optional = true }
 byte-slice-cast = { version = "1.0.0", default-features = false }
 generic-array = { version = "0.14.4", optional = true }
@@ -20,7 +20,7 @@ arbitrary = { version = "1.0.1", features = ["derive"], optional = true }
 [dev-dependencies]
 criterion = "0.3.0"
 serde_derive = { version = "1.0" }
-parity-scale-codec-derive = { path = "derive", version = "2.1.0", default-features = false }
+parity-scale-codec-derive = { path = "derive", version = "2.1.3", default-features = false }
 quickcheck = "1.0"
 
 [[bench]]

--- a/derive/Cargo.toml
+++ b/derive/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "parity-scale-codec-derive"
 description = "Serialization and deserialization derive macro for Parity SCALE Codec"
-version = "2.1.0"
+version = "2.1.3"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "Apache-2.0"
 edition = "2018"


### PR DESCRIPTION
I made a stupid with #273 by not bumping the derive crate version, so the changes were not picked up at all by the new release. Yanked 2.1.2 and am now bumping everything to 2.1.3 properly.