### PR TITLE
Fix max_encoded_len for Compact fields

### DIFF
--- a/derive/src/max_encoded_len.rs
+++ b/derive/src/max_encoded_len.rs
@@ -17,7 +17,7 @@
 
 use crate::{
 	trait_bounds,
-	utils::{codec_crate_path, custom_mel_trait_bound, has_dumb_trait_bound, should_skip},
+	utils::{self, codec_crate_path, custom_mel_trait_bound, has_dumb_trait_bound, should_skip},
 };
 use quote::{quote, quote_spanned};
 use syn::{parse_quote, spanned::Spanned, Data, DeriveInput, Fields, Type};
@@ -43,13 +43,13 @@ pub fn derive_max_encoded_len(input: proc_macro::TokenStream) -> proc_macro::Tok
 		parse_quote!(#crate_path::MaxEncodedLen),
 		None,
 		has_dumb_trait_bound(&input.attrs),
-		&crate_path
+		&crate_path,
 	) {
 		return e.to_compile_error().into()
 	}
 	let (impl_generics, ty_generics, where_clause) = input.generics.split_for_impl();
 
-	let data_expr = data_length_expr(&input.data);
+	let data_expr = data_length_expr(&input.data, &crate_path);
 
 	quote::quote!(
 		const _: () = {
@@ -64,22 +64,24 @@ pub fn derive_max_encoded_len(input: proc_macro::TokenStream) -> proc_macro::Tok
 }
 
 /// generate an expression to sum up the max encoded length from several fields
-fn fields_length_expr(fields: &Fields) -> proc_macro2::TokenStream {
-	let type_iter: Box<dyn Iterator<Item = &Type>> = match fields {
-		Fields::Named(ref fields) => Box::new(
-			fields.named.iter().filter_map(|field| if should_skip(&field.attrs) {
+fn fields_length_expr(fields: &Fields, crate_path: &syn::Path) -> proc_macro2::TokenStream {
+	let type_iter: Box<dyn Iterator<Item = (&Type, bool)>> = match fields {
+		Fields::Named(ref fields) => Box::new(fields.named.iter().filter_map(|field| {
+			if should_skip(&field.attrs) {
 				None
 			} else {
-				Some(&field.ty)
-			})
-		),
-		Fields::Unnamed(ref fields) => Box::new(
-			fields.unnamed.iter().filter_map(|field| if should_skip(&field.attrs) {
+				let is_compact = utils::is_compact(&field);
+
+				Some((&field.ty, is_compact))
+			}
+		})),
+		Fields::Unnamed(ref fields) => Box::new(fields.unnamed.iter().filter_map(|field| {
+			if should_skip(&field.attrs) {
 				None
 			} else {
-				Some(&field.ty)
-			})
-		),
+				Some((&field.ty, false))
+			}
+		})),
 		Fields::Unit => Box::new(std::iter::empty()),
 	};
 	// expands to an expression like
@@ -92,9 +94,15 @@ fn fields_length_expr(fields: &Fields) -> proc_macro2::TokenStream {
 	// `max_encoded_len` call. This way, if one field's type doesn't implement
 	// `MaxEncodedLen`, the compiler's error message will underline which field
 	// caused the issue.
-	let expansion = type_iter.map(|ty| {
-		quote_spanned! {
-			ty.span() => .saturating_add(<#ty>::max_encoded_len())
+	let expansion = type_iter.map(|(ty, is_compact)| {
+		if is_compact {
+			quote_spanned! {
+				ty.span() => .saturating_add(#crate_path::Compact::<#ty>::max_encoded_len())
+			}
+		} else {
+			quote_spanned! {
+				ty.span() => .saturating_add(<#ty>::max_encoded_len())
+			}
 		}
 	});
 	quote! {
@@ -103,9 +111,9 @@ fn fields_length_expr(fields: &Fields) -> proc_macro2::TokenStream {
 }
 
 // generate an expression to sum up the max encoded length of each field
-fn data_length_expr(data: &Data) -> proc_macro2::TokenStream {
+fn data_length_expr(data: &Data, crate_path: &syn::Path) -> proc_macro2::TokenStream {
 	match *data {
-		Data::Struct(ref data) => fields_length_expr(&data.fields),
+		Data::Struct(ref data) => fields_length_expr(&data.fields, crate_path),
 		Data::Enum(ref data) => {
 			// We need an expression expanded for each variant like
 			//
@@ -121,7 +129,7 @@ fn data_length_expr(data: &Data) -> proc_macro2::TokenStream {
 			// Each variant expression's sum is computed the way an equivalent struct's would be.
 
 			let expansion = data.variants.iter().map(|variant| {
-				let variant_expression = fields_length_expr(&variant.fields);
+				let variant_expression = fields_length_expr(&variant.fields, crate_path);
 				quote! {
 					.max(#variant_expression)
 				}

--- a/derive/src/max_encoded_len.rs
+++ b/derive/src/max_encoded_len.rs
@@ -70,16 +70,14 @@ fn fields_length_expr(fields: &Fields, crate_path: &syn::Path) -> proc_macro2::T
 			if should_skip(&field.attrs) {
 				None
 			} else {
-				let is_compact = utils::is_compact(&field);
-
-				Some((&field.ty, is_compact))
+				Some((&field.ty, utils::is_compact(&field)))
 			}
 		})),
 		Fields::Unnamed(ref fields) => Box::new(fields.unnamed.iter().filter_map(|field| {
 			if should_skip(&field.attrs) {
 				None
 			} else {
-				Some((&field.ty, false))
+				Some((&field.ty, utils::is_compact(&field)))
 			}
 		})),
 		Fields::Unit => Box::new(std::iter::empty()),

--- a/derive/src/max_encoded_len.rs
+++ b/derive/src/max_encoded_len.rs
@@ -96,11 +96,11 @@ fn fields_length_expr(fields: &Fields, crate_path: &syn::Path) -> proc_macro2::T
 		let ty = &field.ty;
 		if utils::is_compact(&field) {
 			quote_spanned! {
-				ty.span() => .saturating_add(#crate_path::Compact::<#ty>::max_encoded_len())
+				ty.span() => .saturating_add(<#crate_path::Compact::<#ty> as #crate_path::MaxEncodedLen>::max_encoded_len())
 			}
 		} else {
 			quote_spanned! {
-				ty.span() => .saturating_add(<#ty>::max_encoded_len())
+				ty.span() => .saturating_add(<#ty as #crate_path::MaxEncodedLen>::max_encoded_len())
 			}
 		}
 	});

--- a/tests/max_encoded_len.rs
+++ b/tests/max_encoded_len.rs
@@ -75,7 +75,7 @@ struct CompactField {
 fn compact_field_max_length() {
 	assert_eq!(
 		CompactField::max_encoded_len(),
-		Compact::<u64>::max_encoded_len() + <u64>::max_encoded_len()
+		Compact::<u64>::max_encoded_len() + u64::max_encoded_len()
 	);
 }
 

--- a/tests/max_encoded_len.rs
+++ b/tests/max_encoded_len.rs
@@ -71,6 +71,22 @@ struct CompactField {
 	v: u64,
 }
 
+#[test]
+fn compact_field_max_length() {
+	assert_eq!(
+		CompactField::max_encoded_len(),
+		Compact::<u64>::max_encoded_len() + <u64>::max_encoded_len()
+	);
+}
+
+#[derive(Encode, MaxEncodedLen)]
+struct CompactStruct(#[codec(compact)] u64);
+
+#[test]
+fn compact_struct_max_length() {
+	assert_eq!(CompactStruct::max_encoded_len(), Compact::<u64>::max_encoded_len());
+}
+
 #[derive(Encode, MaxEncodedLen)]
 struct TwoGenerics<T, U> {
 	t: T,

--- a/tests/max_encoded_len.rs
+++ b/tests/max_encoded_len.rs
@@ -16,7 +16,7 @@
 //! Tests for MaxEncodedLen derive macro
 #![cfg(all(feature = "derive", feature = "max-encoded-len"))]
 
-use parity_scale_codec::{MaxEncodedLen, Compact, Decode, Encode};
+use parity_scale_codec::{Compact, Decode, Encode, MaxEncodedLen};
 
 #[derive(Encode, MaxEncodedLen)]
 struct Primitives {
@@ -62,6 +62,13 @@ struct Generic<T> {
 fn generic_max_length() {
 	assert_eq!(Generic::<u8>::max_encoded_len(), u8::max_encoded_len() * 2);
 	assert_eq!(Generic::<u32>::max_encoded_len(), u32::max_encoded_len() * 2);
+}
+
+#[derive(Encode, MaxEncodedLen)]
+struct CompactField {
+	#[codec(compact)]
+	t: u64,
+	v: u64,
 }
 
 #[derive(Encode, MaxEncodedLen)]

--- a/tests/max_encoded_len_ui/unsupported_variant.stderr
+++ b/tests/max_encoded_len_ui/unsupported_variant.stderr
@@ -1,12 +1,16 @@
-error[E0599]: no function or associated item named `max_encoded_len` found for struct `NotMel` in the current scope
+error[E0277]: the trait bound `NotMel: MaxEncodedLen` is not satisfied
  --> tests/max_encoded_len_ui/unsupported_variant.rs:8:9
   |
-4 | struct NotMel;
-  | ------------- function or associated item `max_encoded_len` not found for this struct
-...
 8 |     NotMel(NotMel),
-  |            ^^^^^^ function or associated item not found in `NotMel`
+  |            ^^^^^^ the trait `MaxEncodedLen` is not implemented for `NotMel`
   |
-  = help: items from traits can only be used if the trait is implemented and in scope
-  = note: the following trait defines an item `max_encoded_len`, perhaps you need to implement it:
-          candidate #1: `MaxEncodedLen`
+  = help: the following other types implement trait `MaxEncodedLen`:
+            ()
+            (TupleElement0, TupleElement1)
+            (TupleElement0, TupleElement1, TupleElement2)
+            (TupleElement0, TupleElement1, TupleElement2, TupleElement3)
+            (TupleElement0, TupleElement1, TupleElement2, TupleElement3, TupleElement4)
+            (TupleElement0, TupleElement1, TupleElement2, TupleElement3, TupleElement4, TupleElement5)
+            (TupleElement0, TupleElement1, TupleElement2, TupleElement3, TupleElement4, TupleElement5, TupleElement6)
+            (TupleElement0, TupleElement1, TupleElement2, TupleElement3, TupleElement4, TupleElement5, TupleElement6, TupleElement7)
+          and $N others


### PR DESCRIPTION
Noticed that when using compact fields the max_encoded_len macro expand to the same as if we were not using the compact attribute. 


![Screenshot 2023-09-01 at 21 44 55](https://github.com/paritytech/parity-scale-codec/assets/521091/72b63e6f-ba26-4bb9-b21b-1805d5e6422b)

```rust
#[derive(Encode, Decode, MaxEncodedLen)]
pub struct Weight {
    #[codec(compact)]
    ref_time: u64,
    #[codec(compact)]
    proof_size: u64,
}
```
Will expand to 
```rust
    impl ::codec::MaxEncodedLen for Weight {
        fn max_encoded_len() -> ::core::primitive::usize {
            0_usize
                .saturating_add(<u64>::max_encoded_len())
                .saturating_add(<u64>::max_encoded_len())
        }
    }
```

This PR fix it to 
```rust
    impl ::codec::MaxEncodedLen for Weight {
        fn max_encoded_len() -> ::core::primitive::usize {
            0_usize
                .saturating_add(::parity_scale_codec::Compact<u64>::max_encoded_len())
                .saturating_add(::parity_scale_codec::Compact<u64>::max_encoded_len())
        }
    }
```



