### PR TITLE
Improve `#[codec(crate = path)]` attribute: path, not string literal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,17 @@ and this crate adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.h
 
 ## Unreleased
 
+## [2.2.0-rc.2] - 2021-06-24
+
+- Updated syntax of `#[codec(crate = <path>)]` attribute macro: no longer expects the crate path to
+  be a string literal, but a path literal. This improves usability when used within other macros;
+  the external macro doesn't need to construct a string, but can simply do
+  `#[codec(crate = $crate::my_codec_reexport)]`.
+
 ## [2.2.0-rc.1] - 2021-06-22
 
 ### Added
+
 - `MaxEncodedLen` trait for items that have a statically known maximum encoded size. ([#268](https://github.com/paritytech/parity-scale-codec/pull/268))
 - `#[codec(crate = "<path>")]` top-level attribute to be used with the new `MaxEncodedLen`
 trait, which allows to specify a different path to the crate that contains the `MaxEncodedLen` trait.
@@ -17,11 +25,13 @@ Useful when using generating a type through a macro and this type should impleme
 ## [2.1.3] - 2021-06-14
 
 ### Changed
+
 - Lint attributes now pass through to the derived impls of `Encode`, `Decode` and `CompactAs`. PR #272
 
 ## [2.1.0] - 2021-04-06
 
 ### Fix
+
 - Add support for custom where bounds `codec(encode_bound(T: Encode))` and `codec(decode_bound(T: Decode))` when
 deriving the traits. Pr #262
 - Switch to const generics for array implementations. Pr #261
@@ -29,11 +39,13 @@ deriving the traits. Pr #262
 ## [2.0.1] - 2021-02-26
 
 ### Fix
+
 - Fix type inference issue in `Decode` derive macro. Pr #254
 
 ## [2.0.0] - 2021-01-26
 
 ### Added
+
 - `Decode::skip` allows to skip some encoded types. Pr #243
 - `Decode::encoded_fixed_size` allows to get the fixed encoded size of a type. PR #243
 - `Error` now contains a chain of causes. This full error description can also be activated on
@@ -41,6 +53,7 @@ deriving the traits. Pr #262
 - `Encode::encoded_size` allows to get the encoded size of a type more efficiently. PR #245
 
 ### Changed
+
 - `CompactAs::decode_from` now returns result. This allow for decoding to fail from their compact
   form.
 - derive macro use literal index e.g. `#[codec(index = 15)]` instead of `#[codec(index = "15")]`
@@ -49,6 +62,7 @@ deriving the traits. Pr #262
 - `Output` can now be used as a trait object.
 
 ### Removed
+
 - `EncodeAppend::append` is removed in favor of `EncodeAppend::append_or_new`.
 - `Output::push` is removed in favor of `Encode::encode_to`.
 - Some bounds on `HasCompact::Type` are removed.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,7 +38,7 @@
 //! The `Encode` trait is used for encoding of data into the SCALE format. The `Encode` trait
 //! contains the following functions:
 
-//! 
+//!
 //! * `size_hint(&self) -> usize`: Gets the capacity (in bytes) required for the encoded data.
 //! This is to avoid double-allocation of memory needed for the encoding.
 //! It can be an estimate and does not need to be an exact number.
@@ -331,14 +331,14 @@ pub use max_encoded_len::MaxEncodedLen;
 /// # Within other macros
 ///
 /// Sometimes the `MaxEncodedLen` trait and macro are used within another macro, and it can't be
-/// guaranteed that the `max_encoded_len` module is available at the call site. In that case, the
-/// macro should reexport the `max_encoded_len` module and specify the path to the reexport:
+/// guaranteed that the `parity_scale_codec` module is available at the call site. In that case, the
+/// macro should reexport the `parity_scale_codec` module and specify the path to the reexport:
 ///
 /// ```ignore
-/// pub use parity_scale_codec::max_encoded_len;
+/// pub use parity_scale_codec as codec;
 ///
 /// #[derive(Encode, MaxEncodedLen)]
-/// #[codec(crate = "$crate::max_encoded_len")]
+/// #[codec(crate = $crate::codec)]
 /// struct Example;
 /// ```
 #[cfg(feature = "derive")]

--- a/tests/max_encoded_len_ui.rs
+++ b/tests/max_encoded_len_ui.rs
@@ -21,4 +21,5 @@ fn derive_no_bound_ui() {
 
 	let t = trybuild::TestCases::new();
 	t.compile_fail("tests/max_encoded_len_ui/*.rs");
+	t.pass("tests/max_encoded_len_ui/pass/*.rs");
 }

--- a/tests/max_encoded_len_ui/crate_str.rs
+++ b/tests/max_encoded_len_ui/crate_str.rs
@@ -1,7 +1,7 @@
 use parity_scale_codec::{Encode, MaxEncodedLen};
 
 #[derive(Encode, MaxEncodedLen)]
-#[codec(frame_support::max_encoded_len)]
+#[codec(crate = "parity_scale_codec")]
 struct Example;
 
 fn main() {

--- a/tests/max_encoded_len_ui/crate_str.stderr
+++ b/tests/max_encoded_len_ui/crate_str.stderr
@@ -1,11 +1,11 @@
-error: Invalid attribute: only `#[codec(dumb_trait_bound)]`, `#[codec(encode_bound(T: Encode))]`, `#[codec(crate = "path::to::crate")]`, or `#[codec(decode_bound(T: Decode))]` are accepted as top attribute
- --> $DIR/list_list_item.rs:4:9
+error: Invalid attribute: only `#[codec(dumb_trait_bound)]`, `#[codec(encode_bound(T: Encode))]`, `#[codec(crate = path::to::crate)]`, or `#[codec(decode_bound(T: Decode))]` are accepted as top attribute
+ --> $DIR/crate_str.rs:4:9
   |
-4 | #[codec(crate = "foo()")]
+4 | #[codec(crate = "parity_scale_codec")]
   |         ^^^^^
 
 error[E0277]: the trait bound `Example: WrapperTypeEncode` is not satisfied
-  --> $DIR/list_list_item.rs:3:18
+  --> $DIR/crate_str.rs:3:18
    |
 3  | #[derive(Encode, MaxEncodedLen)]
    |                  ^^^^^^^^^^^^^ the trait `WrapperTypeEncode` is not implemented for `Example`

--- a/tests/max_encoded_len_ui/incomplete_attr.stderr
+++ b/tests/max_encoded_len_ui/incomplete_attr.stderr
@@ -1,4 +1,4 @@
-error: Invalid attribute: only `#[codec(dumb_trait_bound)]`, `#[codec(encode_bound(T: Encode))]`, `#[codec(crate = "path::to::crate")]`, or `#[codec(decode_bound(T: Decode))]` are accepted as top attribute
+error: Invalid attribute: only `#[codec(dumb_trait_bound)]`, `#[codec(encode_bound(T: Encode))]`, `#[codec(crate = path::to::crate)]`, or `#[codec(decode_bound(T: Decode))]` are accepted as top attribute
  --> $DIR/incomplete_attr.rs:4:9
   |
 4 | #[codec(crate)]

--- a/tests/max_encoded_len_ui/missing_crate_specifier.rs
+++ b/tests/max_encoded_len_ui/missing_crate_specifier.rs
@@ -1,7 +1,7 @@
 use parity_scale_codec::{Encode, MaxEncodedLen};
 
 #[derive(Encode, MaxEncodedLen)]
-#[codec(crate = "foo()")]
+#[codec(parity_scale_codec)]
 struct Example;
 
 fn main() {

--- a/tests/max_encoded_len_ui/missing_crate_specifier.stderr
+++ b/tests/max_encoded_len_ui/missing_crate_specifier.stderr
@@ -1,11 +1,11 @@
-error: Invalid attribute: only `#[codec(dumb_trait_bound)]`, `#[codec(encode_bound(T: Encode))]`, `#[codec(crate = "path::to::crate")]`, or `#[codec(decode_bound(T: Decode))]` are accepted as top attribute
- --> $DIR/path_list_item.rs:4:9
+error: Invalid attribute: only `#[codec(dumb_trait_bound)]`, `#[codec(encode_bound(T: Encode))]`, `#[codec(crate = path::to::crate)]`, or `#[codec(decode_bound(T: Decode))]` are accepted as top attribute
+ --> $DIR/missing_crate_specifier.rs:4:9
   |
-4 | #[codec(frame_support::max_encoded_len)]
-  |         ^^^^^^^^^^^^^
+4 | #[codec(parity_scale_codec)]
+  |         ^^^^^^^^^^^^^^^^^^
 
 error[E0277]: the trait bound `Example: WrapperTypeEncode` is not satisfied
-  --> $DIR/path_list_item.rs:3:18
+  --> $DIR/missing_crate_specifier.rs:3:18
    |
 3  | #[derive(Encode, MaxEncodedLen)]
    |                  ^^^^^^^^^^^^^ the trait `WrapperTypeEncode` is not implemented for `Example`

--- a/tests/max_encoded_len_ui/pass/codec_crate.rs
+++ b/tests/max_encoded_len_ui/pass/codec_crate.rs
@@ -1,6 +1,6 @@
-use parity_scale_codec::{self as codec, Encode, MaxEncodedLen};
-
 //! This test case demonstrates correct use of the `#[codec(crate = path)]` attribute.
+
+use parity_scale_codec::{self as codec, Encode, MaxEncodedLen};
 
 #[derive(Encode, MaxEncodedLen)]
 #[codec(crate = codec)]

--- a/tests/max_encoded_len_ui/pass/codec_crate.rs
+++ b/tests/max_encoded_len_ui/pass/codec_crate.rs
@@ -1,0 +1,11 @@
+use parity_scale_codec::{self as codec, Encode, MaxEncodedLen};
+
+//! This test case demonstrates correct use of the `#[codec(crate = path)]` attribute.
+
+#[derive(Encode, MaxEncodedLen)]
+#[codec(crate = codec)]
+struct Example;
+
+fn main() {
+	let _ = Example::max_encoded_len();
+}


### PR DESCRIPTION
Accepting a path instead of a string literal makes life easier for
the downstream macros which need to actually use that attribute.