### PR TITLE
Fix stack overflow when decoding big array newtypes wrapped in a `Box`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this crate are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this crate adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.6.2]
+
+### Fixed
+
+- Trying to deserialize a boxed newtype containing a big array won't overflow the stack anymore.
+
 ## [3.6.1] - 2023-06-19
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this crate are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this crate adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [3.6.2]
+## [3.6.2] - 2023-06-30
 
 ### Fixed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -568,7 +568,7 @@ checksum = "ceedf44fb00f2d1984b0bc98102627ce622e083e49a5bacdb3e514fa4238e267"
 
 [[package]]
 name = "parity-scale-codec"
-version = "3.6.1"
+version = "3.6.2"
 dependencies = [
  "arbitrary",
  "arrayvec",
@@ -589,7 +589,7 @@ dependencies = [
 
 [[package]]
 name = "parity-scale-codec-derive"
-version = "3.6.1"
+version = "3.6.2"
 dependencies = [
  "parity-scale-codec",
  "proc-macro-crate",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "parity-scale-codec"
 description = "SCALE - Simple Concatenating Aggregated Little Endians"
-version = "3.6.1"
+version = "3.6.2"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "Apache-2.0"
 repository = "https://github.com/paritytech/parity-scale-codec"
@@ -12,7 +12,7 @@ rust-version = "1.60.0"
 [dependencies]
 arrayvec = { version = "0.7", default-features = false }
 serde = { version = "1.0.164", optional = true }
-parity-scale-codec-derive = { path = "derive", version = ">= 3.6.1", default-features = false, optional = true }
+parity-scale-codec-derive = { path = "derive", version = ">= 3.6.2", default-features = false, optional = true }
 bitvec = { version = "1", default-features = false, features = [ "alloc" ], optional = true }
 bytes = { version = "1", default-features = false, optional = true }
 byte-slice-cast = { version = "1.2.2", default-features = false }

--- a/derive/Cargo.toml
+++ b/derive/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "parity-scale-codec-derive"
 description = "Serialization and deserialization derive macro for Parity SCALE Codec"
-version = "3.6.1"
+version = "3.6.2"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "Apache-2.0"
 edition = "2021"

--- a/derive/src/decode.rs
+++ b/derive/src/decode.rs
@@ -160,7 +160,7 @@ pub fn quote_decode_into(
 	let mut decode_fields = Vec::new();
 	let mut sizes = Vec::new();
 	for field in fields {
-	let field_type = &field.ty;
+		let field_type = &field.ty;
 		decode_fields.push(quote! {{
 			let dst_: &mut ::core::mem::MaybeUninit<Self> = dst_; // To make sure the type is what we expect.
 

--- a/derive/src/utils.rs
+++ b/derive/src/utils.rs
@@ -20,7 +20,7 @@
 use std::str::FromStr;
 
 use proc_macro2::TokenStream;
-use quote::quote;
+use quote::{ToTokens, quote};
 use syn::{
 	parse::Parse, punctuated::Punctuated, spanned::Spanned, token, Attribute, Data, DeriveInput,
 	Field, Fields, FieldsNamed, FieldsUnnamed, Lit, Meta, MetaNameValue, NestedMeta, Path, Variant,
@@ -430,4 +430,24 @@ fn check_top_attribute(attr: &Attribute) -> syn::Result<()> {
 	} else {
 		Ok(())
 	}
+}
+
+fn check_repr(attrs: &[syn::Attribute], value: &str) -> bool {
+	let mut result = false;
+	for raw_attr in attrs {
+		let path = raw_attr.path.clone().into_token_stream().to_string();
+		if path != "repr" {
+			continue;
+		}
+
+		result = raw_attr.tokens.clone().into_token_stream().to_string() == value;
+	}
+
+	result
+}
+
+/// Checks whether the given attributes contain a `#[repr(transparent)]`.
+pub fn is_transparent(attrs: &[syn::Attribute]) -> bool {
+	// TODO: When migrating to syn 2 the `"(transparent)"` needs to be changed into `"transparent"`.
+	check_repr(attrs, "(transparent)")
 }


### PR DESCRIPTION
Followup of https://github.com/paritytech/parity-scale-codec/pull/426

This PR fixes decoding of big array newtypes wrapped in a `Box`, e.g. previously only this was correctly deserialized:

```rust
#[derive(Decode)]
struct Foobar(Box<[1024 * 1024 * 1024; u8]>);
```

And now this will also be correctly handled:

```rust
#[repr(transparent)]
struct Newtype([1024 * 1024 * 1024; u8]);

#[derive(Decode)]
struct Foobar(Box<Newtype>);
```

(The newtype *must* be marked with `#[repr(transparent)]`; without that attribute it will still crash.)

Fixes https://github.com/paritytech/parity-scale-codec/issues/419