### PR TITLE
Minor codegen hygiene improvements and modernizations

### DIFF
--- a/derive/src/decode.rs
+++ b/derive/src/decode.rs
@@ -111,13 +111,14 @@ fn create_decode_expr(field: &Field, name: &str, input: &TokenStream) -> TokenSt
 	}
 
 	let err_msg = format!("Could not decode `{}`", name);
+	let crate_ident = crate::parity_scale_codec_ident();
 
 	if compact {
 		let field_type = &field.ty;
 		quote_spanned! { field.span() =>
 			{
 				let #res = <
-					<#field_type as _parity_scale_codec::HasCompact>::Type as _parity_scale_codec::Decode
+					<#field_type as #crate_ident::HasCompact>::Type as #crate_ident::Decode
 				>::decode(#input);
 				match #res {
 					::core::result::Result::Err(e) => return ::core::result::Result::Err(e.chain(#err_msg)),
@@ -128,7 +129,7 @@ fn create_decode_expr(field: &Field, name: &str, input: &TokenStream) -> TokenSt
 	} else if let Some(encoded_as) = encoded_as {
 		quote_spanned! { field.span() =>
 			{
-				let #res = <#encoded_as as _parity_scale_codec::Decode>::decode(#input);
+				let #res = <#encoded_as as #crate_ident::Decode>::decode(#input);
 				match #res {
 					::core::result::Result::Err(e) => return ::core::result::Result::Err(e.chain(#err_msg)),
 					::core::result::Result::Ok(#res) => #res.into(),
@@ -141,7 +142,7 @@ fn create_decode_expr(field: &Field, name: &str, input: &TokenStream) -> TokenSt
 		let field_type = &field.ty;
 		quote_spanned! { field.span() =>
 			{
-				let #res = <#field_type as _parity_scale_codec::Decode>::decode(#input);
+				let #res = <#field_type as #crate_ident::Decode>::decode(#input);
 				match #res {
 					::core::result::Result::Err(e) => return ::core::result::Result::Err(e.chain(#err_msg)),
 					::core::result::Result::Ok(#res) => #res,

--- a/derive/src/encode.rs
+++ b/derive/src/encode.rs
@@ -48,12 +48,14 @@ fn encode_single_field(
 		).to_compile_error();
 	}
 
+	let crate_ident = crate::parity_scale_codec_ident();
+
 	let final_field_variable = if compact {
 		let field_type = &field.ty;
 		quote_spanned! {
 			field.span() => {
-				<<#field_type as _parity_scale_codec::HasCompact>::Type as
-					_parity_scale_codec::EncodeAsRef<'_, #field_type>>::RefType::from(#field_name)
+				<<#field_type as #crate_ident::HasCompact>::Type as
+				#crate_ident::EncodeAsRef<'_, #field_type>>::RefType::from(#field_name)
 			}
 		}
 	} else if let Some(encoded_as) = encoded_as {
@@ -61,7 +63,7 @@ fn encode_single_field(
 		quote_spanned! {
 			field.span() => {
 				<#encoded_as as
-					_parity_scale_codec::EncodeAsRef<'_, #field_type>>::RefType::from(#field_name)
+				#crate_ident::EncodeAsRef<'_, #field_type>>::RefType::from(#field_name)
 			}
 		}
 	} else {
@@ -74,19 +76,19 @@ fn encode_single_field(
 	let i_self = quote! { self };
 
 	quote_spanned! { field.span() =>
-			fn encode_to<__CodecOutputEdqy: _parity_scale_codec::Output + ?::core::marker::Sized>(
+			fn encode_to<__CodecOutputEdqy: #crate_ident::Output + ?::core::marker::Sized>(
 				&#i_self,
 				__codec_dest_edqy: &mut __CodecOutputEdqy
 			) {
-				_parity_scale_codec::Encode::encode_to(&#final_field_variable, __codec_dest_edqy)
+				#crate_ident::Encode::encode_to(&#final_field_variable, __codec_dest_edqy)
 			}
 
-			fn encode(&#i_self) -> _parity_scale_codec::alloc::vec::Vec<::core::primitive::u8> {
-				_parity_scale_codec::Encode::encode(&#final_field_variable)
+			fn encode(&#i_self) -> #crate_ident::alloc::vec::Vec<::core::primitive::u8> {
+				#crate_ident::Encode::encode(&#final_field_variable)
 			}
 
 			fn using_encoded<R, F: ::core::ops::FnOnce(&[::core::primitive::u8]) -> R>(&#i_self, f: F) -> R {
-				_parity_scale_codec::Encode::using_encoded(&#final_field_variable, f)
+				#crate_ident::Encode::using_encoded(&#final_field_variable, f)
 			}
 	}
 }
@@ -103,6 +105,7 @@ fn encode_fields<F>(
 		let encoded_as = utils::get_encoded_as_type(f);
 		let compact = utils::is_compact(f);
 		let skip = utils::should_skip(&f.attrs);
+		let crate_ident = crate::parity_scale_codec_ident();
 
 		if encoded_as.is_some() as u8 + compact as u8 + skip as u8 > 1 {
 			return Error::new(
@@ -117,10 +120,10 @@ fn encode_fields<F>(
 			let field_type = &f.ty;
 			quote_spanned! {
 				f.span() => {
-					_parity_scale_codec::Encode::encode_to(
+					#crate_ident::Encode::encode_to(
 						&<
-							<#field_type as _parity_scale_codec::HasCompact>::Type as
-							_parity_scale_codec::EncodeAsRef<'_, #field_type>
+							<#field_type as #crate_ident::HasCompact>::Type as
+							#crate_ident::EncodeAsRef<'_, #field_type>
 						>::RefType::from(#field),
 						#dest,
 					);
@@ -130,10 +133,10 @@ fn encode_fields<F>(
 			let field_type = &f.ty;
 			quote_spanned! {
 				f.span() => {
-					_parity_scale_codec::Encode::encode_to(
+					#crate_ident::Encode::encode_to(
 						&<
 							#encoded_as as
-							_parity_scale_codec::EncodeAsRef<'_, #field_type>
+							#crate_ident::EncodeAsRef<'_, #field_type>
 						>::RefType::from(#field),
 						#dest,
 					);
@@ -145,7 +148,7 @@ fn encode_fields<F>(
 			}
 		} else {
 			quote_spanned! { f.span() =>
-					_parity_scale_codec::Encode::encode_to(#field, #dest);
+				#crate_ident::Encode::encode_to(#field, #dest);
 			}
 		}
 	});
@@ -292,9 +295,9 @@ fn impl_encode(data: &Data, type_name: &Ident) -> TokenStream {
 			"Union types are not supported."
 		).to_compile_error(),
 	};
-
+	let crate_ident = crate::parity_scale_codec_ident();
 	quote! {
-		fn encode_to<__CodecOutputEdqy: _parity_scale_codec::Output + ?Sized>(
+		fn encode_to<__CodecOutputEdqy: #crate_ident::Output + ?::core::marker::Sized>(
 			&#self_,
 			#dest: &mut __CodecOutputEdqy
 		) {

--- a/derive/src/encode.rs
+++ b/derive/src/encode.rs
@@ -74,14 +74,14 @@ fn encode_single_field(
 	let i_self = quote! { self };
 
 	quote_spanned! { field.span() =>
-			fn encode_to<__CodecOutputEdqy: _parity_scale_codec::Output + ?Sized>(
+			fn encode_to<__CodecOutputEdqy: _parity_scale_codec::Output + ?::core::marker::Sized>(
 				&#i_self,
 				__codec_dest_edqy: &mut __CodecOutputEdqy
 			) {
 				_parity_scale_codec::Encode::encode_to(&#final_field_variable, __codec_dest_edqy)
 			}
 
-			fn encode(&#i_self) -> _parity_scale_codec::alloc::vec::Vec<u8> {
+			fn encode(&#i_self) -> _parity_scale_codec::alloc::vec::Vec<::core::primitive::u8> {
 				_parity_scale_codec::Encode::encode(&#final_field_variable)
 			}
 

--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -40,7 +40,7 @@ mod trait_bounds;
 ///
 /// The identifier might change if the depending crate imported it
 /// using a custom package name.
-pub(crate) fn parity_scale_codec_ident_or_err() -> Result<TokenStream2, Error> {
+fn parity_scale_codec_ident() -> Result<TokenStream2, Error> {
 	static CRATE_NAME: &str = "parity-scale-codec";
 	fn root_import(name: &str) -> TokenStream2 {
 		let ident = Ident::new(name, Span::call_site());
@@ -149,7 +149,7 @@ pub fn encode_derive(input: proc_macro::TokenStream) -> proc_macro::TokenStream 
 		return e.to_compile_error().into();
 	}
 
-	let crate_ident = match crate::parity_scale_codec_ident_or_err() {
+	let crate_ident = match crate::parity_scale_codec_ident() {
 		Ok(crate_ident) => crate_ident,
 		Err(error) => {
 			return error.into_compile_error().into()
@@ -200,7 +200,7 @@ pub fn decode_derive(input: proc_macro::TokenStream) -> proc_macro::TokenStream 
 		return e.to_compile_error().into();
 	}
 
-	let crate_ident = match crate::parity_scale_codec_ident_or_err() {
+	let crate_ident = match crate::parity_scale_codec_ident() {
 		Ok(crate_ident) => crate_ident,
 		Err(error) => {
 			return error.into_compile_error().into()
@@ -266,7 +266,7 @@ pub fn compact_as_derive(input: proc_macro::TokenStream) -> proc_macro::TokenStr
 		return e.to_compile_error().into();
 	}
 
-	let crate_ident = match crate::parity_scale_codec_ident_or_err() {
+	let crate_ident = match crate::parity_scale_codec_ident() {
 		Ok(crate_ident) => crate_ident,
 		Err(error) => {
 			return error.into_compile_error().into()

--- a/derive/src/max_encoded_len.rs
+++ b/derive/src/max_encoded_len.rs
@@ -47,7 +47,7 @@ pub fn derive_max_encoded_len(input: proc_macro::TokenStream) -> proc_macro::Tok
 	quote::quote!(
 		const _: () = {
 			impl #impl_generics #mel_trait for #name #ty_generics #where_clause {
-				fn max_encoded_len() -> usize {
+				fn max_encoded_len() -> ::core::primitive::usize {
 					#data_expr
 				}
 			}

--- a/derive/src/trait_bounds.rs
+++ b/derive/src/trait_bounds.rs
@@ -146,7 +146,8 @@ pub fn add(
 				where_clause.predicates.push(parse_quote!(#ty : #codec_bound))
 			});
 
-		let has_compact_bound: syn::Path = parse_quote!(_parity_scale_codec::HasCompact);
+		let crate_ident = crate::parity_scale_codec_ident();
+		let has_compact_bound: syn::Path = parse_quote!(#crate_ident::HasCompact);
 		compact_types
 			.into_iter()
 			.for_each(|ty| {

--- a/derive/src/trait_bounds.rs
+++ b/derive/src/trait_bounds.rs
@@ -14,7 +14,7 @@
 
 use std::iter;
 
-use proc_macro2::Ident;
+use proc_macro2::{Ident, TokenStream};
 use syn::{
 	spanned::Spanned,
 	visit::{self, Visit},
@@ -112,6 +112,7 @@ pub fn add(
 	codec_bound: syn::Path,
 	codec_skip_bound: Option<syn::Path>,
 	dumb_trait_bounds: bool,
+	crate_ident: &TokenStream,
 ) -> Result<()> {
 	let ty_params = generics.type_params().map(|p| p.ident.clone()).collect::<Vec<_>>();
 	if ty_params.is_empty() {
@@ -146,7 +147,6 @@ pub fn add(
 				where_clause.predicates.push(parse_quote!(#ty : #codec_bound))
 			});
 
-		let crate_ident = crate::parity_scale_codec_ident();
 		let has_compact_bound: syn::Path = parse_quote!(#crate_ident::HasCompact);
 		compact_types
 			.into_iter()


### PR DESCRIPTION
This PR fixes some minor macro hygiene issues such as `::core::marker::Sized` and `::core::primitive::u8`.
Also it replaces the `extern crate $name as _parity_scale_codec` by using the imported name:

- For example `::scale` if `parity_scale_codec` has been renamed to `scale` by the dependent crate
- `crate` if the code is generated for the crate itself
- `::parity_scale_codec` for tests of the `parity_scale_codec` crate