### PR TITLE
[Do not merge] migration to ci-unified image

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -10,7 +10,7 @@ variables:
   GIT_STRATEGY:                    fetch
   GIT_DEPTH:                       "100"
   CARGO_INCREMENTAL:               0
-  CI_IMAGE:                        "paritytech/parity-scale-codec:production"
+  CI_IMAGE:                        "paritytech/ci-unified:bullseye-1.70.0-2023-05-23"
 
 default:
   cache:                           {}


### PR DESCRIPTION
New [ci-unified](https://github.com/paritytech/scripts/tree/master/dockerfiles/ci-unified) image for pipelines ($CI_IMAGE)
Replaces base-ci-linux and derived
Relates to https://github.com/paritytech/ci_cd/issues/821