### PR TITLE
Support custom trait bounds on MaxEncodedLen derive macro

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this crate adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.h
 
 ## Unreleased
 
+## [2.2.0-rc.3] - 2021-06-25
+- Add support for custom where bounds `codec(mel_bound(T: MaxEncodedLen))` when deriving the traits. PR #279
+
 ## [2.2.0-rc.2] - 2021-06-24
 
 - Updated syntax of `#[codec(crate = <path>)]` attribute macro: no longer expects the crate path to

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -452,7 +452,7 @@ checksum = "0ab1bc2a289d34bd04a330323ac98a1b4bc82c9d9fcb1e66b63caa84da26b575"
 
 [[package]]
 name = "parity-scale-codec"
-version = "2.2.0-rc.2"
+version = "2.2.0-rc.3"
 dependencies = [
  "arbitrary",
  "arrayvec",
@@ -470,7 +470,7 @@ dependencies = [
 
 [[package]]
 name = "parity-scale-codec-derive"
-version = "2.2.0-rc.2"
+version = "2.2.0-rc.3"
 dependencies = [
  "parity-scale-codec",
  "proc-macro-crate",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "parity-scale-codec"
 description = "SCALE - Simple Concatenating Aggregated Little Endians"
-version = "2.2.0-rc.2"
+version = "2.2.0-rc.3"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "Apache-2.0"
 repository = "https://github.com/paritytech/parity-scale-codec"
@@ -11,7 +11,7 @@ edition = "2018"
 [dependencies]
 arrayvec = { version = "0.7", default-features = false }
 serde = { version = "1.0.102", optional = true }
-parity-scale-codec-derive = { path = "derive", version = "2.2.0-rc.2", default-features = false, optional = true }
+parity-scale-codec-derive = { path = "derive", version = "2.2.0-rc.3", default-features = false, optional = true }
 bitvec = { version = "0.20.1", default-features = false, features = ["alloc"], optional = true }
 byte-slice-cast = { version = "1.0.0", default-features = false }
 generic-array = { version = "0.14.4", optional = true }

--- a/derive/Cargo.toml
+++ b/derive/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "parity-scale-codec-derive"
 description = "Serialization and deserialization derive macro for Parity SCALE Codec"
-version = "2.2.0-rc.2"
+version = "2.2.0-rc.3"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "Apache-2.0"
 edition = "2018"

--- a/derive/src/max_encoded_len.rs
+++ b/derive/src/max_encoded_len.rs
@@ -13,7 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::utils::codec_crate_path;
+use crate::utils::{self, codec_crate_path, custom_mel_trait_bound};
 use quote::{quote, quote_spanned};
 use syn::{
 	Data, DeriveInput, Fields, GenericParam, Generics, TraitBound, Type, TypeParamBound,
@@ -33,7 +33,11 @@ pub fn derive_max_encoded_len(input: proc_macro::TokenStream) -> proc_macro::Tok
 	};
 
 	let name = &input.ident;
-	let generics = add_trait_bounds(input.generics, mel_trait.clone());
+	let generics = if let Some(custom_bound) = custom_mel_trait_bound(&input.attrs) {
+		add_custom_trait_bounds(input.generics, custom_bound)
+	} else {
+		add_trait_bounds(input.generics, mel_trait.clone())
+	};
 	let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
 
 	let data_expr = data_length_expr(&input.data);
@@ -62,6 +66,12 @@ fn add_trait_bounds(mut generics: Generics, mel_trait: TraitBound) -> Generics {
 			type_param.bounds.push(TypeParamBound::Trait(mel_trait.clone()));
 		}
 	}
+	generics
+}
+
+// Add custom trait bounds to the type parameters as specified by the user.
+fn add_custom_trait_bounds(mut generics: Generics, custom_bound: utils::TraitBounds) -> Generics {
+	generics.make_where_clause().predicates.extend(custom_bound);
 	generics
 }
 
@@ -124,7 +134,7 @@ fn data_length_expr(data: &Data) -> proc_macro2::TokenStream {
 		Data::Union(ref data) => {
 			// https://github.com/paritytech/parity-scale-codec/
 			//   blob/f0341dabb01aa9ff0548558abb6dcc5c31c669a1/derive/src/encode.rs#L290-L293
-			syn::Error::new(data.union_token.span(), "Union types are not supported")
+			syn::Error::new(data.union_token.span(), "Union types are not supported.")
 				.to_compile_error()
 		}
 	}

--- a/derive/src/utils.rs
+++ b/derive/src/utils.rs
@@ -201,8 +201,9 @@ impl<N: Parse> Parse for CustomTraitBound<N> {
 
 syn::custom_keyword!(encode_bound);
 syn::custom_keyword!(decode_bound);
+syn::custom_keyword!(mel_bound);
 
-/// Look for a `#[codec(decode_bound(T: Decode))]`in the given attributes.
+/// Look for a `#[codec(decode_bound(T: Decode))]` in the given attributes.
 ///
 /// If found, it should be used as trait bounds when deriving the `Decode` trait.
 pub fn custom_decode_trait_bound(attrs: &[Attribute]) -> Option<TraitBounds> {
@@ -211,11 +212,20 @@ pub fn custom_decode_trait_bound(attrs: &[Attribute]) -> Option<TraitBounds> {
 	})
 }
 
-/// Look for a `#[codec(encode_bound(T: Encode))]`in the given attributes.
+/// Look for a `#[codec(encode_bound(T: Encode))]` in the given attributes.
 ///
 /// If found, it should be used as trait bounds when deriving the `Encode` trait.
 pub fn custom_encode_trait_bound(attrs: &[Attribute]) -> Option<TraitBounds> {
 	find_meta_item(attrs.iter(), |meta: CustomTraitBound<encode_bound>| {
+		Some(meta.bounds)
+	})
+}
+
+/// Look for a `#[codec(mel_bound(T: MaxEncodedLen))]` in the given attributes.
+///
+/// If found, it should be used as the trait bounds when deriving the `MaxEncodedLen` trait.
+pub fn custom_mel_trait_bound(attrs: &[Attribute]) -> Option<TraitBounds> {
+	find_meta_item(attrs.iter(), |meta: CustomTraitBound<mel_bound>| {
 		Some(meta.bounds)
 	})
 }
@@ -242,6 +252,9 @@ pub fn filter_skip_unnamed<'a>(fields: &'a syn::FieldsUnnamed) -> impl Iterator<
 /// The top level can have the following attributes:
 ///
 /// * `#[codec(dumb_trait_bound)]`
+/// * `#[codec(encode_bound(T: Encode))]`
+/// * `#[codec(decode_bound(T: Decode))]`
+/// * `#[codec(mel_bound(T: MaxEncodedLen))]`
 /// * `#[codec(crate = path::to::crate)]
 ///
 /// Fields can have the following attributes:
@@ -361,11 +374,13 @@ fn check_variant_attribute(attr: &Attribute) -> syn::Result<()> {
 // Only `#[codec(dumb_trait_bound)]` is accepted as top attribute
 fn check_top_attribute(attr: &Attribute) -> syn::Result<()> {
 	let top_error = "Invalid attribute: only `#[codec(dumb_trait_bound)]`, \
-		`#[codec(encode_bound(T: Encode))]`, `#[codec(crate = path::to::crate)]`, or \
-		`#[codec(decode_bound(T: Decode))]` are accepted as top attribute";
+		`#[codec(encode_bound(T: Encode))]`, `#[codec(crate = path::to::crate)]`, \
+		`#[codec(decode_bound(T: Decode))]`, or `#[codec(mel_bound(T: MaxEncodedLen))]` \
+		are accepted as top attribute";
 	if attr.path.is_ident("codec")
 		&& attr.parse_args::<CustomTraitBound<encode_bound>>().is_err()
 		&& attr.parse_args::<CustomTraitBound<decode_bound>>().is_err()
+		&& attr.parse_args::<CustomTraitBound<mel_bound>>().is_err()
 		&& codec_crate_path_inner(attr).is_none()
 	{
 		match attr.parse_meta()? {

--- a/derive/src/utils.rs
+++ b/derive/src/utils.rs
@@ -374,7 +374,7 @@ fn check_variant_attribute(attr: &Attribute) -> syn::Result<()> {
 // Only `#[codec(dumb_trait_bound)]` is accepted as top attribute
 fn check_top_attribute(attr: &Attribute) -> syn::Result<()> {
 	let top_error = "Invalid attribute: only `#[codec(dumb_trait_bound)]`, \
-		`#[codec(encode_bound(T: Encode))]`, `#[codec(crate = path::to::crate)]`, \
+		`#[codec(crate = path::to::crate)]`, `#[codec(encode_bound(T: Encode))]`, \
 		`#[codec(decode_bound(T: Decode))]`, or `#[codec(mel_bound(T: MaxEncodedLen))]` \
 		are accepted as top attribute";
 	if attr.path.is_ident("codec")

--- a/tests/max_encoded_len_ui/crate_str.stderr
+++ b/tests/max_encoded_len_ui/crate_str.stderr
@@ -1,4 +1,4 @@
-error: Invalid attribute: only `#[codec(dumb_trait_bound)]`, `#[codec(encode_bound(T: Encode))]`, `#[codec(crate = path::to::crate)]`, or `#[codec(decode_bound(T: Decode))]` are accepted as top attribute
+error: Invalid attribute: only `#[codec(dumb_trait_bound)]`, `#[codec(encode_bound(T: Encode))]`, `#[codec(crate = path::to::crate)]`, `#[codec(decode_bound(T: Decode))]`, or `#[codec(mel_bound(T: MaxEncodedLen))]` are accepted as top attribute
  --> $DIR/crate_str.rs:4:9
   |
 4 | #[codec(crate = "parity_scale_codec")]

--- a/tests/max_encoded_len_ui/crate_str.stderr
+++ b/tests/max_encoded_len_ui/crate_str.stderr
@@ -1,4 +1,4 @@
-error: Invalid attribute: only `#[codec(dumb_trait_bound)]`, `#[codec(encode_bound(T: Encode))]`, `#[codec(crate = path::to::crate)]`, `#[codec(decode_bound(T: Decode))]`, or `#[codec(mel_bound(T: MaxEncodedLen))]` are accepted as top attribute
+error: Invalid attribute: only `#[codec(dumb_trait_bound)]`, `#[codec(crate = path::to::crate)]`, `#[codec(encode_bound(T: Encode))]`, `#[codec(decode_bound(T: Decode))]`, or `#[codec(mel_bound(T: MaxEncodedLen))]` are accepted as top attribute
  --> $DIR/crate_str.rs:4:9
   |
 4 | #[codec(crate = "parity_scale_codec")]

--- a/tests/max_encoded_len_ui/incomplete_attr.stderr
+++ b/tests/max_encoded_len_ui/incomplete_attr.stderr
@@ -1,4 +1,4 @@
-error: Invalid attribute: only `#[codec(dumb_trait_bound)]`, `#[codec(encode_bound(T: Encode))]`, `#[codec(crate = path::to::crate)]`, `#[codec(decode_bound(T: Decode))]`, or `#[codec(mel_bound(T: MaxEncodedLen))]` are accepted as top attribute
+error: Invalid attribute: only `#[codec(dumb_trait_bound)]`, `#[codec(crate = path::to::crate)]`, `#[codec(encode_bound(T: Encode))]`, `#[codec(decode_bound(T: Decode))]`, or `#[codec(mel_bound(T: MaxEncodedLen))]` are accepted as top attribute
  --> $DIR/incomplete_attr.rs:4:9
   |
 4 | #[codec(crate)]

--- a/tests/max_encoded_len_ui/incomplete_attr.stderr
+++ b/tests/max_encoded_len_ui/incomplete_attr.stderr
@@ -1,4 +1,4 @@
-error: Invalid attribute: only `#[codec(dumb_trait_bound)]`, `#[codec(encode_bound(T: Encode))]`, `#[codec(crate = path::to::crate)]`, or `#[codec(decode_bound(T: Decode))]` are accepted as top attribute
+error: Invalid attribute: only `#[codec(dumb_trait_bound)]`, `#[codec(encode_bound(T: Encode))]`, `#[codec(crate = path::to::crate)]`, `#[codec(decode_bound(T: Decode))]`, or `#[codec(mel_bound(T: MaxEncodedLen))]` are accepted as top attribute
  --> $DIR/incomplete_attr.rs:4:9
   |
 4 | #[codec(crate)]

--- a/tests/max_encoded_len_ui/missing_crate_specifier.stderr
+++ b/tests/max_encoded_len_ui/missing_crate_specifier.stderr
@@ -1,4 +1,4 @@
-error: Invalid attribute: only `#[codec(dumb_trait_bound)]`, `#[codec(encode_bound(T: Encode))]`, `#[codec(crate = path::to::crate)]`, `#[codec(decode_bound(T: Decode))]`, or `#[codec(mel_bound(T: MaxEncodedLen))]` are accepted as top attribute
+error: Invalid attribute: only `#[codec(dumb_trait_bound)]`, `#[codec(crate = path::to::crate)]`, `#[codec(encode_bound(T: Encode))]`, `#[codec(decode_bound(T: Decode))]`, or `#[codec(mel_bound(T: MaxEncodedLen))]` are accepted as top attribute
  --> $DIR/missing_crate_specifier.rs:4:9
   |
 4 | #[codec(parity_scale_codec)]

--- a/tests/max_encoded_len_ui/missing_crate_specifier.stderr
+++ b/tests/max_encoded_len_ui/missing_crate_specifier.stderr
@@ -1,4 +1,4 @@
-error: Invalid attribute: only `#[codec(dumb_trait_bound)]`, `#[codec(encode_bound(T: Encode))]`, `#[codec(crate = path::to::crate)]`, or `#[codec(decode_bound(T: Decode))]` are accepted as top attribute
+error: Invalid attribute: only `#[codec(dumb_trait_bound)]`, `#[codec(encode_bound(T: Encode))]`, `#[codec(crate = path::to::crate)]`, `#[codec(decode_bound(T: Decode))]`, or `#[codec(mel_bound(T: MaxEncodedLen))]` are accepted as top attribute
  --> $DIR/missing_crate_specifier.rs:4:9
   |
 4 | #[codec(parity_scale_codec)]

--- a/tests/max_encoded_len_ui/union.stderr
+++ b/tests/max_encoded_len_ui/union.stderr
@@ -3,9 +3,3 @@ error: Union types are not supported.
   |
 4 | union Union {
   | ^^^^^
-
-error: Union types are not supported
- --> $DIR/union.rs:4:1
-  |
-4 | union Union {
-  | ^^^^^


### PR DESCRIPTION
As discussed in paritytech/substrate#9180.