### PR TITLE
Bump ci image

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -10,7 +10,7 @@ variables:
   GIT_STRATEGY:                    fetch
   GIT_DEPTH:                       "100"
   CARGO_INCREMENTAL:               0
-  CI_IMAGE:                        "paritytech/parity-scale-codec:production"
+  CI_IMAGE:                        "paritytech/parity-scale-codec@sha256:ed3d5632087237511cb5c7a6177167d01822bd9b6d8d31789080e014c4491bae" # staging 2023-03-28
 
 default:
   cache:                           {}

--- a/tests/max_encoded_len_ui/crate_str.stderr
+++ b/tests/max_encoded_len_ui/crate_str.stderr
@@ -5,15 +5,24 @@ error: Invalid attribute: only `#[codec(dumb_trait_bound)]`, `#[codec(crate = pa
   |         ^^^^^
 
 error[E0277]: the trait bound `Example: WrapperTypeEncode` is not satisfied
-  --> tests/max_encoded_len_ui/crate_str.rs:3:18
+  --> tests/max_encoded_len_ui/crate_str.rs:5:8
    |
-3  | #[derive(Encode, MaxEncodedLen)]
-   |                  ^^^^^^^^^^^^^ the trait `WrapperTypeEncode` is not implemented for `Example`
+5  | struct Example;
+   |        ^^^^^^^ the trait `WrapperTypeEncode` is not implemented for `Example`
    |
-   = note: required because of the requirements on the impl of `Encode` for `Example`
+   = help: the following other types implement trait `WrapperTypeEncode`:
+             &T
+             &mut T
+             Arc<T>
+             Box<T>
+             Cow<'a, T>
+             Rc<T>
+             String
+             Vec<T>
+             parity_scale_codec::Ref<'a, T, U>
+   = note: required for `Example` to implement `Encode`
 note: required by a bound in `MaxEncodedLen`
   --> src/max_encoded_len.rs
    |
    | pub trait MaxEncodedLen: Encode {
    |                          ^^^^^^ required by this bound in `MaxEncodedLen`
-   = note: this error originates in the derive macro `MaxEncodedLen` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/max_encoded_len_ui/incomplete_attr.stderr
+++ b/tests/max_encoded_len_ui/incomplete_attr.stderr
@@ -5,15 +5,24 @@ error: Invalid attribute: only `#[codec(dumb_trait_bound)]`, `#[codec(crate = pa
   |         ^^^^^
 
 error[E0277]: the trait bound `Example: WrapperTypeEncode` is not satisfied
-  --> tests/max_encoded_len_ui/incomplete_attr.rs:3:18
+  --> tests/max_encoded_len_ui/incomplete_attr.rs:5:8
    |
-3  | #[derive(Encode, MaxEncodedLen)]
-   |                  ^^^^^^^^^^^^^ the trait `WrapperTypeEncode` is not implemented for `Example`
+5  | struct Example;
+   |        ^^^^^^^ the trait `WrapperTypeEncode` is not implemented for `Example`
    |
-   = note: required because of the requirements on the impl of `Encode` for `Example`
+   = help: the following other types implement trait `WrapperTypeEncode`:
+             &T
+             &mut T
+             Arc<T>
+             Box<T>
+             Cow<'a, T>
+             Rc<T>
+             String
+             Vec<T>
+             parity_scale_codec::Ref<'a, T, U>
+   = note: required for `Example` to implement `Encode`
 note: required by a bound in `MaxEncodedLen`
   --> src/max_encoded_len.rs
    |
    | pub trait MaxEncodedLen: Encode {
    |                          ^^^^^^ required by this bound in `MaxEncodedLen`
-   = note: this error originates in the derive macro `MaxEncodedLen` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/max_encoded_len_ui/missing_crate_specifier.stderr
+++ b/tests/max_encoded_len_ui/missing_crate_specifier.stderr
@@ -5,15 +5,24 @@ error: Invalid attribute: only `#[codec(dumb_trait_bound)]`, `#[codec(crate = pa
   |         ^^^^^^^^^^^^^^^^^^
 
 error[E0277]: the trait bound `Example: WrapperTypeEncode` is not satisfied
-  --> tests/max_encoded_len_ui/missing_crate_specifier.rs:3:18
+  --> tests/max_encoded_len_ui/missing_crate_specifier.rs:5:8
    |
-3  | #[derive(Encode, MaxEncodedLen)]
-   |                  ^^^^^^^^^^^^^ the trait `WrapperTypeEncode` is not implemented for `Example`
+5  | struct Example;
+   |        ^^^^^^^ the trait `WrapperTypeEncode` is not implemented for `Example`
    |
-   = note: required because of the requirements on the impl of `Encode` for `Example`
+   = help: the following other types implement trait `WrapperTypeEncode`:
+             &T
+             &mut T
+             Arc<T>
+             Box<T>
+             Cow<'a, T>
+             Rc<T>
+             String
+             Vec<T>
+             parity_scale_codec::Ref<'a, T, U>
+   = note: required for `Example` to implement `Encode`
 note: required by a bound in `MaxEncodedLen`
   --> src/max_encoded_len.rs
    |
    | pub trait MaxEncodedLen: Encode {
    |                          ^^^^^^ required by this bound in `MaxEncodedLen`
-   = note: this error originates in the derive macro `MaxEncodedLen` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/max_encoded_len_ui/not_encode.stderr
+++ b/tests/max_encoded_len_ui/not_encode.stderr
@@ -1,13 +1,22 @@
 error[E0277]: the trait bound `NotEncode: WrapperTypeEncode` is not satisfied
-  --> tests/max_encoded_len_ui/not_encode.rs:3:10
+  --> tests/max_encoded_len_ui/not_encode.rs:4:8
    |
-3  | #[derive(MaxEncodedLen)]
-   |          ^^^^^^^^^^^^^ the trait `WrapperTypeEncode` is not implemented for `NotEncode`
+4  | struct NotEncode;
+   |        ^^^^^^^^^ the trait `WrapperTypeEncode` is not implemented for `NotEncode`
    |
-   = note: required because of the requirements on the impl of `Encode` for `NotEncode`
+   = help: the following other types implement trait `WrapperTypeEncode`:
+             &T
+             &mut T
+             Arc<T>
+             Box<T>
+             Cow<'a, T>
+             Rc<T>
+             String
+             Vec<T>
+             parity_scale_codec::Ref<'a, T, U>
+   = note: required for `NotEncode` to implement `Encode`
 note: required by a bound in `MaxEncodedLen`
   --> src/max_encoded_len.rs
    |
    | pub trait MaxEncodedLen: Encode {
    |                          ^^^^^^ required by this bound in `MaxEncodedLen`
-   = note: this error originates in the derive macro `MaxEncodedLen` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/max_encoded_len_ui/not_mel.stderr
+++ b/tests/max_encoded_len_ui/not_mel.stderr
@@ -2,34 +2,23 @@ error[E0599]: the function or associated item `max_encoded_len` exists for struc
   --> tests/max_encoded_len_ui/not_mel.rs:12:29
    |
 4  | struct NotMel;
-   | -------------- doesn't satisfy `NotMel: MaxEncodedLen`
+   | ------------- doesn't satisfy `NotMel: MaxEncodedLen`
 ...
 7  | struct Generic<T> {
    | -----------------
    | |
-   | function or associated item `max_encoded_len` not found for this
+   | function or associated item `max_encoded_len` not found for this struct
    | doesn't satisfy `Generic<NotMel>: MaxEncodedLen`
 ...
 12 |     let _ = Generic::<NotMel>::max_encoded_len();
    |                                ^^^^^^^^^^^^^^^ function or associated item cannot be called on `Generic<NotMel>` due to unsatisfied trait bounds
    |
-note: the following trait bounds were not satisfied because of the requirements of the implementation of `MaxEncodedLen` for `_`:
-      `NotMel: MaxEncodedLen`
-  --> tests/max_encoded_len_ui/not_mel.rs:6:18
-   |
-6  | #[derive(Encode, MaxEncodedLen)]
-   |                  ^^^^^^^^^^^^^
-7  | struct Generic<T> {
-   |        ^^^^^^^^^^
-note: the following trait must be implemented
+   = note: trait bound `NotMel: MaxEncodedLen` was not satisfied
+note: the trait `MaxEncodedLen` must be implemented
   --> src/max_encoded_len.rs
    |
-   | / pub trait MaxEncodedLen: Encode {
-   | |     /// Upper bound, in bytes, of the maximum encoded size of this item.
-   | |     fn max_encoded_len() -> usize;
-   | | }
-   | |_^
+   | pub trait MaxEncodedLen: Encode {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    = help: items from traits can only be used if the trait is implemented and in scope
    = note: the following trait defines an item `max_encoded_len`, perhaps you need to implement it:
            candidate #1: `MaxEncodedLen`
-   = note: this error originates in the derive macro `MaxEncodedLen` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/max_encoded_len_ui/unsupported_variant.stderr
+++ b/tests/max_encoded_len_ui/unsupported_variant.stderr
@@ -1,8 +1,8 @@
 error[E0599]: no function or associated item named `max_encoded_len` found for struct `NotMel` in the current scope
- --> $DIR/unsupported_variant.rs:8:9
+ --> tests/max_encoded_len_ui/unsupported_variant.rs:8:9
   |
 4 | struct NotMel;
-  | -------------- function or associated item `max_encoded_len` not found for this
+  | ------------- function or associated item `max_encoded_len` not found for this struct
 ...
 8 |     NotMel(NotMel),
   |            ^^^^^^ function or associated item not found in `NotMel`


### PR DESCRIPTION
The image hadn't been updated in 10mo due to an error that went unnoticed. The new image is based on debian 11, rust 1.68 and the latest nightly.