### PR TITLE
Prevent serde from bringing in `std` unless the `std` feature is enabled for this crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ rust-version = "1.60.0"
 
 [dependencies]
 arrayvec = { version = "0.7", default-features = false }
-serde = { version = "1.0.183", default-features = false }
+serde = { version = "1.0.183", default-features = false, optional = true }
 parity-scale-codec-derive = { path = "derive", version = ">= 3.6.4", default-features = false, optional = true }
 bitvec = { version = "1", default-features = false, features = [ "alloc" ], optional = true }
 bytes = { version = "1", default-features = false, optional = true }
@@ -39,7 +39,7 @@ bench = false
 [features]
 default = ["std"]
 derive = ["parity-scale-codec-derive"]
-std = ["bitvec?/std", "byte-slice-cast/std", "chain-error"]
+std = ["serde/std", "bitvec?/std", "byte-slice-cast/std", "chain-error"]
 bit-vec = ["bitvec"]
 fuzz = ["std", "arbitrary"]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ rust-version = "1.60.0"
 
 [dependencies]
 arrayvec = { version = "0.7", default-features = false }
-serde = { version = "1.0.183", default-features = false, features = ["alloc", "derive"], optional = true }
+serde = { version = "1.0.183", default-features = false }
 parity-scale-codec-derive = { path = "derive", version = ">= 3.6.4", default-features = false, optional = true }
 bitvec = { version = "1", default-features = false, features = [ "alloc" ], optional = true }
 bytes = { version = "1", default-features = false, optional = true }
@@ -39,7 +39,7 @@ bench = false
 [features]
 default = ["std"]
 derive = ["parity-scale-codec-derive"]
-std = ["serde/std", "bitvec?/std", "byte-slice-cast/std", "chain-error"]
+std = ["bitvec?/std", "byte-slice-cast/std", "chain-error"]
 bit-vec = ["bitvec"]
 fuzz = ["std", "arbitrary"]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ rust-version = "1.60.0"
 
 [dependencies]
 arrayvec = { version = "0.7", default-features = false }
-serde = { version = "1.0.183", optional = true }
+serde = { version = "1.0.183", default-features = false, features = ["alloc", "derive"], optional = true }
 parity-scale-codec-derive = { path = "derive", version = ">= 3.6.4", default-features = false, optional = true }
 bitvec = { version = "1", default-features = false, features = [ "alloc" ], optional = true }
 bytes = { version = "1", default-features = false, optional = true }
@@ -39,7 +39,7 @@ bench = false
 [features]
 default = ["std"]
 derive = ["parity-scale-codec-derive"]
-std = ["serde", "bitvec?/std", "byte-slice-cast/std", "chain-error"]
+std = ["serde/std", "bitvec?/std", "byte-slice-cast/std", "chain-error"]
 bit-vec = ["bitvec"]
 fuzz = ["std", "arbitrary"]
 

--- a/src/compact.rs
+++ b/src/compact.rs
@@ -192,12 +192,14 @@ impl<T> core::fmt::Debug for Compact<T> where T: core::fmt::Debug {
 	}
 }
 
+#[cfg(feature = "serde")]
 impl<T> serde::Serialize for Compact<T> where T: serde::Serialize {
 	fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error> where S: serde::Serializer {
 		T::serialize(&self.0, serializer)
 	}
 }
 
+#[cfg(feature = "serde")]
 impl<'de, T> serde::Deserialize<'de> for Compact<T> where T: serde::Deserialize<'de> {
 	fn deserialize<D>(deserializer: D) -> Result<Self, D::Error> where D: serde::Deserializer<'de> {
 		T::deserialize(deserializer).map(Compact)

--- a/src/compact.rs
+++ b/src/compact.rs
@@ -192,14 +192,12 @@ impl<T> core::fmt::Debug for Compact<T> where T: core::fmt::Debug {
 	}
 }
 
-#[cfg(feature = "std")]
 impl<T> serde::Serialize for Compact<T> where T: serde::Serialize {
 	fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error> where S: serde::Serializer {
 		T::serialize(&self.0, serializer)
 	}
 }
 
-#[cfg(feature = "std")]
 impl<'de, T> serde::Deserialize<'de> for Compact<T> where T: serde::Deserialize<'de> {
 	fn deserialize<D>(deserializer: D) -> Result<Self, D::Error> where D: serde::Deserializer<'de> {
 		T::deserialize(deserializer).map(Compact)


### PR DESCRIPTION
I ran into an issue using this crate in a `no_std` build where I wanted to have `serde` enabled, but without `std`. The change here addresses that.
Thank you!