### PR TITLE
User core2 for no_std io support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -140,6 +140,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28b9d6de7f49e22cf97ad17fc4036ece69300032f45f78f30b4a4482cdc3f4a6"
 
 [[package]]
+name = "core2"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbceae1ad0d3679d016526dd5cc9863156e9d394c1a9591cf7ab20bb25cab490"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "criterion"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -458,6 +467,7 @@ dependencies = [
  "arrayvec",
  "bitvec",
  "byte-slice-cast",
+ "core2",
  "criterion",
  "generic-array",
  "impl-trait-for-tuples",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,13 +10,14 @@ edition = "2018"
 
 [dependencies]
 arrayvec = { version = "0.7", default-features = false }
-serde = { version = "1.0.102", optional = true }
+serde = { version = "1.0.102", optional = true, default-features = false }
 parity-scale-codec-derive = { path = "derive", version = "2.2.0", default-features = false, optional = true }
 bitvec = { version = "0.20.1", default-features = false, features = ["alloc"], optional = true }
 byte-slice-cast = { version = "1.0.0", default-features = false }
 generic-array = { version = "0.14.4", optional = true }
 arbitrary = { version = "1.0.1", features = ["derive"], optional = true }
 impl-trait-for-tuples = "0.2.1"
+core2 = { version = "0.3.1", default-features = false, features = ["alloc"] }
 
 [dev-dependencies]
 criterion = "0.3.0"
@@ -33,9 +34,9 @@ harness = false
 bench = false
 
 [features]
-default = ["std"]
+default = ["std", "serde"]
 derive = ["parity-scale-codec-derive"]
-std = ["serde", "bitvec/std", "byte-slice-cast/std", "chain-error"]
+std = ["serde/std", "bitvec/std", "byte-slice-cast/std", "chain-error", "core2/std"]
 bit-vec = ["bitvec"]
 fuzz = ["std", "arbitrary"]
 

--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ assert_eq!(<Test1CompactHasCompact<u64>>::decode(&mut &encoded[..]).unwrap().bar
 use serde_derive::{Serialize, Deserialize};
 use parity_scale_codec::{Encode, Decode, Compact, HasCompact, CompactAs, Error};
 
-#[cfg_attr(feature = "std", derive(Serialize, Deserialize, Debug))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize, Debug))]
 #[derive(PartialEq, Eq, Clone)]
 struct StructHasCompact(u32);
 

--- a/src/compact.rs
+++ b/src/compact.rs
@@ -192,14 +192,14 @@ impl<T> core::fmt::Debug for Compact<T> where T: core::fmt::Debug {
 	}
 }
 
-#[cfg(feature = "std")]
+#[cfg(feature = "serde")]
 impl<T> serde::Serialize for Compact<T> where T: serde::Serialize {
 	fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error> where S: serde::Serializer {
 		T::serialize(&self.0, serializer)
 	}
 }
 
-#[cfg(feature = "std")]
+#[cfg(feature = "serde")]
 impl<'de, T> serde::Deserialize<'de> for Compact<T> where T: serde::Deserialize<'de> {
 	fn deserialize<D>(deserializer: D) -> Result<Self, D::Error> where D: serde::Deserializer<'de> {
 		T::deserialize(deserializer).map(Compact)
@@ -752,7 +752,7 @@ mod tests {
 		}
 	}
 
-	#[cfg_attr(feature = "std", derive(Serialize, Deserialize, Debug))]
+	#[cfg_attr(feature = "serde", derive(Serialize, Deserialize, Debug))]
 	#[derive(PartialEq, Eq, Clone)]
 	struct Wrapper(u8);
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -179,7 +179,7 @@
 //! use serde_derive::{Serialize, Deserialize};
 //! use parity_scale_codec::{Encode, Decode, Compact, HasCompact, CompactAs, Error};
 //!
-//! #[cfg_attr(feature = "std", derive(Serialize, Deserialize, Debug))]
+//! #[cfg_attr(feature = "serde", derive(Serialize, Deserialize, Debug))]
 //! #[derive(PartialEq, Eq, Clone)]
 //! struct StructHasCompact(u32);
 //!
@@ -249,7 +249,7 @@ pub extern crate alloc;
 #[macro_use]
 extern crate parity_scale_codec_derive;
 
-#[cfg(all(feature = "std", test))]
+#[cfg(all(feature = "serde", test))]
 #[macro_use]
 extern crate serde_derive;
 
@@ -289,7 +289,6 @@ pub use self::codec::{
 	Input, Output, Decode, Encode, Codec, EncodeAsRef, WrapperTypeEncode, WrapperTypeDecode,
 	OptionBool, DecodeLength, FullCodec, FullEncode,
 };
-#[cfg(feature = "std")]
 pub use self::codec::IoReader;
 pub use self::compact::{Compact, HasCompact, CompactAs, CompactLen};
 pub use self::joiner::Joiner;

--- a/tests/mod.rs
+++ b/tests/mod.rs
@@ -368,7 +368,7 @@ fn generic_bound_encoded_as() {
 
 #[test]
 fn generic_bound_hascompact() {
-	#[cfg_attr(feature = "std", derive(Serialize, Deserialize, Debug))]
+	#[cfg_attr(feature = "serde", derive(Serialize, Deserialize, Debug))]
 	#[derive(PartialEq, Eq, Clone)]
 	// This struct does not impl Codec
 	struct StructHasCompact(u32);

--- a/tests/single_field_struct_encoding.rs
+++ b/tests/single_field_struct_encoding.rs
@@ -10,7 +10,7 @@ struct S {
 	x: u32,
 }
 
-#[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Debug, PartialEq, Eq, Clone, Copy, Encode, Decode, CompactAs)]
 struct SSkip {
 	#[codec(skip)]
@@ -32,15 +32,15 @@ struct Sh<T: HasCompact> {
 	x: T,
 }
 
-#[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Debug, PartialEq, Eq, Clone, Copy, Encode, Decode, CompactAs)]
 struct U(u32);
 
-#[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Debug, PartialEq, Eq, Clone, Copy, Encode, Decode, CompactAs)]
 struct U2 { a: u64 }
 
-#[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Debug, PartialEq, Eq, Clone, Copy, Encode, Decode, CompactAs)]
 struct USkip(#[codec(skip)] u32, u32, #[codec(skip)] u32);
 


### PR DESCRIPTION
The [core2](https://crates.io/crates/core2) crate is usefull for no_std deployments as it implements the common `io` traits and uses `std::io` when `std` support is enabled.