### PR TITLE
impl  compact<()> for MaxEncodedLen

### DIFF
--- a/src/max_encoded_len.rs
+++ b/src/max_encoded_len.rs
@@ -65,6 +65,7 @@ macro_rules! impl_compact {
 }
 
 impl_compact!(
+	() => 0;
 	// github.com/paritytech/parity-scale-codec/blob/f0341dabb01aa9ff0548558abb6dcc5c31c669a1/src/compact.rs#L261
 	u8 => 2;
 	// github.com/paritytech/parity-scale-codec/blob/f0341dabb01aa9ff0548558abb6dcc5c31c669a1/src/compact.rs#L291


### PR DESCRIPTION
Third time's the charm
Adding `impl compact<()> for MaxEncodedLen` to get polkadot-sdk to compile with this branch

see https://github.com/paritytech/polkadot-sdk/pull/1424
