### PR TITLE
Revert breaking changes, bump version to `3.6.9`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -590,7 +590,7 @@ checksum = "ceedf44fb00f2d1984b0bc98102627ce622e083e49a5bacdb3e514fa4238e267"
 
 [[package]]
 name = "parity-scale-codec"
-version = "3.6.8"
+version = "3.6.9"
 dependencies = [
  "arbitrary",
  "arrayvec",
@@ -611,7 +611,7 @@ dependencies = [
 
 [[package]]
 name = "parity-scale-codec-derive"
-version = "3.6.8"
+version = "3.6.9"
 dependencies = [
  "parity-scale-codec",
  "proc-macro-crate",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "parity-scale-codec"
 description = "SCALE - Simple Concatenating Aggregated Little Endians"
-version = "3.6.8"
+version = "3.6.9"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "Apache-2.0"
 repository = "https://github.com/paritytech/parity-scale-codec"
@@ -12,7 +12,7 @@ rust-version = "1.60.0"
 [dependencies]
 arrayvec = { version = "0.7", default-features = false }
 serde = { version = "1.0.193", default-features = false, optional = true }
-parity-scale-codec-derive = { path = "derive", version = ">= 3.6.8", default-features = false, optional = true }
+parity-scale-codec-derive = { path = "derive", version = ">= 3.6.9", default-features = false, optional = true }
 bitvec = { version = "1", default-features = false, features = [ "alloc" ], optional = true }
 bytes = { version = "1", default-features = false, optional = true }
 byte-slice-cast = { version = "1.2.2", default-features = false }

--- a/derive/Cargo.toml
+++ b/derive/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "parity-scale-codec-derive"
 description = "Serialization and deserialization derive macro for Parity SCALE Codec"
-version = "3.6.8"
+version = "3.6.9"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "Apache-2.0"
 edition = "2021"

--- a/derive/src/max_encoded_len.rs
+++ b/derive/src/max_encoded_len.rs
@@ -96,9 +96,7 @@ fn fields_length_expr(fields: &Fields, crate_path: &syn::Path) -> proc_macro2::T
 		let ty = &field.ty;
 		if utils::is_compact(&field) {
 			quote_spanned! {
-				ty.span() => .saturating_add(
-					<<#ty as #crate_path::HasCompact>::Type as #crate_path::MaxEncodedLen>::max_encoded_len()
-				)
+				ty.span() => .saturating_add(<#crate_path::Compact::<#ty> as #crate_path::MaxEncodedLen>::max_encoded_len())
 			}
 		} else {
 			quote_spanned! {

--- a/derive/src/max_encoded_len.rs
+++ b/derive/src/max_encoded_len.rs
@@ -17,10 +17,10 @@
 
 use crate::{
 	trait_bounds,
-	utils::{self, codec_crate_path, custom_mel_trait_bound, has_dumb_trait_bound, should_skip},
+	utils::{codec_crate_path, custom_mel_trait_bound, has_dumb_trait_bound, should_skip},
 };
 use quote::{quote, quote_spanned};
-use syn::{parse_quote, spanned::Spanned, Data, DeriveInput, Field, Fields};
+use syn::{parse_quote, spanned::Spanned, Data, DeriveInput, Fields, Type};
 
 /// impl for `#[derive(MaxEncodedLen)]`
 pub fn derive_max_encoded_len(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
@@ -43,13 +43,13 @@ pub fn derive_max_encoded_len(input: proc_macro::TokenStream) -> proc_macro::Tok
 		parse_quote!(#crate_path::MaxEncodedLen),
 		None,
 		has_dumb_trait_bound(&input.attrs),
-		&crate_path,
+		&crate_path
 	) {
 		return e.to_compile_error().into()
 	}
 	let (impl_generics, ty_generics, where_clause) = input.generics.split_for_impl();
 
-	let data_expr = data_length_expr(&input.data, &crate_path);
+	let data_expr = data_length_expr(&input.data);
 
 	quote::quote!(
 		const _: () = {
@@ -64,22 +64,22 @@ pub fn derive_max_encoded_len(input: proc_macro::TokenStream) -> proc_macro::Tok
 }
 
 /// generate an expression to sum up the max encoded length from several fields
-fn fields_length_expr(fields: &Fields, crate_path: &syn::Path) -> proc_macro2::TokenStream {
-	let fields_iter: Box<dyn Iterator<Item = &Field>> = match fields {
-		Fields::Named(ref fields) => Box::new(fields.named.iter().filter_map(|field| {
-			if should_skip(&field.attrs) {
+fn fields_length_expr(fields: &Fields) -> proc_macro2::TokenStream {
+	let type_iter: Box<dyn Iterator<Item = &Type>> = match fields {
+		Fields::Named(ref fields) => Box::new(
+			fields.named.iter().filter_map(|field| if should_skip(&field.attrs) {
 				None
 			} else {
-				Some(field)
-			}
-		})),
-		Fields::Unnamed(ref fields) => Box::new(fields.unnamed.iter().filter_map(|field| {
-			if should_skip(&field.attrs) {
+				Some(&field.ty)
+			})
+		),
+		Fields::Unnamed(ref fields) => Box::new(
+			fields.unnamed.iter().filter_map(|field| if should_skip(&field.attrs) {
 				None
 			} else {
-				Some(field)
-			}
-		})),
+				Some(&field.ty)
+			})
+		),
 		Fields::Unit => Box::new(std::iter::empty()),
 	};
 	// expands to an expression like
@@ -92,16 +92,9 @@ fn fields_length_expr(fields: &Fields, crate_path: &syn::Path) -> proc_macro2::T
 	// `max_encoded_len` call. This way, if one field's type doesn't implement
 	// `MaxEncodedLen`, the compiler's error message will underline which field
 	// caused the issue.
-	let expansion = fields_iter.map(|field| {
-		let ty = &field.ty;
-		if utils::is_compact(&field) {
-			quote_spanned! {
-				ty.span() => .saturating_add(<#crate_path::Compact::<#ty> as #crate_path::MaxEncodedLen>::max_encoded_len())
-			}
-		} else {
-			quote_spanned! {
-				ty.span() => .saturating_add(<#ty as #crate_path::MaxEncodedLen>::max_encoded_len())
-			}
+	let expansion = type_iter.map(|ty| {
+		quote_spanned! {
+			ty.span() => .saturating_add(<#ty>::max_encoded_len())
 		}
 	});
 	quote! {
@@ -110,9 +103,9 @@ fn fields_length_expr(fields: &Fields, crate_path: &syn::Path) -> proc_macro2::T
 }
 
 // generate an expression to sum up the max encoded length of each field
-fn data_length_expr(data: &Data, crate_path: &syn::Path) -> proc_macro2::TokenStream {
+fn data_length_expr(data: &Data) -> proc_macro2::TokenStream {
 	match *data {
-		Data::Struct(ref data) => fields_length_expr(&data.fields, crate_path),
+		Data::Struct(ref data) => fields_length_expr(&data.fields),
 		Data::Enum(ref data) => {
 			// We need an expression expanded for each variant like
 			//
@@ -128,7 +121,7 @@ fn data_length_expr(data: &Data, crate_path: &syn::Path) -> proc_macro2::TokenSt
 			// Each variant expression's sum is computed the way an equivalent struct's would be.
 
 			let expansion = data.variants.iter().map(|variant| {
-				let variant_expression = fields_length_expr(&variant.fields, crate_path);
+				let variant_expression = fields_length_expr(&variant.fields);
 				quote! {
 					.max(#variant_expression)
 				}

--- a/src/compact.rs
+++ b/src/compact.rs
@@ -20,8 +20,6 @@ use crate::alloc::vec::Vec;
 use crate::codec::{Encode, Decode, Input, Output, EncodeAsRef};
 use crate::encode_like::EncodeLike;
 use crate::Error;
-#[cfg(feature = "max-encoded-len")]
-use crate::MaxEncodedLen;
 #[cfg(feature = "fuzz")]
 use arbitrary::Arbitrary;
 
@@ -208,39 +206,18 @@ impl<'de, T> serde::Deserialize<'de> for Compact<T> where T: serde::Deserialize<
 	}
 }
 
-/// Requires the presence of `MaxEncodedLen` when the `max-encoded-len` feature is active.
-// Remove this trait when the feature is removed.
-#[cfg(feature = "max-encoded-len")]
-pub trait MaybeMaxEncodedLen: MaxEncodedLen {}
-#[cfg(feature = "max-encoded-len")]
-impl<T: MaxEncodedLen> MaybeMaxEncodedLen for T {}
-
-/// Requires the presence of `MaxEncodedLen` when the `max-encoded-len` feature is active.
-// Remove this trait when the feature is removed.
-#[cfg(not(feature = "max-encoded-len"))]
-pub trait MaybeMaxEncodedLen {}
-#[cfg(not(feature = "max-encoded-len"))]
-impl<T> MaybeMaxEncodedLen for T {}
-
 /// Trait that tells you if a given type can be encoded/decoded in a compact way.
 pub trait HasCompact: Sized {
 	/// The compact type; this can be
-	type Type: for<'a> EncodeAsRef<'a, Self> + Decode + From<Self> + Into<Self> + MaybeMaxEncodedLen;
+	type Type: for<'a> EncodeAsRef<'a, Self> + Decode + From<Self> + Into<Self>;
 }
 
 impl<'a, T: 'a> EncodeAsRef<'a, T> for Compact<T> where CompactRef<'a, T>: Encode + From<&'a T> {
 	type RefType = CompactRef<'a, T>;
 }
 
-#[cfg(feature = "max-encoded-len")]
-impl<T> MaxEncodedLen for Compact<T> where T: CompactAs, Compact<T::As>: MaxEncodedLen, Compact<T>: Encode {
-	fn max_encoded_len() -> usize {
-		Compact::<T::As>::max_encoded_len()
-	}
-}
-
 impl<T: 'static> HasCompact for T where
-	Compact<T>: for<'a> EncodeAsRef<'a, T> + Decode + From<Self> + Into<Self> + MaybeMaxEncodedLen
+	Compact<T>: for<'a> EncodeAsRef<'a, T> + Decode + From<Self> + Into<Self>
 {
 	type Type = Compact<T>;
 }

--- a/src/max_encoded_len.rs
+++ b/src/max_encoded_len.rs
@@ -46,8 +46,9 @@ macro_rules! impl_primitives {
 	};
 }
 
+impl_primitives!(u8, u16, u32, u64, u128, i8, i16, i32, i64, i128, bool);
+
 impl_primitives!(
-	u8, i8, u16, i16, u32, i32, u64, i64, u128, i128, bool,
 	NonZeroU8, NonZeroU16, NonZeroU32, NonZeroU64, NonZeroU128, NonZeroI8, NonZeroI16, NonZeroI32,
 	NonZeroI64, NonZeroI128
 );

--- a/tests/max_encoded_len.rs
+++ b/tests/max_encoded_len.rs
@@ -73,26 +73,9 @@ struct CompactField {
 
 #[test]
 fn compact_field_max_length() {
-	assert_eq!(CompactField::max_encoded_len(), 17);
 	assert_eq!(
 		CompactField::max_encoded_len(),
 		Compact::<u64>::max_encoded_len() + u64::max_encoded_len()
-	);
-}
-
-
-#[derive(Encode, MaxEncodedLen)]
-struct CompactFieldGenerics<T: MaxEncodedLen> {
-	#[codec(compact)]
-	t: T,
-	v: u64,
-}
-
-#[test]
-fn compact_field_generics_max_length() {
-	assert_eq!(
-		CompactFieldGenerics::<u64>::max_encoded_len(),
-		CompactField::max_encoded_len()
 	);
 }
 

--- a/tests/max_encoded_len.rs
+++ b/tests/max_encoded_len.rs
@@ -16,7 +16,7 @@
 //! Tests for MaxEncodedLen derive macro
 #![cfg(all(feature = "derive", feature = "max-encoded-len"))]
 
-use parity_scale_codec::{Compact, Decode, Encode, MaxEncodedLen};
+use parity_scale_codec::{MaxEncodedLen, Compact, Decode, Encode};
 
 #[derive(Encode, MaxEncodedLen)]
 struct Primitives {
@@ -62,29 +62,6 @@ struct Generic<T> {
 fn generic_max_length() {
 	assert_eq!(Generic::<u8>::max_encoded_len(), u8::max_encoded_len() * 2);
 	assert_eq!(Generic::<u32>::max_encoded_len(), u32::max_encoded_len() * 2);
-}
-
-#[derive(Encode, MaxEncodedLen)]
-struct CompactField {
-	#[codec(compact)]
-	t: u64,
-	v: u64,
-}
-
-#[test]
-fn compact_field_max_length() {
-	assert_eq!(
-		CompactField::max_encoded_len(),
-		Compact::<u64>::max_encoded_len() + u64::max_encoded_len()
-	);
-}
-
-#[derive(Encode, MaxEncodedLen)]
-struct CompactStruct(#[codec(compact)] u64);
-
-#[test]
-fn compact_struct_max_length() {
-	assert_eq!(CompactStruct::max_encoded_len(), Compact::<u64>::max_encoded_len());
 }
 
 #[derive(Encode, MaxEncodedLen)]

--- a/tests/max_encoded_len_ui/unsupported_variant.stderr
+++ b/tests/max_encoded_len_ui/unsupported_variant.stderr
@@ -1,16 +1,12 @@
-error[E0277]: the trait bound `NotMel: MaxEncodedLen` is not satisfied
+error[E0599]: no function or associated item named `max_encoded_len` found for struct `NotMel` in the current scope
  --> tests/max_encoded_len_ui/unsupported_variant.rs:8:9
   |
+4 | struct NotMel;
+  | ------------- function or associated item `max_encoded_len` not found for this struct
+...
 8 |     NotMel(NotMel),
-  |            ^^^^^^ the trait `MaxEncodedLen` is not implemented for `NotMel`
+  |            ^^^^^^ function or associated item not found in `NotMel`
   |
-  = help: the following other types implement trait `MaxEncodedLen`:
-            bool
-            i8
-            i16
-            i32
-            i64
-            i128
-            u8
-            u16
-          and $N others
+  = help: items from traits can only be used if the trait is implemented and in scope
+  = note: the following trait defines an item `max_encoded_len`, perhaps you need to implement it:
+          candidate #1: `MaxEncodedLen`


### PR DESCRIPTION
Reverts #512 and #508, which are breaking changes, and bumps version to `3.6.9` for release.