### PR TITLE
Add skip_type_params attribute

### DIFF
--- a/derive/src/max_encoded_len.rs
+++ b/derive/src/max_encoded_len.rs
@@ -69,8 +69,8 @@ fn add_trait_bounds(
 			generics.make_where_clause().predicates.extend(bounds);
 			return generics
 		}
-		Some(CustomTraitBound::SkipTypeParams { type_params, .. }) => {
-			type_params.into_iter().map(|tp| tp.ident).collect()
+		Some(CustomTraitBound::SkipTypeParams { type_names, .. }) => {
+			type_names.into_iter().collect::<Vec<_>>()
 		},
 		None => Vec::new()
 	};

--- a/derive/src/max_encoded_len.rs
+++ b/derive/src/max_encoded_len.rs
@@ -42,7 +42,7 @@ pub fn derive_max_encoded_len(input: proc_macro::TokenStream) -> proc_macro::Tok
 		custom_mel_trait_bound(&input.attrs),
 		parse_quote!(#crate_path::MaxEncodedLen),
 		None,
-		true,
+		utils::has_dumb_trait_bound(&input.attrs),
 		&crate_path
 	) {
 		return e.to_compile_error().into()

--- a/derive/src/max_encoded_len.rs
+++ b/derive/src/max_encoded_len.rs
@@ -17,7 +17,7 @@
 
 use crate::{
 	trait_bounds,
-	utils::{codec_crate_path, custom_mel_trait_bound},
+	utils::{codec_crate_path, custom_mel_trait_bound, has_dumb_trait_bound},
 };
 use quote::{quote, quote_spanned};
 use syn::{parse_quote, spanned::Spanned, Data, DeriveInput, Fields, Type};
@@ -42,7 +42,7 @@ pub fn derive_max_encoded_len(input: proc_macro::TokenStream) -> proc_macro::Tok
 		custom_mel_trait_bound(&input.attrs),
 		parse_quote!(#crate_path::MaxEncodedLen),
 		None,
-		utils::has_dumb_trait_bound(&input.attrs),
+		has_dumb_trait_bound(&input.attrs),
 		&crate_path
 	) {
 		return e.to_compile_error().into()

--- a/derive/src/trait_bounds.rs
+++ b/derive/src/trait_bounds.rs
@@ -120,19 +120,15 @@ pub fn add<N>(
 			generics.make_where_clause().predicates.extend(bounds);
 			return Ok(())
 		},
-		Some(CustomTraitBound::SkipTypeParams { type_params, .. }) =>
-			type_params.into_iter().map(|tp| tp.ident).collect::<Vec<_>>(),
+		Some(CustomTraitBound::SkipTypeParams { type_names, .. }) =>
+			type_names.into_iter().collect::<Vec<_>>(),
 		None => Vec::new(),
 	};
 
 	let ty_params = generics
 		.type_params()
 		.filter_map(|tp| {
-			if skip_type_params.iter().any(|skip| skip == &tp.ident) {
-				None
-			} else {
-				Some(tp.ident.clone())
-			}
+			skip_type_params.iter().all(|skip| skip != &tp.ident).then(|| tp.ident.clone())
 		})
 		.collect::<Vec<_>>();
 	if ty_params.is_empty() {
@@ -172,7 +168,7 @@ pub fn add<N>(
 			.for_each(|ty| where_clause.predicates.push(parse_quote!(#ty : #has_compact_bound)));
 
 		skip_types.into_iter().for_each(|ty| {
-			let codec_skip_bound = codec_skip_bound.as_ref().unwrap();
+			let codec_skip_bound = codec_skip_bound.as_ref();
 			where_clause.predicates.push(parse_quote!(#ty : #codec_skip_bound))
 		});
 	}

--- a/derive/src/trait_bounds.rs
+++ b/derive/src/trait_bounds.rs
@@ -21,12 +21,12 @@ use syn::{
 	Generics, Result, Type, TypePath,
 };
 
-use crate::utils;
+use crate::utils::{self, CustomTraitBound};
 
 /// Visits the ast and checks if one of the given idents is found.
 struct ContainIdents<'a> {
 	result: bool,
-	idents: &'a[Ident]
+	idents: &'a [Ident],
 }
 
 impl<'a, 'ast> Visit<'ast> for ContainIdents<'a> {
@@ -47,7 +47,7 @@ fn type_contain_idents(ty: &Type, idents: &[Ident]) -> bool {
 /// Visits the ast and checks if the a type path starts with the given ident.
 struct TypePathStartsWithIdent<'a> {
 	result: bool,
-	ident: &'a Ident
+	ident: &'a Ident,
 }
 
 impl<'a, 'ast> Visit<'ast> for TypePathStartsWithIdent<'a> {
@@ -55,7 +55,7 @@ impl<'a, 'ast> Visit<'ast> for TypePathStartsWithIdent<'a> {
 		if let Some(segment) = i.path.segments.first() {
 			if &segment.ident == self.ident {
 				self.result = true;
-				return;
+				return
 			}
 		}
 
@@ -82,7 +82,7 @@ fn type_or_sub_type_path_starts_with_ident(ty: &Type, ident: &Ident) -> bool {
 /// Returns `T`, `N`, `A` for `Vec<(Recursive<T, N>, A)>` with `Recursive` as ident.
 struct FindTypePathsNotStartOrContainIdent<'a> {
 	result: Vec<TypePath>,
-	ident: &'a Ident
+	ident: &'a Ident,
 }
 
 impl<'a, 'ast> Visit<'ast> for FindTypePathsNotStartOrContainIdent<'a> {
@@ -105,21 +105,42 @@ fn find_type_paths_not_start_or_contain_ident(ty: &Type, ident: &Ident) -> Vec<T
 }
 
 /// Add required trait bounds to all generic types.
-pub fn add(
+pub fn add<N>(
 	input_ident: &Ident,
 	generics: &mut Generics,
 	data: &syn::Data,
+	custom_trait_bound: Option<CustomTraitBound<N>>,
 	codec_bound: syn::Path,
 	codec_skip_bound: Option<syn::Path>,
 	dumb_trait_bounds: bool,
 	crate_path: &syn::Path,
 ) -> Result<()> {
-	let ty_params = generics.type_params().map(|p| p.ident.clone()).collect::<Vec<_>>();
+	let skip_type_params = match custom_trait_bound {
+		Some(CustomTraitBound::SpecifiedBounds { bounds, .. }) => {
+			generics.make_where_clause().predicates.extend(bounds);
+			return Ok(())
+		},
+		Some(CustomTraitBound::SkipTypeParams { type_params, .. }) =>
+			type_params.into_iter().map(|tp| tp.ident).collect::<Vec<_>>(),
+		None => Vec::new(),
+	};
+
+	let ty_params = generics
+		.type_params()
+		.filter_map(|tp| {
+			if skip_type_params.iter().any(|skip| skip == &tp.ident) {
+				None
+			} else {
+				Some(tp.ident.clone())
+			}
+		})
+		.collect::<Vec<_>>();
 	if ty_params.is_empty() {
-		return Ok(());
+		return Ok(())
 	}
 
-	let codec_types = get_types_to_add_trait_bound(input_ident, data, &ty_params, dumb_trait_bounds)?;
+	let codec_types =
+		get_types_to_add_trait_bound(input_ident, data, &ty_params, dumb_trait_bounds)?;
 
 	let compact_types = collect_types(&data, utils::is_compact)?
 		.into_iter()
@@ -143,23 +164,17 @@ pub fn add(
 
 		codec_types
 			.into_iter()
-			.for_each(|ty| {
-				where_clause.predicates.push(parse_quote!(#ty : #codec_bound))
-			});
+			.for_each(|ty| where_clause.predicates.push(parse_quote!(#ty : #codec_bound)));
 
 		let has_compact_bound: syn::Path = parse_quote!(#crate_path::HasCompact);
 		compact_types
 			.into_iter()
-			.for_each(|ty| {
-				where_clause.predicates.push(parse_quote!(#ty : #has_compact_bound))
-			});
+			.for_each(|ty| where_clause.predicates.push(parse_quote!(#ty : #has_compact_bound)));
 
-		skip_types
-			.into_iter()
-			.for_each(|ty| {
-				let codec_skip_bound = codec_skip_bound.as_ref().unwrap();
-				where_clause.predicates.push(parse_quote!(#ty : #codec_skip_bound))
-			});
+		skip_types.into_iter().for_each(|ty| {
+			let codec_skip_bound = codec_skip_bound.as_ref().unwrap();
+			where_clause.predicates.push(parse_quote!(#ty : #codec_skip_bound))
+		});
 	}
 
 	Ok(())
@@ -175,15 +190,17 @@ fn get_types_to_add_trait_bound(
 	if dumb_trait_bound {
 		Ok(ty_params.iter().map(|t| parse_quote!( #t )).collect())
 	} else {
-		let needs_codec_bound = |f: &syn::Field| !utils::is_compact(f)
-				&& utils::get_encoded_as_type(f).is_none()
-				&& !utils::should_skip(&f.attrs);
+		let needs_codec_bound = |f: &syn::Field| {
+			!utils::is_compact(f) &&
+				utils::get_encoded_as_type(f).is_none() &&
+				!utils::should_skip(&f.attrs)
+		};
 		let res = collect_types(&data, needs_codec_bound)?
 			.into_iter()
 			// Only add a bound if the type uses a generic
 			.filter(|ty| type_contain_idents(ty, &ty_params))
-			// If a struct contains itself as field type, we can not add this type into the where clause.
-			// This is required to work a round the following compiler bug: https://github.com/rust-lang/rust/issues/47032
+			// If a struct contains itself as field type, we can not add this type into the where
+			// clause. This is required to work a round the following compiler bug: https://github.com/rust-lang/rust/issues/47032
 			.flat_map(|ty| {
 				find_type_paths_not_start_or_contain_ident(&ty, input_ident)
 					.into_iter()
@@ -193,7 +210,8 @@ fn get_types_to_add_trait_bound(
 					// Add back the original type, as we don't want to loose it.
 					.chain(iter::once(ty))
 			})
-			// Remove all remaining types that start/contain the input ident to not have them in the where clause.
+			// Remove all remaining types that start/contain the input ident to not have them in the
+			// where clause.
 			.filter(|ty| !type_or_sub_type_path_starts_with_ident(ty, input_ident))
 			.collect();
 
@@ -201,45 +219,33 @@ fn get_types_to_add_trait_bound(
 	}
 }
 
-fn collect_types(
-	data: &syn::Data,
-	type_filter: fn(&syn::Field) -> bool,
-) -> Result<Vec<syn::Type>> {
+fn collect_types(data: &syn::Data, type_filter: fn(&syn::Field) -> bool) -> Result<Vec<syn::Type>> {
 	use syn::*;
 
 	let types = match *data {
 		Data::Struct(ref data) => match &data.fields {
-			| Fields::Named(FieldsNamed { named: fields , .. })
-			| Fields::Unnamed(FieldsUnnamed { unnamed: fields, .. }) => {
-				fields.iter()
-					.filter(|f| type_filter(f))
-					.map(|f| f.ty.clone())
-					.collect()
-			},
+			| Fields::Named(FieldsNamed { named: fields, .. }) |
+			Fields::Unnamed(FieldsUnnamed { unnamed: fields, .. }) =>
+				fields.iter().filter(|f| type_filter(f)).map(|f| f.ty.clone()).collect(),
 
-			Fields::Unit => { Vec::new() },
+			Fields::Unit => Vec::new(),
 		},
 
-		Data::Enum(ref data) => data.variants.iter()
+		Data::Enum(ref data) => data
+			.variants
+			.iter()
 			.filter(|variant| !utils::should_skip(&variant.attrs))
-			.flat_map(|variant| {
-				match &variant.fields {
-					| Fields::Named(FieldsNamed { named: fields , .. })
-					| Fields::Unnamed(FieldsUnnamed { unnamed: fields, .. }) => {
-						fields.iter()
-							.filter(|f| type_filter(f))
-							.map(|f| f.ty.clone())
-							.collect()
-					},
+			.flat_map(|variant| match &variant.fields {
+				| Fields::Named(FieldsNamed { named: fields, .. }) |
+				Fields::Unnamed(FieldsUnnamed { unnamed: fields, .. }) =>
+					fields.iter().filter(|f| type_filter(f)).map(|f| f.ty.clone()).collect(),
 
-					Fields::Unit => { Vec::new() },
-				}
-			}).collect(),
+				Fields::Unit => Vec::new(),
+			})
+			.collect(),
 
-		Data::Union(ref data) => return Err(Error::new(
-			data.union_token.span(),
-			"Union types are not supported."
-		)),
+		Data::Union(ref data) =>
+			return Err(Error::new(data.union_token.span(), "Union types are not supported.")),
 	};
 
 	Ok(types)

--- a/derive/src/utils.rs
+++ b/derive/src/utils.rs
@@ -22,17 +22,20 @@ use std::str::FromStr;
 use proc_macro2::TokenStream;
 use quote::quote;
 use syn::{
-	Attribute, Data, DeriveInput, Field, Fields, FieldsNamed, FieldsUnnamed, Lit, Meta,
-	MetaNameValue, NestedMeta, parse::Parse, Path, punctuated::Punctuated,
-	spanned::Spanned, token, Variant,
+	parse::Parse, punctuated::Punctuated, spanned::Spanned, token, Attribute, Data, DeriveInput,
+	Field, Fields, FieldsNamed, FieldsUnnamed, Lit, Meta, MetaNameValue, NestedMeta, Path,
+	TypeParam, Variant,
 };
 
-fn find_meta_item<'a, F, R, I, M>(mut itr: I, mut pred: F) -> Option<R> where
+fn find_meta_item<'a, F, R, I, M>(mut itr: I, mut pred: F) -> Option<R>
+where
 	F: FnMut(M) -> Option<R> + Clone,
-	I: Iterator<Item=&'a Attribute>,
+	I: Iterator<Item = &'a Attribute>,
 	M: Parse,
 {
-	itr.find_map(|attr| attr.path.is_ident("codec").then(|| pred(attr.parse_args().ok()?)).flatten())
+	itr.find_map(|attr| {
+		attr.path.is_ident("codec").then(|| pred(attr.parse_args().ok()?)).flatten()
+	})
 }
 
 /// Look for a `#[scale(index = $int)]` attribute on a variant. If no attribute
@@ -43,7 +46,8 @@ pub fn variant_index(v: &Variant, i: usize) -> TokenStream {
 		if let NestedMeta::Meta(Meta::NameValue(ref nv)) = meta {
 			if nv.path.is_ident("index") {
 				if let Lit::Int(ref v) = nv.lit {
-					let byte = v.base10_parse::<u8>()
+					let byte = v
+						.base10_parse::<u8>()
 						.expect("Internal error, index attribute must have been checked");
 					return Some(byte)
 				}
@@ -54,12 +58,12 @@ pub fn variant_index(v: &Variant, i: usize) -> TokenStream {
 	});
 
 	// then fallback to discriminant or just index
-	index.map(|i| quote! { #i })
-		.unwrap_or_else(|| v.discriminant
+	index.map(|i| quote! { #i }).unwrap_or_else(|| {
+		v.discriminant
 			.as_ref()
 			.map(|&(_, ref expr)| quote! { #expr })
 			.unwrap_or_else(|| quote! { #i })
-		)
+	})
 }
 
 /// Look for a `#[codec(encoded_as = "SomeType")]` outer attribute on the given
@@ -71,8 +75,8 @@ pub fn get_encoded_as_type(field: &Field) -> Option<TokenStream> {
 				if let Lit::Str(ref s) = nv.lit {
 					return Some(
 						TokenStream::from_str(&s.value())
-							.expect("Internal error, encoded_as attribute must have been checked")
-					);
+							.expect("Internal error, encoded_as attribute must have been checked"),
+					)
 				}
 			}
 		}
@@ -86,12 +90,13 @@ pub fn is_compact(field: &Field) -> bool {
 	find_meta_item(field.attrs.iter(), |meta| {
 		if let NestedMeta::Meta(Meta::Path(ref path)) = meta {
 			if path.is_ident("compact") {
-				return Some(());
+				return Some(())
 			}
 		}
 
 		None
-	}).is_some()
+	})
+	.is_some()
 }
 
 /// Look for a `#[codec(skip)]` in the given attributes.
@@ -99,12 +104,13 @@ pub fn should_skip(attrs: &[Attribute]) -> bool {
 	find_meta_item(attrs.iter(), |meta| {
 		if let NestedMeta::Meta(Meta::Path(ref path)) = meta {
 			if path.is_ident("skip") {
-				return Some(path.span());
+				return Some(path.span())
 			}
 		}
 
 		None
-	}).is_some()
+	})
+	.is_some()
 }
 
 /// Look for a `#[codec(dumb_trait_bound)]`in the given attributes.
@@ -112,24 +118,25 @@ pub fn has_dumb_trait_bound(attrs: &[Attribute]) -> bool {
 	find_meta_item(attrs.iter(), |meta| {
 		if let NestedMeta::Meta(Meta::Path(ref path)) = meta {
 			if path.is_ident("dumb_trait_bound") {
-				return Some(());
+				return Some(())
 			}
 		}
 
 		None
-	}).is_some()
+	})
+	.is_some()
 }
 
 /// Generate the crate access for the crate using 2018 syntax.
 fn crate_access() -> syn::Result<proc_macro2::Ident> {
+	use proc_macro2::{Ident, Span};
 	use proc_macro_crate::{crate_name, FoundCrate};
-	use proc_macro2::{Span, Ident};
 	const DEF_CRATE: &str = "parity-scale-codec";
 	match crate_name(DEF_CRATE) {
 		Ok(FoundCrate::Itself) => {
 			let name = DEF_CRATE.to_string().replace("-", "_");
 			Ok(syn::Ident::new(&name, Span::call_site()))
-		}
+		},
 		Ok(FoundCrate::Name(name)) => Ok(Ident::new(&name, Span::call_site())),
 		Err(e) => Err(syn::Error::new(Span::call_site(), e)),
 	}
@@ -153,7 +160,7 @@ impl Parse for CratePath {
 }
 
 impl From<CratePath> for Path {
-	fn from(CratePath { path, ..}: CratePath) -> Self {
+	fn from(CratePath { path, .. }: CratePath) -> Self {
 		path
 	}
 }
@@ -161,10 +168,13 @@ impl From<CratePath> for Path {
 /// Match `#[codec(crate = ...)]` and return the `...` if it is a `Path`.
 fn codec_crate_path_inner(attr: &Attribute) -> Option<Path> {
 	// match `#[codec ...]`
-	attr.path.is_ident("codec").then(|| {
-		// match `#[codec(crate = ...)]` and return the `...`
-		attr.parse_args::<CratePath>().map(Into::into).ok()
-	}).flatten()
+	attr.path
+		.is_ident("codec")
+		.then(|| {
+			// match `#[codec(crate = ...)]` and return the `...`
+			attr.parse_args::<CratePath>().map(Into::into).ok()
+		})
+		.flatten()
 }
 
 /// Match `#[codec(crate = ...)]` and return the ellipsis as a `Path`.
@@ -179,22 +189,40 @@ pub fn codec_crate_path(attrs: &[Attribute]) -> syn::Result<Path> {
 	}
 }
 
-/// Trait bounds.
-pub type TraitBounds = Punctuated<syn::WherePredicate, token::Comma>;
-
 /// Parse `name(T: Bound, N: Bound)` as a custom trait bound.
-struct CustomTraitBound<N> {
-	_name: N,
-	_paren_token: token::Paren,
-	bounds: TraitBounds,
+pub enum CustomTraitBound<N> {
+	SpecifiedBounds {
+		_name: N,
+		_paren_token: token::Paren,
+		bounds: Punctuated<syn::WherePredicate, token::Comma>,
+	},
+	SkipTypeParams {
+		_name: N,
+		_paren_token_1: token::Paren,
+		_skip_type_params: skip_type_params,
+		_paren_token_2: token::Paren,
+		type_params: Punctuated<TypeParam, Token![,]>,
+	},
 }
 
 impl<N: Parse> Parse for CustomTraitBound<N> {
 	fn parse(input: syn::parse::ParseStream) -> syn::Result<Self> {
-		let content;
-		Ok(Self {
-			_name: input.parse()?,
-			_paren_token: syn::parenthesized!(content in input),
+		let mut content;
+		let _name: N = input.parse()?;
+		let _paren_token = syn::parenthesized!(content in input);
+		let lookahead = content.lookahead1();
+		if lookahead.peek(skip_type_params) {
+			return Ok(Self::SkipTypeParams {
+				_name,
+				_paren_token_1: _paren_token,
+				_skip_type_params: content.parse::<skip_type_params>()?,
+				_paren_token_2: syn::parenthesized!(content in content),
+				type_params: content.parse_terminated(syn::TypeParam::parse)?,
+			})
+		}
+		Ok(Self::SpecifiedBounds {
+			_name,
+			_paren_token,
 			bounds: content.parse_terminated(syn::WherePredicate::parse)?,
 		})
 	}
@@ -203,48 +231,42 @@ impl<N: Parse> Parse for CustomTraitBound<N> {
 syn::custom_keyword!(encode_bound);
 syn::custom_keyword!(decode_bound);
 syn::custom_keyword!(mel_bound);
+syn::custom_keyword!(skip_type_params);
 
 /// Look for a `#[codec(decode_bound(T: Decode))]` in the given attributes.
 ///
 /// If found, it should be used as trait bounds when deriving the `Decode` trait.
-pub fn custom_decode_trait_bound(attrs: &[Attribute]) -> Option<TraitBounds> {
-	find_meta_item(attrs.iter(), |meta: CustomTraitBound<decode_bound>| {
-		Some(meta.bounds)
-	})
+pub fn custom_decode_trait_bound(attrs: &[Attribute]) -> Option<CustomTraitBound<decode_bound>> {
+	find_meta_item(attrs.iter(), Some)
 }
 
 /// Look for a `#[codec(encode_bound(T: Encode))]` in the given attributes.
 ///
 /// If found, it should be used as trait bounds when deriving the `Encode` trait.
-pub fn custom_encode_trait_bound(attrs: &[Attribute]) -> Option<TraitBounds> {
-	find_meta_item(attrs.iter(), |meta: CustomTraitBound<encode_bound>| {
-		Some(meta.bounds)
-	})
+pub fn custom_encode_trait_bound(attrs: &[Attribute]) -> Option<CustomTraitBound<encode_bound>> {
+	find_meta_item(attrs.iter(), Some)
 }
 
 /// Look for a `#[codec(mel_bound(T: MaxEncodedLen))]` in the given attributes.
 ///
 /// If found, it should be used as the trait bounds when deriving the `MaxEncodedLen` trait.
 #[cfg(feature = "max-encoded-len")]
-pub fn custom_mel_trait_bound(attrs: &[Attribute]) -> Option<TraitBounds> {
-	find_meta_item(attrs.iter(), |meta: CustomTraitBound<mel_bound>| {
-		Some(meta.bounds)
-	})
+pub fn custom_mel_trait_bound(attrs: &[Attribute]) -> Option<CustomTraitBound<mel_bound>> {
+	find_meta_item(attrs.iter(), Some)
 }
 
 /// Given a set of named fields, return an iterator of `Field` where all fields
 /// marked `#[codec(skip)]` are filtered out.
-pub fn filter_skip_named<'a>(fields: &'a syn::FieldsNamed) -> impl Iterator<Item=&Field> + 'a {
-	fields.named.iter()
-		.filter(|f| !should_skip(&f.attrs))
+pub fn filter_skip_named<'a>(fields: &'a syn::FieldsNamed) -> impl Iterator<Item = &Field> + 'a {
+	fields.named.iter().filter(|f| !should_skip(&f.attrs))
 }
 
 /// Given a set of unnamed fields, return an iterator of `(index, Field)` where all fields
 /// marked `#[codec(skip)]` are filtered out.
-pub fn filter_skip_unnamed<'a>(fields: &'a syn::FieldsUnnamed) -> impl Iterator<Item=(usize, &Field)> + 'a {
-	fields.unnamed.iter()
-		.enumerate()
-		.filter(|(_, f)| !should_skip(&f.attrs))
+pub fn filter_skip_unnamed<'a>(
+	fields: &'a syn::FieldsUnnamed,
+) -> impl Iterator<Item = (usize, &Field)> + 'a {
+	fields.unnamed.iter().enumerate().filter(|(_, f)| !should_skip(&f.attrs))
 }
 
 /// Ensure attributes are correctly applied. This *must* be called before using
@@ -276,17 +298,16 @@ pub fn check_attributes(input: &DeriveInput) -> syn::Result<()> {
 
 	match input.data {
 		Data::Struct(ref data) => match &data.fields {
-			| Fields::Named(FieldsNamed { named: fields , .. })
-			| Fields::Unnamed(FieldsUnnamed { unnamed: fields, .. }) => {
+			| Fields::Named(FieldsNamed { named: fields, .. }) |
+			Fields::Unnamed(FieldsUnnamed { unnamed: fields, .. }) =>
 				for field in fields {
 					for attr in &field.attrs {
 						check_field_attribute(attr)?;
 					}
-				}
-			}
+				},
 			Fields::Unit => (),
-		}
-		Data::Enum(ref data) => {
+		},
+		Data::Enum(ref data) =>
 			for variant in data.variants.iter() {
 				for attr in &variant.attrs {
 					check_variant_attribute(attr)?;
@@ -296,8 +317,7 @@ pub fn check_attributes(input: &DeriveInput) -> syn::Result<()> {
 						check_field_attribute(attr)?;
 					}
 				}
-			}
-		},
+			},
 		Data::Union(_) => (),
 	}
 	Ok(())
@@ -305,10 +325,10 @@ pub fn check_attributes(input: &DeriveInput) -> syn::Result<()> {
 
 // Check if the attribute is `#[allow(..)]`, `#[deny(..)]`, `#[forbid(..)]` or `#[warn(..)]`.
 pub fn is_lint_attribute(attr: &Attribute) -> bool {
-	attr.path.is_ident("allow")
-		|| attr.path.is_ident("deny")
-		|| attr.path.is_ident("forbid")
-		|| attr.path.is_ident("warn")
+	attr.path.is_ident("allow") ||
+		attr.path.is_ident("deny") ||
+		attr.path.is_ident("forbid") ||
+		attr.path.is_ident("warn")
 }
 
 // Ensure a field is decorated only with the following attributes:
@@ -324,15 +344,21 @@ fn check_field_attribute(attr: &Attribute) -> syn::Result<()> {
 			Meta::List(ref meta_list) if meta_list.nested.len() == 1 => {
 				match meta_list.nested.first().expect("Just checked that there is one item; qed") {
 					NestedMeta::Meta(Meta::Path(path))
-						if path.get_ident().map_or(false, |i| i == "skip") => Ok(()),
+						if path.get_ident().map_or(false, |i| i == "skip") =>
+						Ok(()),
 
 					NestedMeta::Meta(Meta::Path(path))
-						if path.get_ident().map_or(false, |i| i == "compact") => Ok(()),
+						if path.get_ident().map_or(false, |i| i == "compact") =>
+						Ok(()),
 
-					NestedMeta::Meta(Meta::NameValue(MetaNameValue { path, lit: Lit::Str(lit_str), .. }))
-						if path.get_ident().map_or(false, |i| i == "encoded_as")
-					=> TokenStream::from_str(&lit_str.value()).map(|_| ())
-						.map_err(|_e| syn::Error::new(lit_str.span(), "Invalid token stream")),
+					NestedMeta::Meta(Meta::NameValue(MetaNameValue {
+						path,
+						lit: Lit::Str(lit_str),
+						..
+					})) if path.get_ident().map_or(false, |i| i == "encoded_as") =>
+						TokenStream::from_str(&lit_str.value())
+							.map(|_| ())
+							.map_err(|_e| syn::Error::new(lit_str.span(), "Invalid token stream")),
 
 					elt @ _ => Err(syn::Error::new(elt.span(), field_error)),
 				}
@@ -356,11 +382,16 @@ fn check_variant_attribute(attr: &Attribute) -> syn::Result<()> {
 			Meta::List(ref meta_list) if meta_list.nested.len() == 1 => {
 				match meta_list.nested.first().expect("Just checked that there is one item; qed") {
 					NestedMeta::Meta(Meta::Path(path))
-						if path.get_ident().map_or(false, |i| i == "skip") => Ok(()),
+						if path.get_ident().map_or(false, |i| i == "skip") =>
+						Ok(()),
 
-					NestedMeta::Meta(Meta::NameValue(MetaNameValue { path, lit: Lit::Int(lit_int), .. }))
-						if path.get_ident().map_or(false, |i| i == "index")
-					=> lit_int.base10_parse::<u8>().map(|_| ())
+					NestedMeta::Meta(Meta::NameValue(MetaNameValue {
+						path,
+						lit: Lit::Int(lit_int),
+						..
+					})) if path.get_ident().map_or(false, |i| i == "index") => lit_int
+						.base10_parse::<u8>()
+						.map(|_| ())
 						.map_err(|_| syn::Error::new(lit_int.span(), "Index must be in 0..255")),
 
 					elt @ _ => Err(syn::Error::new(elt.span(), variant_error)),
@@ -379,21 +410,22 @@ fn check_top_attribute(attr: &Attribute) -> syn::Result<()> {
 		`#[codec(crate = path::to::crate)]`, `#[codec(encode_bound(T: Encode))]`, \
 		`#[codec(decode_bound(T: Decode))]`, or `#[codec(mel_bound(T: MaxEncodedLen))]` \
 		are accepted as top attribute";
-	if attr.path.is_ident("codec")
-		&& attr.parse_args::<CustomTraitBound<encode_bound>>().is_err()
-		&& attr.parse_args::<CustomTraitBound<decode_bound>>().is_err()
-		&& attr.parse_args::<CustomTraitBound<mel_bound>>().is_err()
-		&& codec_crate_path_inner(attr).is_none()
+	if attr.path.is_ident("codec") &&
+		attr.parse_args::<CustomTraitBound<encode_bound>>().is_err() &&
+		attr.parse_args::<CustomTraitBound<decode_bound>>().is_err() &&
+		attr.parse_args::<CustomTraitBound<mel_bound>>().is_err() &&
+		codec_crate_path_inner(attr).is_none()
 	{
 		match attr.parse_meta()? {
 			Meta::List(ref meta_list) if meta_list.nested.len() == 1 => {
 				match meta_list.nested.first().expect("Just checked that there is one item; qed") {
-						NestedMeta::Meta(Meta::Path(path))
-							if path.get_ident().map_or(false, |i| i == "dumb_trait_bound") => Ok(()),
+					NestedMeta::Meta(Meta::Path(path))
+						if path.get_ident().map_or(false, |i| i == "dumb_trait_bound") =>
+						Ok(()),
 
-						elt @ _ => Err(syn::Error::new(elt.span(), top_error)),
-					}
-			}
+					elt @ _ => Err(syn::Error::new(elt.span(), top_error)),
+				}
+			},
 			_ => Err(syn::Error::new(attr.span(), top_error)),
 		}
 	} else {

--- a/derive/src/utils.rs
+++ b/derive/src/utils.rs
@@ -189,7 +189,7 @@ pub fn codec_crate_path(attrs: &[Attribute]) -> syn::Result<Path> {
 	}
 }
 
-/// Parse `name(T: Bound, N: Bound)` as a custom trait bound.
+/// Parse `name(T: Bound, N: Bound)` or `name(skip_type_params(T, N))` as a custom trait bound.
 pub enum CustomTraitBound<N> {
 	SpecifiedBounds {
 		_name: N,

--- a/tests/max_encoded_len.rs
+++ b/tests/max_encoded_len.rs
@@ -16,7 +16,7 @@
 //! Tests for MaxEncodedLen derive macro
 #![cfg(all(feature = "derive", feature = "max-encoded-len"))]
 
-use parity_scale_codec::{MaxEncodedLen, Compact, Encode};
+use parity_scale_codec::{MaxEncodedLen, Compact, Decode, Encode};
 
 #[derive(Encode, MaxEncodedLen)]
 struct Primitives {
@@ -179,4 +179,22 @@ enum EnumMaxNotSum {
 #[test]
 fn enum_max_not_sum_max_length() {
 	assert_eq!(EnumMaxNotSum::max_encoded_len(), 1 + u32::max_encoded_len());
+}
+
+#[test]
+fn skip_type_params() {
+	#[derive(Encode, Decode, MaxEncodedLen)]
+	#[codec(mel_bound(skip_type_params(N)))]
+	struct SomeData<T, N: SomeTrait> {
+		element: T,
+		size: std::marker::PhantomData<N>,
+	}
+
+	trait SomeTrait {}
+
+	struct SomeStruct;
+
+	impl SomeTrait for SomeStruct {}
+
+	assert_eq!(SomeData::<u32, SomeStruct>::max_encoded_len(), 4);
 }

--- a/tests/mod.rs
+++ b/tests/mod.rs
@@ -15,7 +15,7 @@
 #[cfg(not(feature="derive"))]
 use parity_scale_codec_derive::{Encode, Decode};
 use parity_scale_codec::{
-	Encode, Decode, HasCompact, Compact, EncodeAsRef, CompactAs, Error, Output, DecodeAll
+	Encode, Decode, HasCompact, Compact, EncodeAsRef, CompactAs, Error, Output,
 };
 use serde_derive::{Serialize, Deserialize};
 

--- a/tests/mod.rs
+++ b/tests/mod.rs
@@ -591,6 +591,7 @@ fn custom_trait_bound() {
 #[cfg(feature = "bit-vec")]
 fn bit_vec_works() {
 	use bitvec::prelude::*;
+	use parity_scale_codec::DecodeAll;
 
 	// Try some fancy stuff
 	let original_vec = bitvec![u8, Msb0; 1; 8];


### PR DESCRIPTION
Fixes #316.

Adds the `skip_type_params` attribute under the `encode_bound`, `decode_bound` and `mel_bound` attributes:

```rust
#[derive(Encode, Decode, MaxEncodedLen)]
#[codec(mel_bound(skip_type_params(N)))]
struct Foo<N: Get<u32>> {
    _data: PhantomData<N>,
}
```

The `skip_type_params` attribute is done in such a manner because each of the `Encode`, `Decode` and `MaxEncodedLen` derive macros can have their own trait bounds for type parameters that are different from each other, and rather than having `encode_skip_type_params`, `decode_skip_type_params` and `mel_skip_type_params` attributes, I've decided to consolidate them all into one second-level attribute `skip_type_params`.