### PR TITLE
Update codec compact docs links to docs.substrate.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ The encoded data does not include this contextual information.
 
 To get a better understanding of how the encoding is done for different types,
 take a look at the
-[low-level data formats overview page at the Substrate docs site](https://substrate.dev/docs/en/knowledgebase/advanced/codec).
+[low-level data formats overview page at the Substrate docs site](https://docs.substrate.io/v3/advanced/scale-codec/).
 
 ## Implementation
 
@@ -45,7 +45,7 @@ Returns an `Err` if the decoding fails.
 ### CompactAs
 
 The `CompactAs` trait is used for wrapping custom types/structs as compact types, which makes them even more space/memory efficient.
-The compact encoding is described [here](https://substrate.dev/docs/en/knowledgebase/advanced/codec#compactgeneral-integers).
+The compact encoding is described [here](https://docs.substrate.io/v3/advanced/scale-codec/#compactgeneral-integers).
 
 * `encode_as(&self) -> &Self::As`: Encodes the type (self) as a compact type.
 The type `As` is defined in the same trait and its implementation should be compact encode-able.

--- a/src/compact.rs
+++ b/src/compact.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! [Compact encoding](https://substrate.dev/docs/en/overview/low-level-data-format#compact-general-integers)
+//! [Compact encoding](https://docs.substrate.io/v3/advanced/scale-codec/#compactgeneral-integers)
 
 use arrayvec::ArrayVec;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,7 +27,7 @@
 //!
 //! To get a better understanding of how the encoding is done for different types,
 //! take a look at the
-//! [SCALE Code page at the Substrate Knowledge Base](https://substrate.dev/docs/en/knowledgebase/advanced/codec).
+//! [SCALE Code page at the Substrate Knowledge Base](https://docs.substrate.io/v3/advanced/scale-codec/).
 //!
 //! ## Implementation
 //!
@@ -67,7 +67,7 @@
 //! ### CompactAs
 //!
 //! The `CompactAs` trait is used for wrapping custom types/structs as compact types, which makes
-//! them even more space/memory efficient. The compact encoding is described [here](https://substrate.dev/docs/en/knowledgebase/advanced/codec#compactgeneral-integers).
+//! them even more space/memory efficient. The compact encoding is described [here](https://docs.substrate.io/v3/advanced/scale-codec/#compactgeneral-integers).
 //!
 //! * `encode_as(&self) -> &Self::As`: Encodes the type (self) as a compact type.
 //! The type `As` is defined in the same trait and its implementation should be compact encode-able.


### PR DESCRIPTION
`https://substrate.dev/docs/en/overview/low-level-data-format#compact-general-integers` was broken, the others had redirects to `docs.substrate.io` but I updated them too.