### PR TITLE
Remove `full` feature

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -42,15 +42,6 @@ default:
 
 #### stage:                        check
 
-check-rust-stable-no_derive_no_std_full:
-  stage:                           check
-  <<:                              *docker-env
-  variables:
-    RUSTFLAGS:                     "-Cdebug-assertions=y -Dwarnings"
-  script:
-    - time cargo +stable check --verbose --no-default-features --features bit-vec,bytes,generic-array,full
-
-
 check-rust-stable-no_derive_no_std:
   stage:                           check
   <<:                              *docker-env
@@ -69,13 +60,13 @@ check-rust-stable-no_std-chain-error:
     - time cargo +stable check --verbose --no-default-features --features chain-error
 
 
-check-rust-stable-no_derive_full:
+check-rust-stable-no_derive:
   stage:                           check
   <<:                              *docker-env
   variables:
     RUSTFLAGS:                     "-Cdebug-assertions=y -Dwarnings"
   script:
-    - time cargo +stable check --verbose --features bit-vec,bytes,generic-array,full
+    - time cargo +stable check --verbose --features bit-vec,bytes,generic-array
 
 
 #### stage:                        test
@@ -123,6 +114,16 @@ build-no-std:
     # this target doesn't support std envs; it should flag any unexpected uses of std
     - rustup target add thumbv6m-none-eabi
     - time cargo build --target thumbv6m-none-eabi --no-default-features
+
+build-no-atomic-ptrs:
+  stage:                           test
+  <<:                              *docker-env
+  variables:
+    RUST_BACKTRACE:                1
+  script:
+    # this target doesn't have atomic ptrs. Some parts of alloc are not available there
+    # we want to make sure that this crate still works on those targets
+    - cargo +nightly check --target bpfel-unknown-none -Zbuild-std="core,alloc" --no-default-features --features generic-array,derive,max-encoded-len,chain-error
 
 #### stage:                        build
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,15 +51,12 @@ max-encoded-len = ["parity-scale-codec-derive/max-encoded-len"]
 # Should not be used in a constrained environment.
 chain-error = []
 
-# Provide implementations for `String`.
-string = []
-
 # WARNING: DO _NOT_ USE THIS FEATURE IF YOU ARE WORKING ON CONSENSUS CODE!*
 #
 # Provides implementations for more data structures than just Vec and Box.
 # Concretely it will provide parity-scale-codec implementations for many types
 # that can be found in std and/or alloc.
-full = ["string"]
+full = []
 
 [workspace]
 members = ["derive", "fuzzer"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,11 +51,7 @@ max-encoded-len = ["parity-scale-codec-derive/max-encoded-len"]
 # Should not be used in a constrained environment.
 chain-error = []
 
-# WARNING: DO _NOT_ USE THIS FEATURE IF YOU ARE WORKING ON CONSENSUS CODE!*
-#
-# Provides implementations for more data structures than just Vec and Box.
-# Concretely it will provide parity-scale-codec implementations for many types
-# that can be found in std and/or alloc.
+# This does not do anthing anymore. Remove with the next major release.
 full = []
 
 [workspace]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,12 +51,15 @@ max-encoded-len = ["parity-scale-codec-derive/max-encoded-len"]
 # Should not be used in a constrained environment.
 chain-error = []
 
+# Provide implementations for `String`.
+string = []
+
 # WARNING: DO _NOT_ USE THIS FEATURE IF YOU ARE WORKING ON CONSENSUS CODE!*
 #
 # Provides implementations for more data structures than just Vec and Box.
 # Concretely it will provide parity-scale-codec implementations for many types
 # that can be found in std and/or alloc.
-full = []
+full = ["string"]
 
 [workspace]
 members = ["derive", "fuzzer"]

--- a/src/codec.rs
+++ b/src/codec.rs
@@ -43,10 +43,9 @@ use core::num::{
 
 use byte_slice_cast::{AsByteSlice, AsMutByteSlice, ToMutByteSlice};
 
-#[cfg(any(feature = "std", feature = "string"))]
-use crate::alloc::string::String;
 #[cfg(any(feature = "std", feature = "full"))]
 use crate::alloc::{
+	string::String,
 	sync::Arc,
 	rc::Rc,
 };
@@ -366,16 +365,6 @@ impl<'a, T: ToOwned + Encode + ?Sized> EncodeLike for Cow<'a, T> {}
 impl<'a, T: ToOwned + Encode> EncodeLike<T> for Cow<'a, T> {}
 impl<'a, T: ToOwned + Encode> EncodeLike<Cow<'a, T>> for T {}
 
-#[cfg(any(feature = "std", feature = "string"))]
-mod feature_string_wrapper_type_encode {
-	use super::*;
-
-	impl WrapperTypeEncode for String {}
-	impl EncodeLike for String {}
-	impl EncodeLike<&str> for String {}
-	impl EncodeLike<String> for &str {}
-}
-
 #[cfg(any(feature = "std", feature = "full"))]
 mod feature_full_wrapper_type_encode {
 	use super::*;
@@ -389,6 +378,11 @@ mod feature_full_wrapper_type_encode {
 	impl<T: ?Sized + Encode> EncodeLike for Rc<T> {}
 	impl<T: Encode> EncodeLike<T> for Rc<T> {}
 	impl<T: Encode> EncodeLike<Rc<T>> for T {}
+
+	impl WrapperTypeEncode for String {}
+	impl EncodeLike for String {}
+	impl EncodeLike<&str> for String {}
+	impl EncodeLike<String> for &str {}
 }
 
 #[cfg(feature = "bytes")]
@@ -947,7 +941,7 @@ impl<T> Decode for PhantomData<T> {
 	}
 }
 
-#[cfg(any(feature = "std", feature = "string"))]
+#[cfg(any(feature = "std", feature = "full"))]
 impl Decode for String {
 	fn decode<I: Input>(input: &mut I) -> Result<Self, Error> {
 		Self::from_utf8(Vec::decode(input)?).map_err(|_| "Invalid utf8 sequence".into())

--- a/src/codec.rs
+++ b/src/codec.rs
@@ -43,9 +43,10 @@ use core::num::{
 
 use byte_slice_cast::{AsByteSlice, AsMutByteSlice, ToMutByteSlice};
 
+#[cfg(any(feature = "std", feature = "string"))]
+use crate::alloc::string::String;
 #[cfg(any(feature = "std", feature = "full"))]
 use crate::alloc::{
-	string::String,
 	sync::Arc,
 	rc::Rc,
 };
@@ -365,6 +366,16 @@ impl<'a, T: ToOwned + Encode + ?Sized> EncodeLike for Cow<'a, T> {}
 impl<'a, T: ToOwned + Encode> EncodeLike<T> for Cow<'a, T> {}
 impl<'a, T: ToOwned + Encode> EncodeLike<Cow<'a, T>> for T {}
 
+#[cfg(any(feature = "std", feature = "string"))]
+mod feature_string_wrapper_type_encode {
+	use super::*;
+
+	impl WrapperTypeEncode for String {}
+	impl EncodeLike for String {}
+	impl EncodeLike<&str> for String {}
+	impl EncodeLike<String> for &str {}
+}
+
 #[cfg(any(feature = "std", feature = "full"))]
 mod feature_full_wrapper_type_encode {
 	use super::*;
@@ -378,11 +389,6 @@ mod feature_full_wrapper_type_encode {
 	impl<T: ?Sized + Encode> EncodeLike for Rc<T> {}
 	impl<T: Encode> EncodeLike<T> for Rc<T> {}
 	impl<T: Encode> EncodeLike<Rc<T>> for T {}
-
-	impl WrapperTypeEncode for String {}
-	impl EncodeLike for String {}
-	impl EncodeLike<&str> for String {}
-	impl EncodeLike<String> for &str {}
 }
 
 #[cfg(feature = "bytes")]
@@ -941,7 +947,7 @@ impl<T> Decode for PhantomData<T> {
 	}
 }
 
-#[cfg(any(feature = "std", feature = "full"))]
+#[cfg(any(feature = "std", feature = "string"))]
 impl Decode for String {
 	fn decode<I: Input>(input: &mut I) -> Result<Self, Error> {
 		Self::from_utf8(Vec::decode(input)?).map_err(|_| "Invalid utf8 sequence".into())


### PR DESCRIPTION
Guarding things behind features only makes sense to reduce compile time or prevent pulling in situational dependencies.

It is not a good way to guard against accidental implementations on unwanted types. Due to feature unification it can be enabled through oopsies anyways. The feature just makes testing more complicated.

Hence we remove the `full` feature. We leave it in the manifest but it doesn't do anything (for backwards compat). But we also need to put `alloc::syn` behind conditional compilation as it is not available on all targets.