### PR TITLE
Fix PrefixInput read

### DIFF
--- a/src/codec.rs
+++ b/src/codec.rs
@@ -86,7 +86,7 @@ pub trait Input {
 
 	/// Descend into nested reference when decoding.
 	/// This is called when decoding a new refence-based instance,
-	/// such as `Vec` or `Box`. Currently all such types are
+	/// such as `Vec` or `Box`. Currently, all such types are
 	/// allocated on the heap.
 	fn descend_ref(&mut self) -> Result<(), Error> {
 		Ok(())

--- a/src/compact.rs
+++ b/src/compact.rs
@@ -62,8 +62,11 @@ impl<'a, T: 'a + Input> Input for PrefixInput<'a, T> {
 	}
 
 	fn read(&mut self, buffer: &mut [u8]) -> Result<(), Error> {
+		if buffer.is_empty() {
+			return Ok(());
+		}
 		match self.prefix.take() {
-			Some(v) if !buffer.is_empty() => {
+			Some(v) => {
 				buffer[0] = v;
 				self.input.read(&mut buffer[1..])
 			}
@@ -658,6 +661,16 @@ impl Decode for Compact<u128> {
 #[cfg(test)]
 mod tests {
 	use super::*;
+
+	#[test]
+	fn prefix_input_empty_read_unchanged() {
+		let mut input = PrefixInput { prefix: Some(1), input: &mut &vec![2, 3, 4][..] };
+		assert_eq!(input.remaining_len(), Ok(Some(4)));
+		let mut empty_buf = [];
+		assert_eq!(input.read(&mut empty_buf[..]), Ok(()));
+		assert_eq!(input.remaining_len(), Ok(Some(4)));
+		assert_eq!(input.read_byte(), Ok(1));
+	}
 
 	#[test]
 	fn compact_128_encoding_works() {


### PR DESCRIPTION
The current implementation of `PrefixInput` seems to be inconsistent. It checks for the buffer being empty, but only after the prefix is [taken](https://github.com/paritytech/parity-scale-codec/blob/5f4fb36df6b146dfa5417018ae831f92bab17400/src/compact.rs#L66), so trying to read with an zero-length buffer discards the prefix and it cannot be read any longer.

Though the behavior can be fixed for the empty buffer case, I think it is better just to remove the check completely and add a "note" comment, since this is an internal mechanism used to parse compacts only and the buffer is always allocated properly.