### PR TITLE
[ci] change ci image to latest

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -11,7 +11,6 @@ variables:
   GIT_DEPTH:                       "100"
   CARGO_TARGET_DIR:                "/ci-cache/${CI_PROJECT_NAME}/targets/${CI_COMMIT_REF_NAME}/${CI_JOB_NAME}"
   CARGO_INCREMENTAL:               0
-  CI_SERVER_NAME:                  "GitLab CI"
 
 workflow:
   rules:
@@ -19,8 +18,7 @@ workflow:
     - if: $CI_COMMIT_BRANCH
 
 .docker-env:                       &docker-env
-  # Temporary image, remove when clang in "ink-ci-linux:production" is updated to 13
-  image:                           paritytech/parity-scale-codec:staging
+  image:                           paritytech/parity-scale-codec:latest
   before_script:
     - cargo -vV
     - rustc -vV


### PR DESCRIPTION
This is first part of https://github.com/paritytech/ci_cd/issues/344

Before switching to `paritytech/parity-scale-codec:production` image it's needed to use intermediary image (`latest`)