### PR TITLE
Support constant expressions as index attribute variant

### DIFF
--- a/derive/src/decode.rs
+++ b/derive/src/decode.rs
@@ -60,7 +60,7 @@ pub fn quote(
 
 			let recurse = data_variants().enumerate().map(|(i, v)| {
 				let name = &v.ident;
-				let index = utils::variant_index(v, i);
+				let index = utils::variant_index(v, i, &mut Vec::new());
 
 				let create = create_instance(
 					quote! { #type_name #type_generics :: #name },

--- a/tests/scale_codec_ui/duplicate_const_expr.rs
+++ b/tests/scale_codec_ui/duplicate_const_expr.rs
@@ -1,0 +1,12 @@
+#[derive(::parity_scale_codec::Encode)]
+#[codec(crate = ::parity_scale_codec)]
+pub enum Enum {
+    #[codec(index = MY_CONST_INDEX)]
+    Variant1,
+    #[codec(index = MY_CONST_INDEX)]
+    Variant2,
+}
+
+const MY_CONST_INDEX: u8 = 1;
+
+fn main() {}

--- a/tests/scale_codec_ui/duplicate_const_expr.stderr
+++ b/tests/scale_codec_ui/duplicate_const_expr.stderr
@@ -1,0 +1,5 @@
+error: index value `MY_CONST_INDEX` is assigned more than once
+ --> tests/scale_codec_ui/duplicate_const_expr.rs:6:21
+  |
+6 |     #[codec(index = MY_CONST_INDEX)]
+  |                     ^^^^^^^^^^^^^^

--- a/tests/scale_codec_ui/invalid_attr_name.rs
+++ b/tests/scale_codec_ui/invalid_attr_name.rs
@@ -1,0 +1,8 @@
+#[derive(::parity_scale_codec::Encode)]
+#[codec(crate = ::parity_scale_codec)]
+pub enum Enum {
+    #[codec(scale = 1)]
+    Variant1,
+}
+
+fn main() {}

--- a/tests/scale_codec_ui/invalid_attr_name.stderr
+++ b/tests/scale_codec_ui/invalid_attr_name.stderr
@@ -1,0 +1,5 @@
+error: Error checking variant attribute: Invalid attribute on variant, only `#[codec(skip)]` and `#[codec(index = $u8)]` are accepted.
+ --> tests/scale_codec_ui/invalid_attr_name.rs:4:5
+  |
+4 |     #[codec(scale = 1)]
+  |     ^^^^^^^^^^^^^^^^^^^

--- a/tests/scale_codec_ui/invalid_attr_type.rs
+++ b/tests/scale_codec_ui/invalid_attr_type.rs
@@ -1,0 +1,8 @@
+#[derive(::parity_scale_codec::Encode)]
+#[codec(crate = ::parity_scale_codec)]
+pub enum Enum {
+    #[codec(index = "invalid")]
+    Variant1,
+}
+
+fn main() {}

--- a/tests/scale_codec_ui/invalid_attr_type.stderr
+++ b/tests/scale_codec_ui/invalid_attr_type.stderr
@@ -1,0 +1,5 @@
+error: Error checking variant attribute: Only u8 indices are accepted for attribute variant `#[codec(index = $u8)]`
+ --> tests/scale_codec_ui/invalid_attr_type.rs:4:5
+  |
+4 |     #[codec(index = "invalid")]
+  |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/tests/scale_codec_ui/overflowing_index_value.rs
+++ b/tests/scale_codec_ui/overflowing_index_value.rs
@@ -1,0 +1,8 @@
+#[derive(::parity_scale_codec::Encode)]
+#[codec(crate = ::parity_scale_codec)]
+pub enum Enum {
+    #[codec(index = 256)]
+    Variant1,
+}
+
+fn main() {}

--- a/tests/scale_codec_ui/overflowing_index_value.stderr
+++ b/tests/scale_codec_ui/overflowing_index_value.stderr
@@ -1,0 +1,5 @@
+error: Error checking variant attribute: Index attribute variant must be in 0..255
+ --> tests/scale_codec_ui/overflowing_index_value.rs:4:5
+  |
+4 |     #[codec(index = 256)]
+  |     ^^^^^^^^^^^^^^^^^^^^^

--- a/tests/variant_number.rs
+++ b/tests/variant_number.rs
@@ -38,3 +38,38 @@ fn index_attr_variant_counted_and_reused_in_default_index() {
 	assert_eq!(T::A.encode(), vec![1]);
 	assert_eq!(T::B.encode(), vec![1]);
 }
+
+#[test]
+fn different_const_expr_in_index_attr_variant() {
+	const MY_CONST_INDEX: u8 = 1;
+	const ANOTHER_CONST_INDEX: u8 = 2;
+
+	#[derive(DeriveEncode)]
+	enum T {
+		#[codec(index = MY_CONST_INDEX)]
+		A,
+		B,
+		#[codec(index = ANOTHER_CONST_INDEX)]
+		C,
+		#[codec(index = 3)]
+		D,
+	}
+
+	assert_eq!(T::A.encode(), vec![1]);
+	assert_eq!(T::B.encode(), vec![1]);
+	assert_eq!(T::C.encode(), vec![2]);
+	assert_eq!(T::D.encode(), vec![3]);
+}
+
+#[test]
+fn complex_const_expr_in_index_attr_variant() {
+    const MY_CONST_INDEX: u8 = 1;
+
+    #[derive(DeriveEncode)]
+    enum T {
+        #[codec(index = MY_CONST_INDEX + 1_u8)]
+        A,
+    }
+
+    assert_eq!(T::A.encode(), vec![2]);
+}


### PR DESCRIPTION
This pull request introduces the capability to use constant expressions as index attribute variants for enum encoding, addressing the demand from issue https://github.com/paritytech/polkadot-sdk/issues/2665. This update allows developers to declare pallet indices as constants when constructing a runtime.

The uniqueness of constant expression indices is ensured at compile time with `find_const_duplicate`. Due to limitations in Rust's procedural macros, a runtime check approach is adopted to ensure that indices adhere to the u8 range. UI tests have been included to cover various scenarios, ensuring that the checks function as expected.