### PR TITLE
Make tests build

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -68,6 +68,13 @@ check-rust-stable-no_derive:
   script:
     - time cargo +stable check --verbose --features bit-vec,bytes,generic-array
 
+check-rust-stable-only_mel:
+  stage:                           check
+  <<:                              *docker-env
+  variables:
+    RUSTFLAGS:                     "-Cdebug-assertions=y -Dwarnings"
+  script:
+    - time cargo +stable check --features max-encoded-len
 
 #### stage:                        test
 
@@ -137,4 +144,3 @@ build-linux-ubuntu-amd64:
     - if: $CI_COMMIT_REF_NAME == "tags"
   script:
     - cargo build --verbose --release --features bit-vec,bytes,generic-array,derive
-

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -95,6 +95,22 @@ test-rust-stable-no_derive:
   script:
     - time cargo +stable test --verbose --features bit-vec,bytes,generic-array
 
+test-rust-stable-only_mel:
+  stage:                           test
+  <<:                              *docker-env
+  variables:
+    RUSTFLAGS:                     "-Cdebug-assertions=y -Dwarnings"
+  script:
+    - time cargo +stable test --verbose --features max-encoded-len
+
+test-rust-stable-only_mel-no_default_std:
+  stage:                           test
+  <<:                              *docker-env
+  variables:
+    RUSTFLAGS:                     "-Cdebug-assertions=y -Dwarnings"
+  script:
+    - time cargo +stable test --verbose --features max-encoded-len,std --no-default-features
+
 bench-rust-nightly:
   stage:                           test
   <<:                              *docker-env

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -74,7 +74,7 @@ check-rust-stable-only_mel:
   variables:
     RUSTFLAGS:                     "-Cdebug-assertions=y -Dwarnings"
   script:
-    - time cargo +stable check --features max-encoded-len
+    - time cargo +stable check --verbose --features max-encoded-len
 
 #### stage:                        test
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -91,7 +91,8 @@
 //!
 //! ### Simple types
 //!
-//! ```
+#![cfg_attr(feature = "derive", doc = "```rust")]
+#![cfg_attr(not(feature = "derive"), doc = "*(Only compiled with feature `derive`)*\n```ignore")]
 //! # use parity_scale_codec_derive::{Encode as DeriveEncode, Decode as DeriveDecode};
 //!
 //! use parity_scale_codec::{Encode, Decode};
@@ -140,7 +141,8 @@
 //!
 //! ### Compact type with HasCompact
 //!
-//! ```
+#![cfg_attr(feature = "derive", doc = "```rust")]
+#![cfg_attr(not(feature = "derive"), doc = "*(Only compiled with feature `derive`)*\n```ignore")]
 //! # use parity_scale_codec_derive::{Encode as DeriveEncode, Decode as DeriveDecode};
 //!
 //! use parity_scale_codec::{Encode, Decode, Compact, HasCompact};
@@ -167,7 +169,8 @@
 //! ```
 //! ### Type with CompactAs
 //!
-//! ```rust
+#![cfg_attr(feature = "derive", doc = "```rust")]
+#![cfg_attr(not(feature = "derive"), doc = "*(Only compiled with feature `derive`)*\n```ignore")]
 //! # use parity_scale_codec_derive::{Encode as DeriveEncode, Decode as DeriveDecode};
 //! use serde_derive::{Serialize, Deserialize};
 //! use parity_scale_codec::{Encode, Decode, Compact, HasCompact, CompactAs, Error};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -92,13 +92,11 @@
 //! ### Simple types
 //!
 //! ```
-//! # // Import macros if derive feature is not used.
-//! # #[cfg(not(feature="derive"))]
-//! # use parity_scale_codec_derive::{Encode, Decode};
+//! # use parity_scale_codec_derive::{Encode as DeriveEncode, Decode as DeriveDecode};
 //!
 //! use parity_scale_codec::{Encode, Decode};
 //!
-//! #[derive(Debug, PartialEq, Encode, Decode)]
+//! #[derive(Debug, PartialEq, DeriveEncode, DeriveDecode)]
 //! enum EnumType {
 //! 	#[codec(index = 15)]
 //! 	A,
@@ -143,19 +141,17 @@
 //! ### Compact type with HasCompact
 //!
 //! ```
-//! # // Import macros if derive feature is not used.
-//! # #[cfg(not(feature="derive"))]
-//! # use parity_scale_codec_derive::{Encode, Decode};
+//! # use parity_scale_codec_derive::{Encode as DeriveEncode, Decode as DeriveDecode};
 //!
 //! use parity_scale_codec::{Encode, Decode, Compact, HasCompact};
 //!
-//! #[derive(Debug, PartialEq, Encode, Decode)]
+//! #[derive(Debug, PartialEq, DeriveEncode, DeriveDecode)]
 //! struct Test1CompactHasCompact<T: HasCompact> {
 //!     #[codec(compact)]
 //!     bar: T,
 //! }
 //!
-//! #[derive(Debug, PartialEq, Encode, Decode)]
+//! #[derive(Debug, PartialEq, DeriveEncode, DeriveDecode)]
 //! struct Test1HasCompact<T: HasCompact> {
 //!     #[codec(encoded_as = "<T as HasCompact>::Type")]
 //!     bar: T,
@@ -172,10 +168,7 @@
 //! ### Type with CompactAs
 //!
 //! ```rust
-//! # // Import macros if derive feature is not used.
-//! # #[cfg(not(feature="derive"))]
-//! # use parity_scale_codec_derive::{Encode, Decode};
-//!
+//! # use parity_scale_codec_derive::{Encode as DeriveEncode, Decode as DeriveDecode};
 //! use serde_derive::{Serialize, Deserialize};
 //! use parity_scale_codec::{Encode, Decode, Compact, HasCompact, CompactAs, Error};
 //!
@@ -201,7 +194,7 @@
 //!     }
 //! }
 //!
-//! #[derive(Debug, PartialEq, Encode, Decode)]
+//! #[derive(Debug, PartialEq, DeriveEncode, DeriveDecode)]
 //! enum TestGenericHasCompact<T> {
 //!     A {
 //!         #[codec(compact)] a: T

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -93,11 +93,9 @@
 //!
 #![cfg_attr(feature = "derive", doc = "```rust")]
 #![cfg_attr(not(feature = "derive"), doc = "*(Only compiled with feature `derive`)*\n```ignore")]
-//! # use parity_scale_codec_derive::{Encode as DeriveEncode, Decode as DeriveDecode};
-//!
 //! use parity_scale_codec::{Encode, Decode};
 //!
-//! #[derive(Debug, PartialEq, DeriveEncode, DeriveDecode)]
+//! #[derive(Debug, PartialEq, Encode, Decode)]
 //! enum EnumType {
 //! 	#[codec(index = 15)]
 //! 	A,
@@ -143,17 +141,15 @@
 //!
 #![cfg_attr(feature = "derive", doc = "```rust")]
 #![cfg_attr(not(feature = "derive"), doc = "*(Only compiled with feature `derive`)*\n```ignore")]
-//! # use parity_scale_codec_derive::{Encode as DeriveEncode, Decode as DeriveDecode};
-//!
 //! use parity_scale_codec::{Encode, Decode, Compact, HasCompact};
 //!
-//! #[derive(Debug, PartialEq, DeriveEncode, DeriveDecode)]
+//! #[derive(Debug, PartialEq, Encode, Decode)]
 //! struct Test1CompactHasCompact<T: HasCompact> {
 //!     #[codec(compact)]
 //!     bar: T,
 //! }
 //!
-//! #[derive(Debug, PartialEq, DeriveEncode, DeriveDecode)]
+//! #[derive(Debug, PartialEq, Encode, Decode)]
 //! struct Test1HasCompact<T: HasCompact> {
 //!     #[codec(encoded_as = "<T as HasCompact>::Type")]
 //!     bar: T,
@@ -171,7 +167,6 @@
 //!
 #![cfg_attr(feature = "derive", doc = "```rust")]
 #![cfg_attr(not(feature = "derive"), doc = "*(Only compiled with feature `derive`)*\n```ignore")]
-//! # use parity_scale_codec_derive::{Encode as DeriveEncode, Decode as DeriveDecode};
 //! use serde_derive::{Serialize, Deserialize};
 //! use parity_scale_codec::{Encode, Decode, Compact, HasCompact, CompactAs, Error};
 //!
@@ -197,7 +192,7 @@
 //!     }
 //! }
 //!
-//! #[derive(Debug, PartialEq, DeriveEncode, DeriveDecode)]
+//! #[derive(Debug, PartialEq, Encode, Decode)]
 //! enum TestGenericHasCompact<T> {
 //!     A {
 //!         #[codec(compact)] a: T

--- a/tests/chain-error.rs
+++ b/tests/chain-error.rs
@@ -12,22 +12,21 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#[cfg(not(feature="derive"))]
-use parity_scale_codec_derive::Decode;
+use parity_scale_codec_derive::Decode as DeriveDecode;
 use parity_scale_codec::Decode;
 
-#[derive(Decode, Debug)]
+#[derive(DeriveDecode, Debug)]
 struct Wrapper<T>(T);
 
-#[derive(Decode, Debug)]
+#[derive(DeriveDecode, Debug)]
 struct StructNamed {
 	_foo: u16
 }
 
-#[derive(Decode, Debug)]
+#[derive(DeriveDecode, Debug)]
 struct StructUnnamed(u16);
 
-#[derive(Decode, Debug)]
+#[derive(DeriveDecode, Debug)]
 enum E {
 	VariantNamed { _foo: u16, },
 	VariantUnnamed(u16),

--- a/tests/mod.rs
+++ b/tests/mod.rs
@@ -15,24 +15,23 @@
 use parity_scale_codec::{
 	Compact, CompactAs, Decode, Encode, EncodeAsRef, Error, HasCompact, Output,
 };
-#[cfg(not(feature = "derive"))]
-use parity_scale_codec_derive::{Decode, Encode};
+use parity_scale_codec_derive::{Decode as DeriveDecode, Encode as DeriveEncode};
 use serde_derive::{Deserialize, Serialize};
 
-#[derive(Debug, PartialEq, Encode, Decode)]
+#[derive(Debug, PartialEq, DeriveEncode, DeriveDecode)]
 struct Unit;
 
-#[derive(Debug, PartialEq, Encode, Decode)]
+#[derive(Debug, PartialEq, DeriveEncode, DeriveDecode)]
 struct Indexed(u32, u64);
 
-#[derive(Debug, PartialEq, Encode, Decode, Default)]
+#[derive(Debug, PartialEq, DeriveEncode, DeriveDecode, Default)]
 struct Struct<A, B, C> {
 	pub a: A,
 	pub b: B,
 	pub c: C,
 }
 
-#[derive(Debug, PartialEq, Encode, Decode)]
+#[derive(Debug, PartialEq, DeriveEncode, DeriveDecode)]
 struct StructWithPhantom {
 	pub a: u32,
 	pub b: u64,
@@ -47,7 +46,7 @@ impl<A, B, C> Struct<A, B, C> {
 	}
 }
 
-#[derive(Debug, PartialEq, Encode, Decode)]
+#[derive(Debug, PartialEq, DeriveEncode, DeriveDecode)]
 enum EnumType {
 	#[codec(index = 15)]
 	A,
@@ -58,26 +57,26 @@ enum EnumType {
 	},
 }
 
-#[derive(Debug, PartialEq, Encode, Decode)]
+#[derive(Debug, PartialEq, DeriveEncode, DeriveDecode)]
 enum EnumWithDiscriminant {
 	A = 1,
 	B = 15,
 	C = 255,
 }
 
-#[derive(Debug, PartialEq, Encode, Decode)]
+#[derive(Debug, PartialEq, DeriveEncode, DeriveDecode)]
 struct TestHasCompact<T: HasCompact> {
 	#[codec(encoded_as = "<T as HasCompact>::Type")]
 	bar: T,
 }
 
-#[derive(Debug, PartialEq, Encode, Decode)]
+#[derive(Debug, PartialEq, DeriveEncode, DeriveDecode)]
 struct TestCompactHasCompact<T: HasCompact> {
 	#[codec(compact)]
 	bar: T,
 }
 
-#[derive(Debug, PartialEq, Encode, Decode)]
+#[derive(Debug, PartialEq, DeriveEncode, DeriveDecode)]
 enum TestHasCompactEnum<T: HasCompact> {
 	Unnamed(#[codec(encoded_as = "<T as HasCompact>::Type")] T),
 	Named {
@@ -91,13 +90,13 @@ enum TestHasCompactEnum<T: HasCompact> {
 	},
 }
 
-#[derive(Debug, PartialEq, Encode, Decode)]
+#[derive(Debug, PartialEq, DeriveEncode, DeriveDecode)]
 struct TestCompactAttribute {
 	#[codec(compact)]
 	bar: u64,
 }
 
-#[derive(Debug, PartialEq, Encode, Decode)]
+#[derive(Debug, PartialEq, DeriveEncode, DeriveDecode)]
 enum TestCompactAttributeEnum {
 	Unnamed(#[codec(compact)] u64),
 	Named {
@@ -330,7 +329,7 @@ fn associated_type_bounds() {
 		type NonEncodableType;
 	}
 
-	#[derive(Encode, Decode, Debug, PartialEq)]
+	#[derive(DeriveEncode, DeriveDecode, Debug, PartialEq)]
 	struct Struct<T: Trait, Type> {
 		field: (Vec<T::EncodableType>, Type),
 	}
@@ -372,7 +371,7 @@ fn generic_bound_encoded_as() {
 		type RefType = &'a u32;
 	}
 
-	#[derive(Debug, PartialEq, Encode, Decode)]
+	#[derive(Debug, PartialEq, DeriveEncode, DeriveDecode)]
 	struct TestGeneric<A: From<u32>>
 	where
 		u32: for<'a> EncodeAsRef<'a, A>,
@@ -408,7 +407,7 @@ fn generic_bound_hascompact() {
 		}
 	}
 
-	#[derive(Debug, PartialEq, Encode, Decode)]
+	#[derive(Debug, PartialEq, DeriveEncode, DeriveDecode)]
 	enum TestGenericHasCompact<T> {
 		A {
 			#[codec(compact)]
@@ -429,14 +428,14 @@ fn generic_trait() {
 
 	struct StructNoCodec;
 
-	#[derive(Debug, PartialEq, Encode, Decode)]
+	#[derive(Debug, PartialEq, DeriveEncode, DeriveDecode)]
 	struct StructCodec;
 
 	impl TraitNoCodec for StructNoCodec {
 		type Type = StructCodec;
 	}
 
-	#[derive(Debug, PartialEq, Encode, Decode)]
+	#[derive(Debug, PartialEq, DeriveEncode, DeriveDecode)]
 	struct TestGenericTrait<T: TraitNoCodec> {
 		t: T::Type,
 	}
@@ -448,7 +447,7 @@ fn generic_trait() {
 
 #[test]
 fn recursive_variant_1_encode_works() {
-	#[derive(Debug, PartialEq, Encode, Decode, Default)]
+	#[derive(Debug, PartialEq, DeriveEncode, DeriveDecode, Default)]
 	struct Recursive<N> {
 		data: N,
 		other: Vec<Recursive<N>>,
@@ -460,7 +459,7 @@ fn recursive_variant_1_encode_works() {
 
 #[test]
 fn recursive_variant_2_encode_works() {
-	#[derive(Debug, PartialEq, Encode, Decode, Default)]
+	#[derive(Debug, PartialEq, DeriveEncode, DeriveDecode, Default)]
 	struct Recursive<A, B, N> {
 		data: N,
 		other: Vec<Struct<A, B, Recursive<A, B, N>>>,
@@ -476,10 +475,10 @@ fn private_type_in_where_bound() {
 	// an error.
 	#![deny(warnings)]
 
-	#[derive(Debug, PartialEq, Encode, Decode, Default)]
+	#[derive(Debug, PartialEq, DeriveEncode, DeriveDecode, Default)]
 	struct Private;
 
-	#[derive(Debug, PartialEq, Encode, Decode, Default)]
+	#[derive(Debug, PartialEq, DeriveEncode, DeriveDecode, Default)]
 	#[codec(dumb_trait_bound)]
 	pub struct Test<N> {
 		data: Vec<(N, Private)>,
@@ -491,7 +490,7 @@ fn private_type_in_where_bound() {
 
 #[test]
 fn encode_decode_empty_enum() {
-	#[derive(Encode, Decode, PartialEq, Debug)]
+	#[derive(DeriveEncode, DeriveDecode, PartialEq, Debug)]
 	enum EmptyEnumDerive {}
 
 	fn impls_encode_decode<T: Encode + Decode>() {}
@@ -513,13 +512,13 @@ fn codec_vec_u8() {
 
 #[test]
 fn recursive_type() {
-	#[derive(Encode, Decode)]
+	#[derive(DeriveEncode, DeriveDecode)]
 	pub enum Foo {
 		T(Box<Bar>),
 		A,
 	}
 
-	#[derive(Encode, Decode)]
+	#[derive(DeriveEncode, DeriveDecode)]
 	pub struct Bar {
 		field: Foo,
 	}
@@ -567,7 +566,7 @@ fn weird_derive() {
 		};
 	}
 
-	make_struct!(#[derive(Encode, Decode)]);
+	make_struct!(#[derive(DeriveEncode, DeriveDecode)]);
 }
 
 #[test]
@@ -577,7 +576,7 @@ fn output_trait_object() {
 
 #[test]
 fn custom_trait_bound() {
-	#[derive(Encode, Decode)]
+	#[derive(DeriveEncode, DeriveDecode)]
 	#[codec(encode_bound(N: Encode, T: Default))]
 	#[codec(decode_bound(N: Decode, T: Default))]
 	struct Something<T, N> {
@@ -585,7 +584,7 @@ fn custom_trait_bound() {
 		val: N,
 	}
 
-	#[derive(Encode, Decode)]
+	#[derive(DeriveEncode, DeriveDecode)]
 	#[codec(encode_bound())]
 	#[codec(decode_bound())]
 	struct Hello<T> {
@@ -637,7 +636,7 @@ fn bit_vec_works() {
 
 #[test]
 fn no_warning_for_deprecated() {
-	#[derive(Encode, Decode)]
+	#[derive(DeriveEncode, DeriveDecode)]
 	pub enum MyEnum {
 		VariantA,
 		#[deprecated]

--- a/tests/mod.rs
+++ b/tests/mod.rs
@@ -619,7 +619,7 @@ fn bit_vec_works() {
 
 	assert_eq!(original_vec, original_vec_clone);
 
-	#[derive(Decode, Encode, PartialEq, Debug)]
+	#[derive(DeriveDecode, DeriveEncode, PartialEq, Debug)]
 	struct MyStruct {
 		v: BitVec<u8, Msb0>,
 		x: u8,

--- a/tests/single_field_struct_encoding.rs
+++ b/tests/single_field_struct_encoding.rs
@@ -1,17 +1,14 @@
-#[cfg(not(feature="derive"))]
-use parity_scale_codec_derive::{Encode, Decode, CompactAs};
-#[cfg(feature="derive")]
-use parity_scale_codec::CompactAs;
+use parity_scale_codec_derive::{Encode as DeriveEncode, Decode as DeriveDecode, CompactAs as DeriveCompactAs};
 use parity_scale_codec::{Compact, Decode, Encode, HasCompact};
 use serde_derive::{Serialize, Deserialize};
 
-#[derive(Debug, PartialEq, Encode, Decode)]
+#[derive(Debug, PartialEq, DeriveEncode, DeriveDecode)]
 struct S {
 	x: u32,
 }
 
 #[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
-#[derive(Debug, PartialEq, Eq, Clone, Copy, Encode, Decode, CompactAs)]
+#[derive(Debug, PartialEq, Eq, Clone, Copy, DeriveEncode, DeriveDecode, DeriveCompactAs)]
 struct SSkip {
 	#[codec(skip)]
 	s1: u32,
@@ -20,43 +17,43 @@ struct SSkip {
 	s2: u32,
 }
 
-#[derive(Debug, PartialEq, Encode, Decode)]
+#[derive(Debug, PartialEq, DeriveEncode, DeriveDecode)]
 struct Sc {
 	#[codec(compact)]
 	x: u32,
 }
 
-#[derive(Debug, PartialEq, Encode, Decode)]
+#[derive(Debug, PartialEq, DeriveEncode, DeriveDecode)]
 struct Sh<T: HasCompact> {
 	#[codec(encoded_as = "<T as HasCompact>::Type")]
 	x: T,
 }
 
 #[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
-#[derive(Debug, PartialEq, Eq, Clone, Copy, Encode, Decode, CompactAs)]
+#[derive(Debug, PartialEq, Eq, Clone, Copy, DeriveEncode, DeriveDecode, DeriveCompactAs)]
 struct U(u32);
 
 #[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
-#[derive(Debug, PartialEq, Eq, Clone, Copy, Encode, Decode, CompactAs)]
+#[derive(Debug, PartialEq, Eq, Clone, Copy, DeriveEncode, DeriveDecode, DeriveCompactAs)]
 struct U2 { a: u64 }
 
 #[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
-#[derive(Debug, PartialEq, Eq, Clone, Copy, Encode, Decode, CompactAs)]
+#[derive(Debug, PartialEq, Eq, Clone, Copy, DeriveEncode, DeriveDecode, DeriveCompactAs)]
 struct USkip(#[codec(skip)] u32, u32, #[codec(skip)] u32);
 
-#[derive(Debug, PartialEq, Encode, Decode)]
+#[derive(Debug, PartialEq, DeriveEncode, DeriveDecode)]
 struct Uc(#[codec(compact)] u32);
 
-#[derive(Debug, PartialEq, Clone, Encode, Decode)]
+#[derive(Debug, PartialEq, Clone, DeriveEncode, DeriveDecode)]
 struct Ucas(#[codec(compact)] U);
 
-#[derive(Debug, PartialEq, Clone, Encode, Decode)]
+#[derive(Debug, PartialEq, Clone, DeriveEncode, DeriveDecode)]
 struct USkipcas(#[codec(compact)] USkip);
 
-#[derive(Debug, PartialEq, Clone, Encode, Decode)]
+#[derive(Debug, PartialEq, Clone, DeriveEncode, DeriveDecode)]
 struct SSkipcas(#[codec(compact)] SSkip);
 
-#[derive(Debug, PartialEq, Encode, Decode)]
+#[derive(Debug, PartialEq, DeriveEncode, DeriveDecode)]
 struct Uh<T: HasCompact>(#[codec(encoded_as = "<T as HasCompact>::Type")] T);
 
 #[test]

--- a/tests/skip.rs
+++ b/tests/skip.rs
@@ -1,5 +1,4 @@
-#[cfg(not(feature="derive"))]
-use parity_scale_codec_derive::{Encode, Decode};
+use parity_scale_codec_derive::{Encode as DeriveEncode, Decode as DeriveDecode};
 use parity_scale_codec::{Encode, Decode};
 
 #[test]
@@ -10,7 +9,8 @@ fn enum_struct_test() {
 	#[derive(PartialEq, Debug)]
 	struct UncodecUndefaultType;
 
-	#[derive(PartialEq, Debug, Encode, Decode)]
+use parity_scale_codec_derive::{Encode as DeriveEncode, Decode as DeriveDecode};
+	#[derive(PartialEq, Debug, DeriveEncode, DeriveDecode)]
 	enum Enum<T=UncodecType, S=UncodecUndefaultType> {
 		#[codec(skip)]
 		A(S),
@@ -26,14 +26,14 @@ fn enum_struct_test() {
 		),
 	}
 
-	#[derive(PartialEq, Debug, Encode, Decode)]
+	#[derive(PartialEq, Debug, DeriveEncode, DeriveDecode)]
 	struct StructNamed<T=UncodecType> {
 		#[codec(skip)]
 		a: T,
 		b: u32,
 	}
 
-	#[derive(PartialEq, Debug, Encode, Decode)]
+	#[derive(PartialEq, Debug, DeriveEncode, DeriveDecode)]
 	struct StructUnnamed<T=UncodecType>(
 		#[codec(skip)]
 		T,
@@ -64,7 +64,7 @@ fn skip_enum_struct_inner_variant() {
 	// Make sure the skipping does not generates a warning.
 	#![deny(warnings)]
 
-	#[derive(Encode, Decode)]
+	#[derive(DeriveEncode, DeriveDecode)]
 	enum Enum {
 		Data {
 			some_named: u32,

--- a/tests/type_inference.rs
+++ b/tests/type_inference.rs
@@ -14,8 +14,7 @@
 
 //! Test for type inference issue in decode.
 
-#[cfg(not(feature = "derive"))]
-use parity_scale_codec_derive::Decode;
+use parity_scale_codec_derive::Decode as DeriveDecode;
 use parity_scale_codec::Decode;
 
 pub trait Trait {
@@ -23,7 +22,7 @@ pub trait Trait {
 	type AccountId: Decode;
 }
 
-#[derive(Decode)]
+#[derive(DeriveDecode)]
 pub enum A<T: Trait> {
 	_C(
 		(T::AccountId, T::AccountId),
@@ -31,5 +30,5 @@ pub enum A<T: Trait> {
 	),
 }
 
-#[derive(Decode)]
+#[derive(DeriveDecode)]
 pub struct B<T: Trait>((T::AccountId, T::AccountId), Vec<(T::Value, T::Value)>);

--- a/tests/variant_number.rs
+++ b/tests/variant_number.rs
@@ -1,10 +1,9 @@
-#[cfg(not(feature="derive"))]
-use parity_scale_codec_derive::Encode;
+use parity_scale_codec_derive::Encode as DeriveEncode;
 use parity_scale_codec::Encode;
 
 #[test]
 fn discriminant_variant_counted_in_default_index() {
-	#[derive(Encode)]
+	#[derive(DeriveEncode)]
 	enum T {
 		A = 1,
 		B,
@@ -16,7 +15,7 @@ fn discriminant_variant_counted_in_default_index() {
 
 #[test]
 fn skipped_variant_not_counted_in_default_index() {
-	#[derive(Encode)]
+	#[derive(DeriveEncode)]
 	enum T {
 		#[codec(skip)]
 		A,
@@ -29,7 +28,7 @@ fn skipped_variant_not_counted_in_default_index() {
 
 #[test]
 fn index_attr_variant_counted_and_reused_in_default_index() {
-	#[derive(Encode)]
+	#[derive(DeriveEncode)]
 	enum T {
 		#[codec(index = 1)]
 		A,


### PR DESCRIPTION
Tests do not build with only MEL feature as pointed out in https://github.com/paritytech/parity-scale-codec/pull/428#pullrequestreview-1407066751

This standard pattern that is used multiple times in the code does not actually work:  
```rust
#[cfg(not(feature = "derive"))]
use parity_scale_codec_derive::Decode;
use parity_scale_codec::Decode;
```
It errors with a redefinition of `Decode` when the feature is disabled. I aliased them in the tests now to `DeriveDecode`.  
It is a bit unfortunate that `parity_scale_codec::Decode` is both a trait and a derive macro, depending on the features.