### PR TITLE
Bump minor version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this crate are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this crate adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.4.0]
+
+This release renders the `full` feature defunct. The implementations guarded behind
+this feature are now always provided.
+
+### Changes
+
+- All implementations guarded behind `full` are not unconditionally implemented.
+
 ## [3.3.0]
 
 This release exports `decode_vec_with_len` to support custom decoding of `Vec`s.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -429,7 +429,7 @@ checksum = "0ab1bc2a289d34bd04a330323ac98a1b4bc82c9d9fcb1e66b63caa84da26b575"
 
 [[package]]
 name = "parity-scale-codec"
-version = "3.3.0"
+version = "3.4.0"
 dependencies = [
  "arbitrary",
  "arrayvec",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "parity-scale-codec"
 description = "SCALE - Simple Concatenating Aggregated Little Endians"
-version = "3.3.0"
+version = "3.4.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "Apache-2.0"
 repository = "https://github.com/paritytech/parity-scale-codec"


### PR DESCRIPTION
I think minor version bumb is required here. I think enabling those impls for the additional types (removing full feature) should not be a breaking change. Correct me if I am wrong.