### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ The encoded data does not include this contextual information.
 
 To get a better understanding of how the encoding is done for different types,
 take a look at the
-[low-level data formats overview page at the Substrate docs site](https://docs.substrate.io/v3/advanced/scale-codec/).
+[low-level data formats overview page at the Substrate docs site](https://docs.substrate.io/reference/scale-codec/).
 
 ## Implementation
 


### PR DESCRIPTION
Very small change to save time for other devs who come here to learn more about Scale. The link to documentation describing Scale codec in the README was outdated. Updated it to point to the new page at https://docs.substrate.io/reference/scale-codec/