### PR TITLE
Prepare for release 2.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,20 @@
 # Changelog
+
 All notable changes to this crate are documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this crate adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [2.3.1] - 2021-09-28
+
+### Added
+
+- Associated method to DecodeLimit for advancing input index. ([#286](https://github.com/paritytech/parity-scale-codec/pull/286))
+
+### Fix
+
+- Improve macro hygiene of `Encode` and `Decode` proc. macro expansions.
+
 
 ## [2.3.0] - 2021-09-11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,8 +13,7 @@ and this crate adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.h
 
 ### Fix
 
-- Improve macro hygiene of `Encode` and `Decode` proc. macro expansions.
-
+- Improve macro hygiene of `Encode` and `Decode` proc. macro expansions. ([#291](https://github.com/paritytech/parity-scale-codec/pull/291), [#293](https://github.com/paritytech/parity-scale-codec/pull/293))
 
 ## [2.3.0] - 2021-09-11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,6 @@ and this crate adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.h
 
 ## [2.3.1] - 2021-09-28
 
-### Added
-
-- Associated method to DecodeLimit for advancing input index. ([#286](https://github.com/paritytech/parity-scale-codec/pull/286))
-
 ### Fix
 
 - Improve macro hygiene of `Encode` and `Decode` proc. macro expansions. ([#291](https://github.com/paritytech/parity-scale-codec/pull/291), [#293](https://github.com/paritytech/parity-scale-codec/pull/293))

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -417,7 +417,7 @@ checksum = "0ab1bc2a289d34bd04a330323ac98a1b4bc82c9d9fcb1e66b63caa84da26b575"
 
 [[package]]
 name = "parity-scale-codec"
-version = "2.3.0"
+version = "2.3.1"
 dependencies = [
  "arbitrary",
  "arrayvec",
@@ -435,7 +435,7 @@ dependencies = [
 
 [[package]]
 name = "parity-scale-codec-derive"
-version = "2.3.0"
+version = "2.3.1"
 dependencies = [
  "parity-scale-codec",
  "proc-macro-crate",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ edition = "2018"
 [dependencies]
 arrayvec = { version = "0.7", default-features = false }
 serde = { version = "1.0.102", optional = true }
-parity-scale-codec-derive = { path = "derive", version = "2.2.0", default-features = false, optional = true }
+parity-scale-codec-derive = { path = "derive", version = "2.3.1", default-features = false, optional = true }
 bitvec = { version = "0.20.1", default-features = false, features = ["alloc"], optional = true }
 byte-slice-cast = { version = "1.0.0", default-features = false }
 generic-array = { version = "0.14.4", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "parity-scale-codec"
 description = "SCALE - Simple Concatenating Aggregated Little Endians"
-version = "2.3.0"
+version = "2.3.1"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "Apache-2.0"
 repository = "https://github.com/paritytech/parity-scale-codec"

--- a/derive/Cargo.toml
+++ b/derive/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "parity-scale-codec-derive"
 description = "Serialization and deserialization derive macro for Parity SCALE Codec"
-version = "2.3.0"
+version = "2.3.1"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "Apache-2.0"
 edition = "2018"


### PR DESCRIPTION
- Write changelog
- Bump crate versions from `2.3.0` to `2.3.1`.