### PR TITLE
Array size

### DIFF
--- a/src/codec.rs
+++ b/src/codec.rs
@@ -891,13 +891,13 @@ impl<T: Decode, const N: usize> Decode for [T; N] {
 	}
 
 	fn skip<I: Input>(input: &mut I) -> Result<(), Error> {
-		if let Some(_) = Self::encoded_fixed_size() {
-		// Should skip the bytes, but Input does not support skip.
+		if Self::encoded_fixed_size().is_some() {
+			// Should skip the bytes, but Input does not support skip.
 			for _ in 0..N {
-				T::skip(input) ?;
+				T::skip(input)?;
 			}
 		} else {
-		    Self::decode(input) ?;
+		    Self::decode(input)?;
 		}
 		Ok(())
 	}
@@ -1379,7 +1379,7 @@ impl Decode for bool {
 	}
 
 	fn encoded_fixed_size() -> Option<usize> {
-		Some(mem::size_of::<bool>())
+		Some(1)
 	}
 }
 

--- a/src/codec.rs
+++ b/src/codec.rs
@@ -889,6 +889,22 @@ impl<T: Decode, const N: usize> Decode for [T; N] {
 	fn decode<I: Input>(input: &mut I) -> Result<Self, Error> {
 		decode_array(input)
 	}
+
+	fn skip<I: Input>(input: &mut I) -> Result<(), Error> {
+		if let Some(_) = Self::encoded_fixed_size() {
+		// Should skip the bytes, but Input does not support skip.
+			for _ in 0..N {
+				T::skip(input) ?;
+			}
+		} else {
+		    Self::decode(input) ?;
+		}
+		Ok(())
+	}
+
+	fn encoded_fixed_size() -> Option<usize> {
+		Some(<T as Decode>::encoded_fixed_size()? * N)
+	}
 }
 
 impl<T: EncodeLike<U>, U: Encode, const N: usize> EncodeLike<[U; N]> for [T; N] {}

--- a/src/codec.rs
+++ b/src/codec.rs
@@ -1318,6 +1318,10 @@ macro_rules! impl_endians {
 				input.read(&mut buf)?;
 				Ok(<$t>::from_le_bytes(buf))
 			}
+
+			fn encoded_fixed_size() -> Option<usize> {
+				Some(mem::size_of::<$t>())
+			}
 		}
 	)* }
 }
@@ -1372,6 +1376,10 @@ impl Decode for bool {
 			1 => Ok(true),
 			_ => Err("Invalid boolean representation".into())
 		}
+	}
+
+	fn encoded_fixed_size() -> Option<usize> {
+		Some(mem::size_of::<bool>())
 	}
 }
 


### PR DESCRIPTION
I guess you guys ignore `Decode::encoded_fixed_size` these?  There are a lot more of these missing.  Also `Input` does not even have a mechanism for skipping bytes.