### PR TITLE
Add `decode_from_bytes`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -423,7 +423,7 @@ checksum = "0ab1bc2a289d34bd04a330323ac98a1b4bc82c9d9fcb1e66b63caa84da26b575"
 
 [[package]]
 name = "parity-scale-codec"
-version = "3.1.2"
+version = "3.1.3"
 dependencies = [
  "arbitrary",
  "arrayvec",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "parity-scale-codec"
 description = "SCALE - Simple Concatenating Aggregated Little Endians"
-version = "3.1.2"
+version = "3.1.3"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "Apache-2.0"
 repository = "https://github.com/paritytech/parity-scale-codec"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -345,3 +345,6 @@ pub use max_encoded_len::MaxEncodedLen;
 /// ```
 #[cfg(all(feature = "derive", feature = "max-encoded-len"))]
 pub use parity_scale_codec_derive::MaxEncodedLen;
+
+#[cfg(feature = "bytes")]
+pub use self::codec::decode_from_bytes;


### PR DESCRIPTION
This PR adds a new public API:

`fn decode_from_bytes<T>(bytes: bytes::Bytes) -> Result<T, Error> where T: Decode`

This allows zero-copy deserialization of raw bytes when the input is also `Bytes`.

See the comment in `decode_from_bytes` for an explanation as to why this method was added instead of simply implementing `Input` for `Bytes`.