### PR TITLE
Make `CompactRef` public

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -291,7 +291,7 @@ pub use self::codec::{
 };
 #[cfg(feature = "std")]
 pub use self::codec::IoReader;
-pub use self::compact::{Compact, HasCompact, CompactAs, CompactLen};
+pub use self::compact::{Compact, HasCompact, CompactAs, CompactLen, CompactRef};
 pub use self::joiner::Joiner;
 pub use self::keyedvec::KeyedVec;
 pub use self::decode_all::DecodeAll;


### PR DESCRIPTION
Makes the `CompactRef` struct public. Resolves #320.