### PR TITLE
move to rust 2021

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ All notable changes to this crate are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this crate adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+- Migrated to 2021 edition, enforcing MSRV of `1.56.1`. [#298](https://github.com/paritytech/parity-scale-codec/pull/298)
+
 ## [2.3.1] - 2021-09-28
 
 ### Fix

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13,18 +13,18 @@ dependencies = [
 
 [[package]]
 name = "arbitrary"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "577b08a4acd7b99869f863c50011b01eb73424ccc798ecd996f2e24817adfca7"
+checksum = "510c76ecefdceada737ea728f4f9a84bd2e1ef29f1ba555e560940fe279954de"
 dependencies = [
  "derive_arbitrary",
 ]
 
 [[package]]
 name = "arrayvec"
-version = "0.7.1"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be4dc07131ffa69b8072d35f5007352af944213cde02545e2103680baed38fcd"
+checksum = "8da52d66c7071e2e3fa2a1e5c6d088fec47b593032b254f5e980de8ea54454d6"
 
 [[package]]
 name = "atty"
@@ -63,9 +63,9 @@ dependencies = [
 
 [[package]]
 name = "bstr"
-version = "0.2.16"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90682c8d613ad3373e66de8c6411e0ae2ab2571e879d2efbf73558cc66f21279"
+checksum = "ba3569f383e8f1598449f1a423e72e99569137b47740b1da11ef19af3d5c3223"
 dependencies = [
  "lazy_static",
  "memchr",
@@ -75,15 +75,15 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.7.0"
+version = "3.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c59e7af012c713f529e7a3ee57ce9b31ddd858d4b512923602f74608b009631"
+checksum = "8f1e260c3a9040a7c19a12468758f4c16f31a81a1fe087482be9570ec864bb6c"
 
 [[package]]
 name = "byte-slice-cast"
-version = "1.0.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65c1bf4a04a88c54f589125563643d773f3254b5c38571395e2b591c693bbc81"
+checksum = "1d30c751592b77c499e7bce34d99d67c2c11bdc0574e9a488ddade14150a4698"
 
 [[package]]
 name = "cast"
@@ -285,9 +285,9 @@ checksum = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
 
 [[package]]
 name = "half"
-version = "1.7.1"
+version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62aca2aba2d62b4a7f5b33f3712cb1b0692779a56fb510499d5c0aa594daeaf3"
+checksum = "eabb4a44450da02c90444cf74558da904edde8fb4e9035a9a6a4e15445af0bd7"
 
 [[package]]
 name = "hermit-abi"
@@ -337,9 +337,9 @@ checksum = "b71991ff56294aa922b450139ee08b3bfc70982c6b2c7562771375cf73542dd4"
 
 [[package]]
 name = "js-sys"
-version = "0.3.54"
+version = "0.3.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1866b355d9c878e5e607473cbe3f63282c0b7aad2db1dbebf55076c686918254"
+checksum = "7cc9ffccd38c451a86bf13657df244e9c3f37493cce8e5e21e940963777acc84"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -352,9 +352,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.101"
+version = "0.2.108"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3cb00336871be5ed2c8ed44b60ae9959dc5b9f08539422ed43f09e34ecaeba21"
+checksum = "8521a1b57e76b1ec69af7599e75e38e7b7fad6610f037db8c79b127201b5d119"
 
 [[package]]
 name = "log"
@@ -474,9 +474,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro-crate"
-version = "1.0.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41fdbd1df62156fbc5945f4762632564d7d038153091c3fcf1067f6aef7cff92"
+checksum = "1ebace6889caf889b4d3f76becee12e90353f2b8c7d875534a71e5742f8f6f83"
 dependencies = [
  "thiserror",
  "toml",
@@ -484,9 +484,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.29"
+version = "1.0.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9f5105d4fdaab20335ca9565e106a5d9b82b6219b5ba735731124ac6711d23d"
+checksum = "ba508cc11742c0dc5c1659771673afbab7a0efab23aa17e854cbab0837ed0b43"
 dependencies = [
  "unicode-xid",
 ]
@@ -504,9 +504,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.9"
+version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3d0b9745dc2debf507c8422de05d7226cc1f0644216dfdfead988f9b1ab32a7"
+checksum = "38bc8cc6a5f2e3655e0899c1b848643b2562f853f114bfec7be120678e3ace05"
 dependencies = [
  "proc-macro2",
 ]
@@ -651,9 +651,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.67"
+version = "1.0.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7f9e390c27c3c0ce8bc5d725f6e4d30a29d26659494aa4b17535f7522c5c950"
+checksum = "063bf466a64011ac24040a49009724ee60a57da1b437617ceb32e53ad61bfb19"
 dependencies = [
  "itoa",
  "ryu",
@@ -662,9 +662,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.76"
+version = "1.0.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6f107db402c2c2055242dbf4d2af0e69197202e9faacbef9571bbe47f5a1b84"
+checksum = "f2afee18b8beb5a596ecb4a2dce128c719b4ba399d34126b9e4396e3f9860966"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -697,18 +697,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.29"
+version = "1.0.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "602eca064b2d83369e2b2f34b09c70b605402801927c65c11071ac911d299b88"
+checksum = "854babe52e4df1653706b98fcfc05843010039b406875930a70e4d9644e5c417"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.29"
+version = "1.0.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bad553cc2c78e8de258400763a647e80e6d1b31ee237275d756f6836d204494c"
+checksum = "aa32fd3f627f367fe16f893e2597ae3c05020f8bba2666a4e6ea73d377e5714b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -736,9 +736,9 @@ dependencies = [
 
 [[package]]
 name = "trybuild"
-version = "1.0.45"
+version = "1.0.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5bdaf2a1d317f3d58b44b31c7f6436b9b9acafe7bddfeace50897c2b804d7792"
+checksum = "150e726dc059e6fbd4fce3288f5bb3cf70128cf63b0dde23b938a3cad810fb23"
 dependencies = [
  "glob",
  "lazy_static",
@@ -756,9 +756,9 @@ checksum = "b63708a265f51345575b27fe43f9500ad611579e764c79edbc2037b1121959ec"
 
 [[package]]
 name = "unicode-width"
-version = "0.1.8"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9337591893a19b88d8d87f2cec1e73fad5cdfd10e5a6f349f498ad6ea2ffb1e3"
+checksum = "3ed742d4ea2bd1176e236172c8429aaf54486e7ac098db29ffe6529e0ce50973"
 
 [[package]]
 name = "unicode-xid"
@@ -791,9 +791,9 @@ checksum = "fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.77"
+version = "0.2.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e68338db6becec24d3c7977b5bf8a48be992c934b5d07177e3931f5dc9b076c"
+checksum = "632f73e236b219150ea279196e54e610f5dbafa5d61786303d4da54f84e47fce"
 dependencies = [
  "cfg-if",
  "wasm-bindgen-macro",
@@ -801,9 +801,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.77"
+version = "0.2.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f34c405b4f0658583dba0c1c7c9b694f3cac32655db463b56c254a1c75269523"
+checksum = "a317bf8f9fba2476b4b2c85ef4c4af8ff39c3c7f0cdfeed4f82c34a880aa837b"
 dependencies = [
  "bumpalo",
  "lazy_static",
@@ -816,9 +816,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.77"
+version = "0.2.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9d5a6580be83b19dc570a8f9c324251687ab2184e57086f71625feb57ec77c8"
+checksum = "d56146e7c495528bf6587663bea13a8eb588d39b36b679d83972e1a2dbbdacf9"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -826,9 +826,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.77"
+version = "0.2.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3775a030dc6f5a0afd8a84981a21cc92a781eb429acef9ecce476d0c9113e92"
+checksum = "7803e0eea25835f8abdc585cd3021b3deb11543c6fe226dcd30b228857c5c5ab"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -839,15 +839,15 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.77"
+version = "0.2.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c279e376c7a8e8752a8f1eaa35b7b0bee6bb9fb0cdacfa97cc3f1f289c87e2b4"
+checksum = "0237232789cf037d5480773fe568aac745bfe2afbc11a863e97901780a6b47cc"
 
 [[package]]
 name = "web-sys"
-version = "0.3.54"
+version = "0.3.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a84d70d1ec7d2da2d26a5bd78f4bca1b8c3254805363ce743b7a05bc30d195a"
+checksum = "38eb105f1c59d9eaa6b5cdc92b859d85b926e82cb2e0945cd0c9259faa6fe9fb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ authors = ["Parity Technologies <admin@parity.io>"]
 license = "Apache-2.0"
 repository = "https://github.com/paritytech/parity-scale-codec"
 categories = ["encoding"]
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 arrayvec = { version = "0.7", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ license = "Apache-2.0"
 repository = "https://github.com/paritytech/parity-scale-codec"
 categories = ["encoding"]
 edition = "2021"
+rust-version = "1.56.1"
 
 [dependencies]
 arrayvec = { version = "0.7", default-features = false }

--- a/derive/Cargo.toml
+++ b/derive/Cargo.toml
@@ -5,6 +5,7 @@ version = "2.3.1"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "Apache-2.0"
 edition = "2021"
+rust-version = "1.56.1"
 
 [lib]
 proc-macro = true

--- a/derive/Cargo.toml
+++ b/derive/Cargo.toml
@@ -4,7 +4,7 @@ description = "Serialization and deserialization derive macro for Parity SCALE C
 version = "2.3.1"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "Apache-2.0"
-edition = "2018"
+edition = "2021"
 
 [lib]
 proc-macro = true

--- a/fuzzer/Cargo.toml
+++ b/fuzzer/Cargo.toml
@@ -3,6 +3,7 @@ name = "codec-fuzzer"
 version = "0.1.0"
 authors = ["Parity Technologies <admin@parity.io>", "Vincent Ulitzsch <vincent@srlabs.de>"]
 edition = "2021"
+rust-version = "1.56.1"
 publish = false
 
 [dependencies]

--- a/fuzzer/Cargo.toml
+++ b/fuzzer/Cargo.toml
@@ -2,7 +2,7 @@
 name = "codec-fuzzer"
 version = "0.1.0"
 authors = ["Parity Technologies <admin@parity.io>", "Vincent Ulitzsch <vincent@srlabs.de>"]
-edition = "2018"
+edition = "2021"
 publish = false
 
 [dependencies]

--- a/tests/max_encoded_len_ui/crate_str.stderr
+++ b/tests/max_encoded_len_ui/crate_str.stderr
@@ -1,16 +1,18 @@
 error: Invalid attribute: only `#[codec(dumb_trait_bound)]`, `#[codec(crate = path::to::crate)]`, `#[codec(encode_bound(T: Encode))]`, `#[codec(decode_bound(T: Decode))]`, or `#[codec(mel_bound(T: MaxEncodedLen))]` are accepted as top attribute
- --> $DIR/crate_str.rs:4:9
+ --> tests/max_encoded_len_ui/crate_str.rs:4:9
   |
 4 | #[codec(crate = "parity_scale_codec")]
   |         ^^^^^
 
 error[E0277]: the trait bound `Example: WrapperTypeEncode` is not satisfied
-  --> $DIR/crate_str.rs:3:18
+  --> tests/max_encoded_len_ui/crate_str.rs:3:18
    |
 3  | #[derive(Encode, MaxEncodedLen)]
    |                  ^^^^^^^^^^^^^ the trait `WrapperTypeEncode` is not implemented for `Example`
    |
-  ::: $WORKSPACE/src/max_encoded_len.rs
+   = note: required because of the requirements on the impl of `Encode` for `Example`
+note: required by a bound in `MaxEncodedLen`
+  --> src/max_encoded_len.rs
    |
    | pub trait MaxEncodedLen: Encode {
    |                          ^^^^^^ required by this bound in `MaxEncodedLen`

--- a/tests/max_encoded_len_ui/crate_str.stderr
+++ b/tests/max_encoded_len_ui/crate_str.stderr
@@ -13,7 +13,5 @@ error[E0277]: the trait bound `Example: WrapperTypeEncode` is not satisfied
   ::: $WORKSPACE/src/max_encoded_len.rs
    |
    | pub trait MaxEncodedLen: Encode {
-   |                          ------ required by this bound in `MaxEncodedLen`
-   |
-   = note: required because of the requirements on the impl of `Encode` for `Example`
+   |                          ^^^^^^ required by this bound in `MaxEncodedLen`
    = note: this error originates in the derive macro `MaxEncodedLen` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/max_encoded_len_ui/incomplete_attr.stderr
+++ b/tests/max_encoded_len_ui/incomplete_attr.stderr
@@ -10,10 +10,10 @@ error[E0277]: the trait bound `Example: WrapperTypeEncode` is not satisfied
 3  | #[derive(Encode, MaxEncodedLen)]
    |                  ^^^^^^^^^^^^^ the trait `WrapperTypeEncode` is not implemented for `Example`
    |
+   = note: required because of the requirements on the impl of `Encode` for `Example`
+note: required by a bound in `MaxEncodedLen`
   ::: $WORKSPACE/src/max_encoded_len.rs
    |
    | pub trait MaxEncodedLen: Encode {
-   |                          ------ required by this bound in `MaxEncodedLen`
-   |
-   = note: required because of the requirements on the impl of `Encode` for `Example`
+   |                          ^^^^^^ required by this bound in `MaxEncodedLen`
    = note: this error originates in the derive macro `MaxEncodedLen` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/max_encoded_len_ui/incomplete_attr.stderr
+++ b/tests/max_encoded_len_ui/incomplete_attr.stderr
@@ -1,18 +1,18 @@
 error: Invalid attribute: only `#[codec(dumb_trait_bound)]`, `#[codec(crate = path::to::crate)]`, `#[codec(encode_bound(T: Encode))]`, `#[codec(decode_bound(T: Decode))]`, or `#[codec(mel_bound(T: MaxEncodedLen))]` are accepted as top attribute
- --> $DIR/incomplete_attr.rs:4:9
+ --> tests/max_encoded_len_ui/incomplete_attr.rs:4:9
   |
 4 | #[codec(crate)]
   |         ^^^^^
 
 error[E0277]: the trait bound `Example: WrapperTypeEncode` is not satisfied
-  --> $DIR/incomplete_attr.rs:3:18
+  --> tests/max_encoded_len_ui/incomplete_attr.rs:3:18
    |
 3  | #[derive(Encode, MaxEncodedLen)]
    |                  ^^^^^^^^^^^^^ the trait `WrapperTypeEncode` is not implemented for `Example`
    |
    = note: required because of the requirements on the impl of `Encode` for `Example`
 note: required by a bound in `MaxEncodedLen`
-  ::: $WORKSPACE/src/max_encoded_len.rs
+  --> src/max_encoded_len.rs
    |
    | pub trait MaxEncodedLen: Encode {
    |                          ^^^^^^ required by this bound in `MaxEncodedLen`

--- a/tests/max_encoded_len_ui/missing_crate_specifier.stderr
+++ b/tests/max_encoded_len_ui/missing_crate_specifier.stderr
@@ -10,10 +10,10 @@ error[E0277]: the trait bound `Example: WrapperTypeEncode` is not satisfied
 3  | #[derive(Encode, MaxEncodedLen)]
    |                  ^^^^^^^^^^^^^ the trait `WrapperTypeEncode` is not implemented for `Example`
    |
+   = note: required because of the requirements on the impl of `Encode` for `Example`
+note: required by a bound in `MaxEncodedLen`
   ::: $WORKSPACE/src/max_encoded_len.rs
    |
    | pub trait MaxEncodedLen: Encode {
-   |                          ------ required by this bound in `MaxEncodedLen`
-   |
-   = note: required because of the requirements on the impl of `Encode` for `Example`
+   |                          ^^^^^^ required by this bound in `MaxEncodedLen`
    = note: this error originates in the derive macro `MaxEncodedLen` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/max_encoded_len_ui/missing_crate_specifier.stderr
+++ b/tests/max_encoded_len_ui/missing_crate_specifier.stderr
@@ -1,18 +1,18 @@
 error: Invalid attribute: only `#[codec(dumb_trait_bound)]`, `#[codec(crate = path::to::crate)]`, `#[codec(encode_bound(T: Encode))]`, `#[codec(decode_bound(T: Decode))]`, or `#[codec(mel_bound(T: MaxEncodedLen))]` are accepted as top attribute
- --> $DIR/missing_crate_specifier.rs:4:9
+ --> tests/max_encoded_len_ui/missing_crate_specifier.rs:4:9
   |
 4 | #[codec(parity_scale_codec)]
   |         ^^^^^^^^^^^^^^^^^^
 
 error[E0277]: the trait bound `Example: WrapperTypeEncode` is not satisfied
-  --> $DIR/missing_crate_specifier.rs:3:18
+  --> tests/max_encoded_len_ui/missing_crate_specifier.rs:3:18
    |
 3  | #[derive(Encode, MaxEncodedLen)]
    |                  ^^^^^^^^^^^^^ the trait `WrapperTypeEncode` is not implemented for `Example`
    |
    = note: required because of the requirements on the impl of `Encode` for `Example`
 note: required by a bound in `MaxEncodedLen`
-  ::: $WORKSPACE/src/max_encoded_len.rs
+  --> src/max_encoded_len.rs
    |
    | pub trait MaxEncodedLen: Encode {
    |                          ^^^^^^ required by this bound in `MaxEncodedLen`

--- a/tests/max_encoded_len_ui/not_encode.stderr
+++ b/tests/max_encoded_len_ui/not_encode.stderr
@@ -4,10 +4,10 @@ error[E0277]: the trait bound `NotEncode: WrapperTypeEncode` is not satisfied
 3  | #[derive(MaxEncodedLen)]
    |          ^^^^^^^^^^^^^ the trait `WrapperTypeEncode` is not implemented for `NotEncode`
    |
+   = note: required because of the requirements on the impl of `Encode` for `NotEncode`
+note: required by a bound in `MaxEncodedLen`
   ::: $WORKSPACE/src/max_encoded_len.rs
    |
    | pub trait MaxEncodedLen: Encode {
-   |                          ------ required by this bound in `MaxEncodedLen`
-   |
-   = note: required because of the requirements on the impl of `Encode` for `NotEncode`
+   |                          ^^^^^^ required by this bound in `MaxEncodedLen`
    = note: this error originates in the derive macro `MaxEncodedLen` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/max_encoded_len_ui/not_encode.stderr
+++ b/tests/max_encoded_len_ui/not_encode.stderr
@@ -1,12 +1,12 @@
 error[E0277]: the trait bound `NotEncode: WrapperTypeEncode` is not satisfied
-  --> $DIR/not_encode.rs:3:10
+  --> tests/max_encoded_len_ui/not_encode.rs:3:10
    |
 3  | #[derive(MaxEncodedLen)]
    |          ^^^^^^^^^^^^^ the trait `WrapperTypeEncode` is not implemented for `NotEncode`
    |
    = note: required because of the requirements on the impl of `Encode` for `NotEncode`
 note: required by a bound in `MaxEncodedLen`
-  ::: $WORKSPACE/src/max_encoded_len.rs
+  --> src/max_encoded_len.rs
    |
    | pub trait MaxEncodedLen: Encode {
    |                          ^^^^^^ required by this bound in `MaxEncodedLen`


### PR DESCRIPTION
Confirmed to build locally on Ubuntu 20.04.3 LTS:
```
rustc 1.56.1 (59eed8a2a 2021-11-01)
rustc 1.58.0-nightly (e90c5fbbc 2021-11-12)
```