### PR TITLE
Use core RangeInclusive instead of std

### DIFF
--- a/src/max_encoded_len.rs
+++ b/src/max_encoded_len.rs
@@ -17,8 +17,7 @@
 
 use crate::{Compact, Encode};
 use impl_trait_for_tuples::impl_for_tuples;
-use core::{mem, marker::PhantomData, num::*, ops::Range, time::Duration};
-use std::ops::RangeInclusive;
+use core::{mem, marker::PhantomData, num::*, ops::{Range, RangeInclusive}, time::Duration};
 use crate::alloc::boxed::Box;
 
 /// Items implementing `MaxEncodedLen` have a statically known maximum encoded size.


### PR DESCRIPTION
Changes import of `RangeInclusive` from `std` to `core`. Fixes #377.