### PR TITLE
Bump bitvec dependency to 0.22.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -51,9 +51,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitvec"
-version = "0.20.4"
+version = "0.22.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7774144344a4faa177370406a7ff5f1da24303817368584c6206c8303eb07848"
+checksum = "5237f00a8c86130a0cc317830e558b966dd7850d48a953d998c813f01a41b527"
 dependencies = [
  "funty",
  "radium",
@@ -252,9 +252,9 @@ dependencies = [
 
 [[package]]
 name = "funty"
-version = "1.1.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fed34cd105917e91daa4da6b3728c47b068749d6a62c59811f06ed2ac71d9da7"
+checksum = "1847abb9cb65d566acd5942e94aea9c8f547ad02c98e1649326fc0e8910b8b1e"
 
 [[package]]
 name = "generic-array"
@@ -886,6 +886,9 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "wyz"
-version = "0.2.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85e60b0d1b5f99db2556934e21937020776a5d31520bf169e851ac44e6420214"
+checksum = "129e027ad65ce1453680623c3fb5163cbf7107bfe1aa32257e7d0e63f9ced188"
+dependencies = [
+ "tap",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ edition = "2018"
 arrayvec = { version = "0.7", default-features = false }
 serde = { version = "1.0.102", optional = true }
 parity-scale-codec-derive = { path = "derive", version = "2.3.1", default-features = false, optional = true }
-bitvec = { version = "0.20.1", default-features = false, features = ["alloc"], optional = true }
+bitvec = { version = "0.22.3", default-features = false, features = ["alloc"], optional = true }
 byte-slice-cast = { version = "1.0.0", default-features = false }
 generic-array = { version = "0.14.4", optional = true }
 arbitrary = { version = "1.0.1", features = ["derive"], optional = true }

--- a/fuzzer/Cargo.toml
+++ b/fuzzer/Cargo.toml
@@ -9,4 +9,4 @@ publish = false
 parity-scale-codec = { path = "..", features = ["derive", "bit-vec", "fuzz"] }
 honggfuzz = "0.5.54"
 arbitrary = { version = "1.0.1", features = ["derive"] }
-bitvec = { version = "0.20.1", features = ["alloc"] }
+bitvec = { version = "0.22.3", features = ["alloc"] }


### PR DESCRIPTION
There was a conflict between bitvec and a dependency of it (funty) that
caused a build failure. See:
- https://github.com/bitvecto-rs/bitvec/issues/105
- https://github.com/myrrlyn/funty/issues/3

Due to semver, when importing parity-scale-codec as a library and
resolving bitvec 0.20.1 dependencies, funty 0.12 is pulled, which causes
the aforementioned build failure.  I believe this is not happening when
testing parity-scale-codec itself because Cargo.lock pins funty to
1.1.0, but when importing parity-scale-codec from another crate, this
pinning is sometimes not possible.  Bumping bitvec to 0.22.3 solves this
issue, as it is compatible with funty 0.12.