### PR TITLE
Export `decode_vec_with_len`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,19 @@ All notable changes to this crate are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this crate adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.3.0]
+
+This release exports `decode_vec_with_len` to support custom decoding of `Vec`s.
+
+### Added
+
+- Export `decode_vec_with_len`.
+
 ## [3.2.1] - 2022-09-14
 
 This release fixes compilation on no-std envs.
 
-## Changed
+### Changed
 
  - Use core RangeInclusive instead of std [#378](https://github.com/paritytech/parity-scale-codec/pull/378)
 
@@ -17,7 +25,7 @@ This release fixes compilation on no-std envs.
 
 This release (specifically [#375](https://github.com/paritytech/parity-scale-codec/pull/375)) bumps the MSRV to 1.60.0 as it depends on the Cargo.toml weak dependency feature.
 
-## Changed
+### Changed
 
 - Don't include bitvec with std feature unless asked for explicitly. [#375](https://github.com/paritytech/parity-scale-codec/pull/375)
 - Implement `MaxEncodedLen` on more core lib types. [#350](https://github.com/paritytech/parity-scale-codec/pull/350)
@@ -26,13 +34,13 @@ This release (specifically [#375](https://github.com/paritytech/parity-scale-cod
 
 A quick release to fix an issue introduced in 3.1.4 that broke compiling on no-std.
 
-## Changed
+### Changed
 
 - Fix compiling on no-std. (see https://github.com/paritytech/parity-scale-codec/commit/c25f14a46546c75e4208363ced9d89aa81c85e7f)
 
 ## [3.1.3] - 2022-06-10
 
-## Changed
+### Changed
 
 - Impl `MaxEncodedLen` for `Box<T>`. [#349](https://github.com/paritytech/parity-scale-codec/pull/349)
 - Add `decode_from_bytes`. [#342](https://github.com/paritytech/parity-scale-codec/pull/342)
@@ -41,7 +49,7 @@ A quick release to fix an issue introduced in 3.1.4 that broke compiling on no-s
 
 Be aware that version 3.0.0. up to 3.1.1 contained some bugs in the `BitVec` encoder that could lead to an invalid encoding. Thus, we yanked these crate version and it is advised to upgrade to 3.1.2. Any release before 3.0.0 wasn't affected by this bug.
 
-## Changed
+### Changed
 
 - Optimised the `Decode::decode` for `[T; N]` by @xgreenx. [#299](https://github.com/paritytech/parity-scale-codec/pull/299)
 - Add some doc for the derive macro by @thiolliere. [#301](https://github.com/paritytech/parity-scale-codec/pull/301)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -429,7 +429,7 @@ checksum = "0ab1bc2a289d34bd04a330323ac98a1b4bc82c9d9fcb1e66b63caa84da26b575"
 
 [[package]]
 name = "parity-scale-codec"
-version = "3.2.2"
+version = "3.3.0"
 dependencies = [
  "arbitrary",
  "arrayvec",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "parity-scale-codec"
 description = "SCALE - Simple Concatenating Aggregated Little Endians"
-version = "3.2.2"
+version = "3.3.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "Apache-2.0"
 repository = "https://github.com/paritytech/parity-scale-codec"

--- a/src/codec.rs
+++ b/src/codec.rs
@@ -826,11 +826,11 @@ pub(crate) fn decode_array<I: Input, T: Decode, const N: usize>(input: &mut I) -
 	}
 }
 
-/// Decode the vec (without prepended the len).
+/// Decode the vec (without a prepended len).
 ///
 /// This is equivalent to decode all elements one by one, but it is optimized in some
 /// situation.
-pub(crate) fn decode_vec_with_len<T: Decode, I: Input>(
+pub fn decode_vec_with_len<T: Decode, I: Input>(
 	input: &mut I,
 	len: usize,
 ) -> Result<Vec<T>, Error> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -295,7 +295,7 @@ mod max_encoded_len;
 pub use self::error::Error;
 pub use self::codec::{
 	Input, Output, Decode, Encode, Codec, EncodeAsRef, WrapperTypeEncode, WrapperTypeDecode,
-	OptionBool, DecodeLength, FullCodec, FullEncode,
+	OptionBool, DecodeLength, FullCodec, FullEncode, decode_vec_with_len
 };
 #[cfg(feature = "std")]
 pub use self::codec::IoReader;


### PR DESCRIPTION
This is necessary to fix the custom `impl Decode` for `BoundedVec`. Currently when decoding, it will [allocate before doing a length check](https://github.com/paritytech/substrate/blob/2dff067e9f7f6f3cc4dbfdaaa97753eccc407689/primitives/core/src/bounded/bounded_vec.rs#L311-L315). See:

https://github.com/paritytech/polkadot/pull/6603#discussion_r1083461147

> You want to ensure that you don't even start try decoding/allocating when the length of the vector is more than the
> allowed maximum.

> You first decode length of the vector and then early reject if that is too long.