### PR TITLE
Facilitate publishing by removing version in codec dev-dependency

### DIFF
--- a/derive/Cargo.toml
+++ b/derive/Cargo.toml
@@ -16,4 +16,4 @@ proc-macro2 = "1.0.6"
 proc-macro-crate = "1.0.0"
 
 [dev-dependencies]
-parity-scale-codec = { path = "..", version = "2.2.0-rc.1" }
+parity-scale-codec = { path = ".." }


### PR DESCRIPTION
Cargo will automatically strip dev-dependency for us, which removes the
need for manually doing so before publishing the crates.

See https://github.com/rust-lang/cargo/pull/7333