### PR TITLE
Bump version to 2.2.0 and hide `MaxEncodedLen` behind an additional crate feature

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -81,7 +81,7 @@ test-rust-stable:
   stage:                           test
   <<:                              *docker-env
   script:
-    - time cargo +stable test --verbose --all --features bit-vec,generic-array,derive
+    - time cargo +stable test --verbose --all --features bit-vec,generic-array,derive,max-encoded-len
     - sccache -s
 
 test-rust-stable-no_derive:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -452,7 +452,7 @@ checksum = "0ab1bc2a289d34bd04a330323ac98a1b4bc82c9d9fcb1e66b63caa84da26b575"
 
 [[package]]
 name = "parity-scale-codec"
-version = "2.2.0-rc.3"
+version = "2.2.0"
 dependencies = [
  "arbitrary",
  "arrayvec",
@@ -470,7 +470,7 @@ dependencies = [
 
 [[package]]
 name = "parity-scale-codec-derive"
-version = "2.2.0-rc.3"
+version = "2.2.0"
 dependencies = [
  "parity-scale-codec",
  "proc-macro-crate",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "parity-scale-codec"
 description = "SCALE - Simple Concatenating Aggregated Little Endians"
-version = "2.2.0-rc.3"
+version = "2.2.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "Apache-2.0"
 repository = "https://github.com/paritytech/parity-scale-codec"
@@ -11,7 +11,7 @@ edition = "2018"
 [dependencies]
 arrayvec = { version = "0.7", default-features = false }
 serde = { version = "1.0.102", optional = true }
-parity-scale-codec-derive = { path = "derive", version = "2.2.0-rc.3", default-features = false, optional = true }
+parity-scale-codec-derive = { path = "derive", version = "2.2.0", default-features = false, optional = true }
 bitvec = { version = "0.20.1", default-features = false, features = ["alloc"], optional = true }
 byte-slice-cast = { version = "1.0.0", default-features = false }
 generic-array = { version = "0.14.4", optional = true }
@@ -21,7 +21,7 @@ impl-trait-for-tuples = "0.2.1"
 [dev-dependencies]
 criterion = "0.3.0"
 serde_derive = { version = "1.0" }
-parity-scale-codec-derive = { path = "derive", version = "2.2.0-rc.1", default-features = false }
+parity-scale-codec-derive = { path = "derive", default-features = false }
 quickcheck = "1.0"
 trybuild = "1.0.42"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,11 @@ std = ["serde", "bitvec/std", "byte-slice-cast/std", "chain-error"]
 bit-vec = ["bitvec"]
 fuzz = ["std", "arbitrary"]
 
+# Enables the new `MaxEncodedLen` trait.
+# NOTE: This is still considered experimental and is exempt from the usual
+# SemVer guarantees. We do not guarantee no code breakage when using this.
+max-encoded-len = ["parity-scale-codec-derive/max-encoded-len"]
+
 # Make error fully descriptive with chaining error message.
 # Should not be used in a constrained environment.
 chain-error = []

--- a/derive/Cargo.toml
+++ b/derive/Cargo.toml
@@ -17,3 +17,9 @@ proc-macro-crate = "1.0.0"
 
 [dev-dependencies]
 parity-scale-codec = { path = ".." }
+
+[features]
+# Enables the new `MaxEncodedLen` trait.
+# NOTE: This is still considered experimental and is exempt from the usual
+# SemVer guarantees. We do not guarantee no code breakage when using this.
+max-encoded-len = []

--- a/derive/Cargo.toml
+++ b/derive/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "parity-scale-codec-derive"
 description = "Serialization and deserialization derive macro for Parity SCALE Codec"
-version = "2.2.0-rc.3"
+version = "2.2.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "Apache-2.0"
 edition = "2018"

--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -336,6 +336,7 @@ pub fn compact_as_derive(input: proc_macro::TokenStream) -> proc_macro::TokenStr
 }
 
 /// Derive `MaxEncodedLen`.
+#[cfg(feature = "max-encoded-len")]
 #[proc_macro_derive(MaxEncodedLen, attributes(max_encoded_len_mod))]
 pub fn derive_max_encoded_len(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
 	max_encoded_len::derive_max_encoded_len(input)

--- a/derive/src/max_encoded_len.rs
+++ b/derive/src/max_encoded_len.rs
@@ -13,6 +13,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#![cfg(feature = "max-encoded-len")]
+
 use crate::utils::{self, codec_crate_path, custom_mel_trait_bound};
 use quote::{quote, quote_spanned};
 use syn::{

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -281,6 +281,7 @@ mod depth_limit;
 mod encode_append;
 mod encode_like;
 mod error;
+#[cfg(feature = "max-encoded-len")]
 mod max_encoded_len;
 
 pub use self::error::Error;
@@ -297,6 +298,7 @@ pub use self::decode_all::DecodeAll;
 pub use self::depth_limit::DecodeLimit;
 pub use self::encode_append::EncodeAppend;
 pub use self::encode_like::{EncodeLike, Ref};
+#[cfg(feature = "max-encoded-len")]
 pub use max_encoded_len::MaxEncodedLen;
 /// Derive macro for [`MaxEncodedLen`][max_encoded_len::MaxEncodedLen].
 ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -343,5 +343,5 @@ pub use max_encoded_len::MaxEncodedLen;
 /// #[codec(crate = $crate::codec)]
 /// struct Example;
 /// ```
-#[cfg(feature = "derive")]
+#[cfg(all(feature = "derive", feature = "max-encoded-len"))]
 pub use parity_scale_codec_derive::MaxEncodedLen;

--- a/src/max_encoded_len.rs
+++ b/src/max_encoded_len.rs
@@ -15,6 +15,8 @@
 
 //! `trait MaxEncodedLen` bounds the maximum encoded length of items.
 
+#![cfg(feature = "max-encoded-len")]
+
 use crate::{Compact, Encode};
 use impl_trait_for_tuples::impl_for_tuples;
 use core::{mem, marker::PhantomData};

--- a/src/max_encoded_len.rs
+++ b/src/max_encoded_len.rs
@@ -15,8 +15,6 @@
 
 //! `trait MaxEncodedLen` bounds the maximum encoded length of items.
 
-#![cfg(feature = "max-encoded-len")]
-
 use crate::{Compact, Encode};
 use impl_trait_for_tuples::impl_for_tuples;
 use core::{mem, marker::PhantomData};


### PR DESCRIPTION
Implemented the scheme outlined in https://github.com/paritytech/parity-common/pull/552#issuecomment-872252537.

This avoids the required otherwise cascade bumps across https://github.com/paritytech/parity-common which is something that I didn't consider at first due to the requirement of explicitly selecting pre-releases. Thanks to that, other dependencies can keep on depending on `^2` or `^2.1` versions of the codec, while the only crate outside of the Substrate workspace, which is `primitive-types -> impl-codec`, can just opt-in to `max-encoded-len` and directly implement the new trait. Since the trait definition is somewhat stable and FWIU only related new attributes require some more polish, this will probably not cause any breakages.

Tested locally https://github.com/paritytech/substrate/pull/9163 and it's looking good so far.