### PR TITLE
Add test to assert macro hygiene for Encode and Decode derives

### DIFF
--- a/derive/src/decode.rs
+++ b/derive/src/decode.rs
@@ -90,7 +90,9 @@ pub fn quote(
 					.map_err(|e| e.chain(#read_byte_err_msg))?
 				{
 					#( #recurse )*
-					_ => ::core::result::Result::Err(#invalid_variant_err_msg.into()),
+					_ => ::core::result::Result::Err(
+						<_ as ::core::convert::Into<_>>::into(#invalid_variant_err_msg)
+					),
 				}
 			}
 

--- a/src/bit_vec.rs
+++ b/src/bit_vec.rs
@@ -191,6 +191,10 @@ mod tests {
 	}
 
 	#[test]
+	// Flaky test due to:
+	// * https://github.com/bitvecto-rs/bitvec/issues/135
+	// * https://github.com/rust-lang/miri/issues/1866
+	#[cfg(not(miri))]
 	fn bitvec_u32() {
 		for v in &test_data!(u32) {
 			let encoded = v.encode();

--- a/tests/max_encoded_len.rs
+++ b/tests/max_encoded_len.rs
@@ -14,7 +14,7 @@
 // limitations under the License.
 
 //! Tests for MaxEncodedLen derive macro
-#![cfg(feature = "derive")]
+#![cfg(all(feature = "derive", feature = "max-encoded-len"))]
 
 use parity_scale_codec::{MaxEncodedLen, Compact, Encode};
 

--- a/tests/scale_codec_ui.rs
+++ b/tests/scale_codec_ui.rs
@@ -1,0 +1,25 @@
+// Copyright (C) 2020-2021 Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#[test]
+#[cfg(feature = "derive")]
+fn scale_codec_ui_tests() {
+	// As trybuild is using `cargo check`, we don't need the real WASM binaries.
+	std::env::set_var("SKIP_WASM_BUILD", "1");
+
+	let t = trybuild::TestCases::new();
+	t.compile_fail("tests/scale_codec_ui/*.rs");
+	t.pass("tests/scale_codec_ui/pass/*.rs");
+}

--- a/tests/scale_codec_ui/pass/decode-no-implicit-prelude.rs
+++ b/tests/scale_codec_ui/pass/decode-no-implicit-prelude.rs
@@ -1,0 +1,23 @@
+#![no_implicit_prelude]
+
+#[derive(::parity_scale_codec::Decode)]
+pub struct Struct {
+    field_1: i8,
+    field_2: i16,
+    field_3: i32,
+    field_4: i64,
+}
+
+#[derive(::parity_scale_codec::Decode)]
+pub enum Enum {
+    Variant1,
+    Variant2(i8, i16, i32, i64),
+    Variant3 {
+        field_1: i8,
+        field_2: i16,
+        field_3: i32,
+        field_4: i64,
+    }
+}
+
+fn main() {}

--- a/tests/scale_codec_ui/pass/encode-no-implicit-prelude.rs
+++ b/tests/scale_codec_ui/pass/encode-no-implicit-prelude.rs
@@ -1,0 +1,23 @@
+#![no_implicit_prelude]
+
+#[derive(::parity_scale_codec::Encode)]
+pub struct Struct {
+    field_1: i8,
+    field_2: i16,
+    field_3: i32,
+    field_4: i64,
+}
+
+#[derive(::parity_scale_codec::Encode)]
+pub enum Enum {
+    Variant1,
+    Variant2(i8, i16, i32, i64),
+    Variant3 {
+        field_1: i8,
+        field_2: i16,
+        field_3: i32,
+        field_4: i64,
+    }
+}
+
+fn main() {}


### PR DESCRIPTION
Uses the `#![no_implicit_prelude]` attribute to add UI tests to guard `Encode` and `Decode` derives against macro hygiene mistakes.

This way the PR found a minor macro hygiene bug in `Decode` and fixes it.
Also fixed a minor bug with `MaxEncodedLen` test.