### PR TITLE
Bump derive & codec version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -429,7 +429,7 @@ checksum = "0ab1bc2a289d34bd04a330323ac98a1b4bc82c9d9fcb1e66b63caa84da26b575"
 
 [[package]]
 name = "parity-scale-codec"
-version = "3.2.0"
+version = "3.2.2"
 dependencies = [
  "arbitrary",
  "arrayvec",
@@ -449,7 +449,7 @@ dependencies = [
 
 [[package]]
 name = "parity-scale-codec-derive"
-version = "3.1.3"
+version = "3.1.4"
 dependencies = [
  "parity-scale-codec",
  "proc-macro-crate",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "parity-scale-codec"
 description = "SCALE - Simple Concatenating Aggregated Little Endians"
-version = "3.2.1"
+version = "3.2.2"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "Apache-2.0"
 repository = "https://github.com/paritytech/parity-scale-codec"
@@ -12,7 +12,7 @@ rust-version = "1.60.0"
 [dependencies]
 arrayvec = { version = "0.7", default-features = false }
 serde = { version = "1.0.139", optional = true }
-parity-scale-codec-derive = { path = "derive", version = "3.1.3", default-features = false, optional = true }
+parity-scale-codec-derive = { path = "derive", version = "3.1.4", default-features = false, optional = true }
 bitvec = { version = "1", default-features = false, features = [ "alloc" ], optional = true }
 bytes = { version = "1", default-features = false, optional = true }
 byte-slice-cast = { version = "1.2.1", default-features = false }

--- a/derive/Cargo.toml
+++ b/derive/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "parity-scale-codec-derive"
 description = "Serialization and deserialization derive macro for Parity SCALE Codec"
-version = "3.1.3"
+version = "3.1.4"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "Apache-2.0"
 edition = "2021"


### PR DESCRIPTION
This brings support for `codec(skip)` for MEL.