### PR TITLE
Fix prelude imports in `decode_into`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this crate are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this crate adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.6.3] - 2023-07-03
+
+### Fixed
+
+- Provide full path to elements from `::core` in `Decode` derivation (caused compilation error when 
+  `no-implicit-prelude` was used).
+
 ## [3.6.2] - 2023-06-30
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -568,7 +568,7 @@ checksum = "ceedf44fb00f2d1984b0bc98102627ce622e083e49a5bacdb3e514fa4238e267"
 
 [[package]]
 name = "parity-scale-codec"
-version = "3.6.2"
+version = "3.6.3"
 dependencies = [
  "arbitrary",
  "arrayvec",
@@ -589,7 +589,7 @@ dependencies = [
 
 [[package]]
 name = "parity-scale-codec-derive"
-version = "3.6.2"
+version = "3.6.3"
 dependencies = [
  "parity-scale-codec",
  "proc-macro-crate",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "parity-scale-codec"
 description = "SCALE - Simple Concatenating Aggregated Little Endians"
-version = "3.6.2"
+version = "3.6.3"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "Apache-2.0"
 repository = "https://github.com/paritytech/parity-scale-codec"
@@ -12,7 +12,7 @@ rust-version = "1.60.0"
 [dependencies]
 arrayvec = { version = "0.7", default-features = false }
 serde = { version = "1.0.164", optional = true }
-parity-scale-codec-derive = { path = "derive", version = ">= 3.6.2", default-features = false, optional = true }
+parity-scale-codec-derive = { path = "derive", version = ">= 3.6.3", default-features = false, optional = true }
 bitvec = { version = "1", default-features = false, features = [ "alloc" ], optional = true }
 bytes = { version = "1", default-features = false, optional = true }
 byte-slice-cast = { version = "1.2.2", default-features = false }

--- a/derive/Cargo.toml
+++ b/derive/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "parity-scale-codec-derive"
 description = "Serialization and deserialization derive macro for Parity SCALE Codec"
-version = "3.6.2"
+version = "3.6.3"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "Apache-2.0"
 edition = "2021"

--- a/derive/src/decode.rs
+++ b/derive/src/decode.rs
@@ -188,13 +188,13 @@ pub fn quote_decode_into(
 
 	Some(quote!{
 		// Just a sanity check. These should always be true and will be optimized-out.
-		assert_eq!(#(#sizes)*, ::core::mem::size_of::<Self>());
-		assert!(#(#non_zst_field_count)* <= 1);
+		::core::assert_eq!(#(#sizes)*, ::core::mem::size_of::<Self>());
+		::core::assert!(#(#non_zst_field_count)* <= 1);
 
 		#(#decode_fields)*
 
 		// SAFETY: We've successfully called `decode_into` for all of the fields.
-		unsafe { Ok(#crate_path::DecodeFinished::assert_decoding_finished()) }
+		unsafe { ::core::result::Result::Ok(#crate_path::DecodeFinished::assert_decoding_finished()) }
 	})
 }
 

--- a/tests/scale_codec_ui/pass/decode-no-implicit-prelude.rs
+++ b/tests/scale_codec_ui/pass/decode-no-implicit-prelude.rs
@@ -10,6 +10,12 @@ pub struct Struct {
 }
 
 #[derive(::parity_scale_codec::Decode)]
+#[repr(transparent)]
+struct Transparent {
+    a: u8
+}
+
+#[derive(::parity_scale_codec::Decode)]
 #[codec(crate = ::parity_scale_codec)]
 pub enum Enum {
     Variant1,


### PR DESCRIPTION
The Friday release was using bare `Ok` and `assert_eq`, which fails when `no-implicit-prelude` attribute is used. This causes ink master and PRs to fail (https://github.com/paritytech/ink/pull/1830).

This PR fixes it and bumps patch version