### PR TITLE
Don't include bitvec with std  feature unless asked for explicitly

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ license = "Apache-2.0"
 repository = "https://github.com/paritytech/parity-scale-codec"
 categories = ["encoding"]
 edition = "2021"
-rust-version = "1.56.1"
+rust-version = "1.60.0"
 
 [dependencies]
 arrayvec = { version = "0.7", default-features = false }
@@ -38,7 +38,7 @@ bench = false
 [features]
 default = ["std"]
 derive = ["parity-scale-codec-derive"]
-std = ["serde", "bitvec/std", "byte-slice-cast/std", "chain-error"]
+std = ["serde", "bitvec?/std", "byte-slice-cast/std", "chain-error"]
 bit-vec = ["bitvec"]
 fuzz = ["std", "arbitrary"]
 


### PR DESCRIPTION
Should not be a breaking code change since bitvec things are all controlled by the "bit-vec" feature, but should avoid pulling in the dep unless it's asked for.

(Part of trying to remove bitvec as a mandatory dependency for consumers (see https://github.com/paritytech/scale-info/pull/168))

Minimum Rust version from this is increased to 1.60.0.

What's our versioning policy w.r.t minimum supported rust version being increased?