### PR TITLE
Source code formatting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,20 @@ jobs:
         run: echo "IMAGE=${{ env.IMAGE }}" >> $GITHUB_OUTPUT
 
 # Checks
+  fmt:
+    runs-on: ubuntu-latest
+    needs: [set-image]
+    container: ${{ needs.set-image.outputs.IMAGE }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Show Cargo version
+        run: cargo +nightly -vV
+
+      - name: Cargo fmt
+        run: cargo +nightly fmt --all -- --check
+
   clippy:
     runs-on: ubuntu-latest
     needs: [set-image]

--- a/derive/src/decode.rs
+++ b/derive/src/decode.rs
@@ -84,9 +84,9 @@ pub fn quote(
 			});
 
 			let read_byte_err_msg =
-				format!("Could not decode `{}`, failed to read variant byte", type_name,);
+				format!("Could not decode `{type_name}`, failed to read variant byte");
 			let invalid_variant_err_msg =
-				format!("Could not decode `{}`, variant doesn't exist", type_name,);
+				format!("Could not decode `{type_name}`, variant doesn't exist");
 			quote! {
 				match #input.read_byte()
 					.map_err(|e| e.chain(#read_byte_err_msg))?

--- a/derive/src/decode.rs
+++ b/derive/src/decode.rs
@@ -12,11 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use proc_macro2::{Span, TokenStream, Ident};
-use syn::{
-	spanned::Spanned,
-	Data, Fields, Field, Error,
-};
+use proc_macro2::{Ident, Span, TokenStream};
+use syn::{spanned::Spanned, Data, Error, Field, Fields};
 
 use crate::utils;
 
@@ -49,13 +46,15 @@ pub fn quote(
 			},
 		},
 		Data::Enum(ref data) => {
-			let data_variants = || data.variants.iter().filter(|variant| !utils::should_skip(&variant.attrs));
+			let data_variants =
+				|| data.variants.iter().filter(|variant| !utils::should_skip(&variant.attrs));
 
 			if data_variants().count() > 256 {
 				return Error::new(
 					data.variants.span(),
-					"Currently only enums with at most 256 variants are encodable."
-				).to_compile_error();
+					"Currently only enums with at most 256 variants are encodable.",
+				)
+				.to_compile_error();
 			}
 
 			let recurse = data_variants().enumerate().map(|(i, v)| {
@@ -84,14 +83,10 @@ pub fn quote(
 				}
 			});
 
-			let read_byte_err_msg = format!(
-				"Could not decode `{}`, failed to read variant byte",
-				type_name,
-			);
-			let invalid_variant_err_msg = format!(
-				"Could not decode `{}`, variant doesn't exist",
-				type_name,
-			);
+			let read_byte_err_msg =
+				format!("Could not decode `{}`, failed to read variant byte", type_name,);
+			let invalid_variant_err_msg =
+				format!("Could not decode `{}`, variant doesn't exist", type_name,);
 			quote! {
 				match #input.read_byte()
 					.map_err(|e| e.chain(#read_byte_err_msg))?
@@ -107,9 +102,9 @@ pub fn quote(
 					},
 				}
 			}
-
 		},
-		Data::Union(_) => Error::new(Span::call_site(), "Union types are not supported.").to_compile_error(),
+		Data::Union(_) =>
+			Error::new(Span::call_site(), "Union types are not supported.").to_compile_error(),
 	}
 }
 
@@ -117,7 +112,7 @@ pub fn quote_decode_into(
 	data: &Data,
 	crate_path: &syn::Path,
 	input: &TokenStream,
-	attrs: &[syn::Attribute]
+	attrs: &[syn::Attribute],
 ) -> Option<TokenStream> {
 	// Make sure the type is `#[repr(transparent)]`, as this guarantees that
 	// there can be only one field that is not zero-sized.
@@ -126,16 +121,13 @@ pub fn quote_decode_into(
 	}
 
 	let fields = match data {
-		Data::Struct(
-			syn::DataStruct {
-				fields: Fields::Named(syn::FieldsNamed { named: fields, .. }) |
-				        Fields::Unnamed(syn::FieldsUnnamed { unnamed: fields, .. }),
-				..
-			}
-		) => {
-			fields
-		},
-		_ => return None
+		Data::Struct(syn::DataStruct {
+			fields:
+				Fields::Named(syn::FieldsNamed { named: fields, .. }) |
+				Fields::Unnamed(syn::FieldsUnnamed { unnamed: fields, .. }),
+			..
+		}) => fields,
+		_ => return None,
 	};
 
 	if fields.is_empty() {
@@ -143,11 +135,11 @@ pub fn quote_decode_into(
 	}
 
 	// Bail if there are any extra attributes which could influence how the type is decoded.
-	if fields.iter().any(|field|
+	if fields.iter().any(|field| {
 		utils::get_encoded_as_type(field).is_some() ||
-		utils::is_compact(field) ||
-		utils::should_skip(&field.attrs)
-	) {
+			utils::is_compact(field) ||
+			utils::should_skip(&field.attrs)
+	}) {
 		return None;
 	}
 
@@ -183,10 +175,11 @@ pub fn quote_decode_into(
 		if !non_zst_field_count.is_empty() {
 			non_zst_field_count.push(quote! { + });
 		}
-		non_zst_field_count.push(quote! { if ::core::mem::size_of::<#field_type>() > 0 { 1 } else { 0 } });
+		non_zst_field_count
+			.push(quote! { if ::core::mem::size_of::<#field_type>() > 0 { 1 } else { 0 } });
 	}
 
-	Some(quote!{
+	Some(quote! {
 		// Just a sanity check. These should always be true and will be optimized-out.
 		::core::assert_eq!(#(#sizes)*, ::core::mem::size_of::<Self>());
 		::core::assert!(#(#non_zst_field_count)* <= 1);
@@ -198,7 +191,12 @@ pub fn quote_decode_into(
 	})
 }
 
-fn create_decode_expr(field: &Field, name: &str, input: &TokenStream, crate_path: &syn::Path) -> TokenStream {
+fn create_decode_expr(
+	field: &Field,
+	name: &str,
+	input: &TokenStream,
+	crate_path: &syn::Path,
+) -> TokenStream {
 	let encoded_as = utils::get_encoded_as_type(field);
 	let compact = utils::is_compact(field);
 	let skip = utils::should_skip(&field.attrs);
@@ -208,8 +206,9 @@ fn create_decode_expr(field: &Field, name: &str, input: &TokenStream, crate_path
 	if encoded_as.is_some() as u8 + compact as u8 + skip as u8 > 1 {
 		return Error::new(
 			field.span(),
-			"`encoded_as`, `compact` and `skip` can only be used one at a time!"
-		).to_compile_error();
+			"`encoded_as`, `compact` and `skip` can only be used one at a time!",
+		)
+		.to_compile_error();
 	}
 
 	let err_msg = format!("Could not decode `{}`", name);
@@ -282,7 +281,7 @@ fn create_instance(
 			}
 		},
 		Fields::Unnamed(ref fields) => {
-			let recurse = fields.unnamed.iter().enumerate().map(|(i, f) | {
+			let recurse = fields.unnamed.iter().enumerate().map(|(i, f)| {
 				let field_name = format!("{}.{}", name_str, i);
 
 				create_decode_expr(f, &field_name, input, crate_path)

--- a/derive/src/encode.rs
+++ b/derive/src/encode.rs
@@ -35,7 +35,7 @@ fn encode_single_field(
 			Span::call_site(),
 			"Internal error: cannot encode single field optimisation if skipped",
 		)
-		.to_compile_error()
+		.to_compile_error();
 	}
 
 	if encoded_as.is_some() && compact {
@@ -43,7 +43,7 @@ fn encode_single_field(
 			Span::call_site(),
 			"`encoded_as` and `compact` can not be used at the same time!",
 		)
-		.to_compile_error()
+		.to_compile_error();
 	}
 
 	let final_field_variable = if compact {
@@ -128,7 +128,7 @@ where
 				f.span(),
 				"`encoded_as`, `compact` and `skip` can only be used one at a time!",
 			)
-			.to_compile_error()
+			.to_compile_error();
 		}
 
 		// Based on the seen attribute, we call a handler that generates code for a specific
@@ -306,12 +306,12 @@ fn impl_encode(data: &Data, type_name: &Ident, crate_path: &syn::Path) -> TokenS
 					data.variants.span(),
 					"Currently only enums with at most 256 variants are encodable.",
 				)
-				.to_compile_error()
+				.to_compile_error();
 			}
 
 			// If the enum has no variants, we don't need to encode anything.
 			if data_variants().count() == 0 {
-				return quote!()
+				return quote!();
 			}
 
 			let recurse = data_variants().enumerate().map(|(i, f)| {

--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -129,7 +129,7 @@ pub fn encode_derive(input: proc_macro::TokenStream) -> proc_macro::TokenStream 
 	};
 
 	if let Err(e) = utils::check_attributes(&input) {
-		return e.to_compile_error().into()
+		return e.to_compile_error().into();
 	}
 
 	let crate_path = match codec_crate_path(&input.attrs) {
@@ -147,7 +147,7 @@ pub fn encode_derive(input: proc_macro::TokenStream) -> proc_macro::TokenStream 
 		utils::has_dumb_trait_bound(&input.attrs),
 		&crate_path,
 	) {
-		return e.to_compile_error().into()
+		return e.to_compile_error().into();
 	}
 
 	let name = &input.ident;
@@ -179,7 +179,7 @@ pub fn decode_derive(input: proc_macro::TokenStream) -> proc_macro::TokenStream 
 	};
 
 	if let Err(e) = utils::check_attributes(&input) {
-		return e.to_compile_error().into()
+		return e.to_compile_error().into();
 	}
 
 	let crate_path = match codec_crate_path(&input.attrs) {
@@ -197,7 +197,7 @@ pub fn decode_derive(input: proc_macro::TokenStream) -> proc_macro::TokenStream 
 		utils::has_dumb_trait_bound(&input.attrs),
 		&crate_path,
 	) {
-		return e.to_compile_error().into()
+		return e.to_compile_error().into();
 	}
 
 	let name = &input.ident;
@@ -208,12 +208,8 @@ pub fn decode_derive(input: proc_macro::TokenStream) -> proc_macro::TokenStream 
 	let decoding =
 		decode::quote(&input.data, name, &quote!(#ty_gen_turbofish), &input_, &crate_path);
 
-	let decode_into_body = decode::quote_decode_into(
-		&input.data,
-		&crate_path,
-		&input_,
-		&input.attrs
-	);
+	let decode_into_body =
+		decode::quote_decode_into(&input.data, &crate_path, &input_, &input.attrs);
 
 	let impl_decode_into = if let Some(body) = decode_into_body {
 		quote! {
@@ -266,7 +262,7 @@ pub fn compact_as_derive(input: proc_macro::TokenStream) -> proc_macro::TokenStr
 	};
 
 	if let Err(e) = utils::check_attributes(&input) {
-		return e.to_compile_error().into()
+		return e.to_compile_error().into();
 	}
 
 	let crate_path = match codec_crate_path(&input.attrs) {
@@ -284,7 +280,7 @@ pub fn compact_as_derive(input: proc_macro::TokenStream) -> proc_macro::TokenStr
 		utils::has_dumb_trait_bound(&input.attrs),
 		&crate_path,
 	) {
-		return e.to_compile_error().into()
+		return e.to_compile_error().into();
 	}
 
 	let name = &input.ident;

--- a/derive/src/max_encoded_len.rs
+++ b/derive/src/max_encoded_len.rs
@@ -45,7 +45,7 @@ pub fn derive_max_encoded_len(input: proc_macro::TokenStream) -> proc_macro::Tok
 		has_dumb_trait_bound(&input.attrs),
 		&crate_path,
 	) {
-		return e.to_compile_error().into()
+		return e.to_compile_error().into();
 	}
 	let (impl_generics, ty_generics, where_clause) = input.generics.split_for_impl();
 

--- a/derive/src/trait_bounds.rs
+++ b/derive/src/trait_bounds.rs
@@ -55,7 +55,7 @@ impl<'a, 'ast> Visit<'ast> for TypePathStartsWithIdent<'a> {
 		if let Some(segment) = i.path.segments.first() {
 			if &segment.ident == self.ident {
 				self.result = true;
-				return
+				return;
 			}
 		}
 
@@ -119,7 +119,7 @@ pub fn add<N>(
 	let skip_type_params = match custom_trait_bound {
 		Some(CustomTraitBound::SpecifiedBounds { bounds, .. }) => {
 			generics.make_where_clause().predicates.extend(bounds);
-			return Ok(())
+			return Ok(());
 		},
 		Some(CustomTraitBound::SkipTypeParams { type_names, .. }) =>
 			type_names.into_iter().collect::<Vec<_>>(),
@@ -132,7 +132,7 @@ pub fn add<N>(
 		.map(|tp| tp.ident.clone())
 		.collect::<Vec<_>>();
 	if ty_params.is_empty() {
-		return Ok(())
+		return Ok(());
 	}
 
 	let codec_types =

--- a/derive/src/utils.rs
+++ b/derive/src/utils.rs
@@ -20,7 +20,7 @@
 use std::str::FromStr;
 
 use proc_macro2::TokenStream;
-use quote::{ToTokens, quote};
+use quote::{quote, ToTokens};
 use syn::{
 	parse::Parse, punctuated::Punctuated, spanned::Spanned, token, Attribute, Data, DeriveInput,
 	Field, Fields, FieldsNamed, FieldsUnnamed, Lit, Meta, MetaNameValue, NestedMeta, Path, Variant,
@@ -48,7 +48,7 @@ pub fn variant_index(v: &Variant, i: usize) -> TokenStream {
 					let byte = v
 						.base10_parse::<u8>()
 						.expect("Internal error, index attribute must have been checked");
-					return Some(byte)
+					return Some(byte);
 				}
 			}
 		}
@@ -75,7 +75,7 @@ pub fn get_encoded_as_type(field: &Field) -> Option<TokenStream> {
 					return Some(
 						TokenStream::from_str(&s.value())
 							.expect("Internal error, encoded_as attribute must have been checked"),
-					)
+					);
 				}
 			}
 		}
@@ -89,7 +89,7 @@ pub fn is_compact(field: &Field) -> bool {
 	find_meta_item(field.attrs.iter(), |meta| {
 		if let NestedMeta::Meta(Meta::Path(ref path)) = meta {
 			if path.is_ident("compact") {
-				return Some(())
+				return Some(());
 			}
 		}
 
@@ -103,7 +103,7 @@ pub fn should_skip(attrs: &[Attribute]) -> bool {
 	find_meta_item(attrs.iter(), |meta| {
 		if let NestedMeta::Meta(Meta::Path(ref path)) = meta {
 			if path.is_ident("skip") {
-				return Some(path.span())
+				return Some(path.span());
 			}
 		}
 
@@ -117,7 +117,7 @@ pub fn has_dumb_trait_bound(attrs: &[Attribute]) -> bool {
 	find_meta_item(attrs.iter(), |meta| {
 		if let NestedMeta::Meta(Meta::Path(ref path)) = meta {
 			if path.is_ident("dumb_trait_bound") {
-				return Some(())
+				return Some(());
 			}
 		}
 
@@ -262,9 +262,7 @@ pub fn filter_skip_named(fields: &syn::FieldsNamed) -> impl Iterator<Item = &Fie
 
 /// Given a set of unnamed fields, return an iterator of `(index, Field)` where all fields
 /// marked `#[codec(skip)]` are filtered out.
-pub fn filter_skip_unnamed(
-	fields: &syn::FieldsUnnamed,
-) -> impl Iterator<Item = (usize, &Field)> {
+pub fn filter_skip_unnamed(fields: &syn::FieldsUnnamed) -> impl Iterator<Item = (usize, &Field)> {
 	fields.unnamed.iter().enumerate().filter(|(_, f)| !should_skip(&f.attrs))
 }
 

--- a/fuzzer/src/main.rs
+++ b/fuzzer/src/main.rs
@@ -1,27 +1,36 @@
-use std::collections::{BTreeMap, BTreeSet, VecDeque, LinkedList, BinaryHeap};
-use std::time::Duration;
+use std::{
+	collections::{BTreeMap, BTreeSet, BinaryHeap, LinkedList, VecDeque},
+	time::Duration,
+};
 
-use bitvec::{vec::BitVec, order::Msb0, order::BitOrder, store::BitStore};
-use honggfuzz::fuzz;
-use parity_scale_codec::{Encode, Decode, Compact};
-use honggfuzz::arbitrary::{Arbitrary, Unstructured, Result as ArbResult};
+use bitvec::{
+	order::{BitOrder, Msb0},
+	store::BitStore,
+	vec::BitVec,
+};
+use honggfuzz::{
+	arbitrary::{Arbitrary, Result as ArbResult, Unstructured},
+	fuzz,
+};
+use parity_scale_codec::{Compact, Decode, Encode};
 
 #[derive(Encode, Decode, Clone, PartialEq, Debug, Arbitrary)]
-pub struct MockStruct{
-	vec_u: Vec<u8>
+pub struct MockStruct {
+	vec_u: Vec<u8>,
 }
 
 /// Used for implementing the Arbitrary trait for a BitVec.
 #[derive(Encode, Decode, Clone, PartialEq, Debug)]
 pub struct BitVecWrapper<T: BitStore, O: BitOrder>(BitVec<T, O>);
 
-impl<'a, O: 'static + BitOrder, T: 'static + BitStore + Arbitrary<'a>> Arbitrary<'a> for BitVecWrapper<T, O> {
+impl<'a, O: 'static + BitOrder, T: 'static + BitStore + Arbitrary<'a>> Arbitrary<'a>
+	for BitVecWrapper<T, O>
+{
 	fn arbitrary(u: &mut Unstructured<'a>) -> ArbResult<Self> {
 		let v = Vec::<T>::arbitrary(u)?;
 		Ok(BitVecWrapper(BitVec::<T, O>::from_vec(v)))
 	}
 }
-
 
 /// Used for implementing the PartialEq trait for a BinaryHeap.
 #[derive(Encode, Decode, Debug, Clone, Arbitrary)]
@@ -38,19 +47,16 @@ pub enum MockEnum {
 	Empty,
 	Unit(u32),
 	UnitVec(Vec<u8>),
-	Complex {
-		data: Vec<u32>,
-		bitvec: BitVecWrapper<u8, Msb0>,
-		string: String,
-	},
+	Complex { data: Vec<u32>, bitvec: BitVecWrapper<u8, Msb0>, string: String },
 	Mock(MockStruct),
 	NestedVec(Vec<Vec<Vec<Vec<Vec<Vec<Vec<Vec<Option<u8>>>>>>>>>),
 }
 
 /// `fuzz_flow` parameter can either be `round_trip` or `only_decode`.
-/// `round_trip` will decode -> encode and compare the obtained encoded bytes with the original data.
-/// `only_decode` will only decode, without trying to encode the decoded object.
-/// `round_trip_sort` will decode -> encode and compare the obtained encoded SORTED bytes with the original SORTED data.
+/// `round_trip` will decode -> encode and compare the obtained encoded bytes with the original
+/// data. `only_decode` will only decode, without trying to encode the decoded object.
+/// `round_trip_sort` will decode -> encode and compare the obtained encoded SORTED bytes with the
+/// original SORTED data.
 macro_rules! fuzz_decoder {
 	(
 		$fuzz_flow:ident;
@@ -253,23 +259,22 @@ macro_rules! fuzz_encoder {
 	};
 }
 
-fn fuzz_encode<T: Encode + Decode + Clone + PartialEq + std::fmt::Debug> (data: T) {
+fn fuzz_encode<T: Encode + Decode + Clone + PartialEq + std::fmt::Debug>(data: T) {
 	let original = data.clone();
 	let mut obj: &[u8] = &data.encode();
 	let decoded = <T>::decode(&mut obj);
 	match decoded {
-		Ok(object) => {
+		Ok(object) =>
 			if object != original {
 				println!("original object: {:?}", original);
 				println!("decoded object: {:?}", object);
 				panic!("Original object differs from decoded object")
-			}
-		}
+			},
 		Err(e) => {
 			println!("original object: {:?}", original);
 			println!("decoding error: {:?}", e);
 			panic!("Failed to decode the encoded object");
-		}
+		},
 	}
 }
 
@@ -308,7 +313,9 @@ macro_rules! fuzz_encoding {
 
 fn main() {
 	loop {
-		fuzz!(|data: &[u8]| { fuzz_decode(data); });
+		fuzz!(|data: &[u8]| {
+			fuzz_decode(data);
+		});
 		fuzz_encoding!();
 	}
 }

--- a/src/bit_vec.rs
+++ b/src/bit_vec.rs
@@ -14,11 +14,11 @@
 
 //! `BitVec` specific serialization.
 
-use bitvec::{
-	vec::BitVec, store::BitStore, order::BitOrder, slice::BitSlice, boxed::BitBox, view::BitView,
-};
 use crate::{
-	EncodeLike, Encode, Decode, Input, Output, Error, Compact, codec::decode_vec_with_len,
+	codec::decode_vec_with_len, Compact, Decode, Encode, EncodeLike, Error, Input, Output,
+};
+use bitvec::{
+	boxed::BitBox, order::BitOrder, slice::BitSlice, store::BitStore, vec::BitVec, view::BitView,
 };
 
 impl<O: BitOrder, T: BitStore + Encode> Encode for BitSlice<T, O> {
@@ -59,12 +59,13 @@ impl<O: BitOrder, T: BitStore + Decode> Decode for BitVec<T, O> {
 			}
 			let vec = decode_vec_with_len(input, bitvec::mem::elts::<T>(bits as usize))?;
 
-			let mut result = Self::try_from_vec(vec)
-				.map_err(|_| {
-					Error::from("UNEXPECTED ERROR: `bits` is less or equal to
+			let mut result = Self::try_from_vec(vec).map_err(|_| {
+				Error::from(
+					"UNEXPECTED ERROR: `bits` is less or equal to
 					`ARCH32BIT_BITSLICE_MAX_BITS`; So BitVec must be able to handle the number of
-					segment needed for `bits` to be represented; qed")
-				})?;
+					segment needed for `bits` to be represented; qed",
+				)
+			})?;
 
 			assert!(bits as usize <= result.len());
 			result.truncate(bits as usize);
@@ -90,8 +91,11 @@ impl<O: BitOrder, T: BitStore + Decode> Decode for BitBox<T, O> {
 #[cfg(test)]
 mod tests {
 	use super::*;
-	use bitvec::{bitvec, order::{Msb0, Lsb0}};
 	use crate::{codec::MAX_PREALLOCATION, CompactLen};
+	use bitvec::{
+		bitvec,
+		order::{Lsb0, Msb0},
+	};
 
 	macro_rules! test_data {
 		($inner_type:ident) => (
@@ -202,7 +206,10 @@ mod tests {
 			(bitvec![u8, Lsb0; 1, 1, 1, 1].encode(), (Compact(4u32), 0b00001111u8).encode()),
 			(bitvec![u8, Lsb0; 1, 1, 1, 1, 1].encode(), (Compact(5u32), 0b00011111u8).encode()),
 			(bitvec![u8, Lsb0; 1, 1, 1, 1, 1, 0].encode(), (Compact(6u32), 0b00011111u8).encode()),
-			(bitvec![u8, Lsb0; 1, 1, 1, 1, 1, 0, 0, 0, 1, 1, 0, 1].encode(), (Compact(12u32), 0b00011111u8, 0b00001011u8).encode()),
+			(
+				bitvec![u8, Lsb0; 1, 1, 1, 1, 1, 0, 0, 0, 1, 1, 0, 1].encode(),
+				(Compact(12u32), 0b00011111u8, 0b00001011u8).encode(),
+			),
 		];
 
 		for (idx, (actual, expected)) in cases.into_iter().enumerate() {

--- a/src/compact.rs
+++ b/src/compact.rs
@@ -16,12 +16,14 @@
 
 use arrayvec::ArrayVec;
 
-use crate::alloc::vec::Vec;
-use crate::codec::{Encode, Decode, Input, Output, EncodeAsRef};
-use crate::encode_like::EncodeLike;
-use crate::Error;
 #[cfg(feature = "max-encoded-len")]
 use crate::MaxEncodedLen;
+use crate::{
+	alloc::vec::Vec,
+	codec::{Decode, Encode, EncodeAsRef, Input, Output},
+	encode_like::EncodeLike,
+	Error,
+};
 #[cfg(feature = "fuzz")]
 use arbitrary::Arbitrary;
 
@@ -66,8 +68,8 @@ impl<'a, T: 'a + Input> Input for PrefixInput<'a, T> {
 			Some(v) if !buffer.is_empty() => {
 				buffer[0] = v;
 				self.input.read(&mut buffer[1..])
-			}
-			_ => self.input.read(buffer)
+			},
+			_ => self.input.read(buffer),
 		}
 	}
 }
@@ -84,11 +86,15 @@ pub trait CompactLen<T> {
 pub struct Compact<T>(pub T);
 
 impl<T> From<T> for Compact<T> {
-	fn from(x: T) -> Compact<T> { Compact(x) }
+	fn from(x: T) -> Compact<T> {
+		Compact(x)
+	}
 }
 
 impl<'a, T: Copy> From<&'a T> for Compact<T> {
-	fn from(x: &'a T) -> Compact<T> { Compact(*x) }
+	fn from(x: &'a T) -> Compact<T> {
+		Compact(*x)
+	}
 }
 
 /// Allow foreign structs to be wrap in Compact
@@ -103,10 +109,7 @@ pub trait CompactAs: From<Compact<Self>> {
 	fn decode_from(_: Self::As) -> Result<Self, Error>;
 }
 
-impl<T> EncodeLike for Compact<T>
-where
-	for<'a> CompactRef<'a, T>: Encode,
-{}
+impl<T> EncodeLike for Compact<T> where for<'a> CompactRef<'a, T>: Encode {}
 
 impl<T> Encode for Compact<T>
 where
@@ -133,7 +136,8 @@ impl<'a, T> EncodeLike for CompactRef<'a, T>
 where
 	T: CompactAs,
 	for<'b> CompactRef<'b, T::As>: Encode,
-{}
+{
+}
 
 impl<'a, T> Encode for CompactRef<'a, T>
 where
@@ -185,25 +189,42 @@ impl_from_compact! { (), u8, u16, u32, u64, u128 }
 pub struct CompactRef<'a, T>(pub &'a T);
 
 impl<'a, T> From<&'a T> for CompactRef<'a, T> {
-	fn from(x: &'a T) -> Self { CompactRef(x) }
+	fn from(x: &'a T) -> Self {
+		CompactRef(x)
+	}
 }
 
-impl<T> core::fmt::Debug for Compact<T> where T: core::fmt::Debug {
+impl<T> core::fmt::Debug for Compact<T>
+where
+	T: core::fmt::Debug,
+{
 	fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
 		self.0.fmt(f)
 	}
 }
 
 #[cfg(feature = "serde")]
-impl<T> serde::Serialize for Compact<T> where T: serde::Serialize {
-	fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error> where S: serde::Serializer {
+impl<T> serde::Serialize for Compact<T>
+where
+	T: serde::Serialize,
+{
+	fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+	where
+		S: serde::Serializer,
+	{
 		T::serialize(&self.0, serializer)
 	}
 }
 
 #[cfg(feature = "serde")]
-impl<'de, T> serde::Deserialize<'de> for Compact<T> where T: serde::Deserialize<'de> {
-	fn deserialize<D>(deserializer: D) -> Result<Self, D::Error> where D: serde::Deserializer<'de> {
+impl<'de, T> serde::Deserialize<'de> for Compact<T>
+where
+	T: serde::Deserialize<'de>,
+{
+	fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+	where
+		D: serde::Deserializer<'de>,
+	{
 		T::deserialize(deserializer).map(Compact)
 	}
 }
@@ -228,26 +249,34 @@ pub trait HasCompact: Sized {
 	type Type: for<'a> EncodeAsRef<'a, Self> + Decode + From<Self> + Into<Self> + MaybeMaxEncodedLen;
 }
 
-impl<'a, T: 'a> EncodeAsRef<'a, T> for Compact<T> where CompactRef<'a, T>: Encode + From<&'a T> {
+impl<'a, T: 'a> EncodeAsRef<'a, T> for Compact<T>
+where
+	CompactRef<'a, T>: Encode + From<&'a T>,
+{
 	type RefType = CompactRef<'a, T>;
 }
 
 #[cfg(feature = "max-encoded-len")]
-impl<T> MaxEncodedLen for Compact<T> where T: CompactAs, Compact<T::As>: MaxEncodedLen, Compact<T>: Encode {
+impl<T> MaxEncodedLen for Compact<T>
+where
+	T: CompactAs,
+	Compact<T::As>: MaxEncodedLen,
+	Compact<T>: Encode,
+{
 	fn max_encoded_len() -> usize {
 		Compact::<T::As>::max_encoded_len()
 	}
 }
 
-impl<T: 'static> HasCompact for T where
-	Compact<T>: for<'a> EncodeAsRef<'a, T> + Decode + From<Self> + Into<Self> + MaybeMaxEncodedLen
+impl<T: 'static> HasCompact for T
+where
+	Compact<T>: for<'a> EncodeAsRef<'a, T> + Decode + From<Self> + Into<Self> + MaybeMaxEncodedLen,
 {
 	type Type = Compact<T>;
 }
 
 impl<'a> Encode for CompactRef<'a, ()> {
-	fn encode_to<W: Output + ?Sized>(&self, _dest: &mut W) {
-	}
+	fn encode_to<W: Output + ?Sized>(&self, _dest: &mut W) {}
 
 	fn using_encoded<R, F: FnOnce(&[u8]) -> R>(&self, f: F) -> R {
 		f(&[])
@@ -325,11 +354,12 @@ impl<'a> Encode for CompactRef<'a, u32> {
 		match self.0 {
 			0..=0b0011_1111 => dest.push_byte((*self.0 as u8) << 2),
 			0..=0b0011_1111_1111_1111 => (((*self.0 as u16) << 2) | 0b01).encode_to(dest),
-			0..=0b0011_1111_1111_1111_1111_1111_1111_1111 => ((*self.0 << 2) | 0b10).encode_to(dest),
+			0..=0b0011_1111_1111_1111_1111_1111_1111_1111 =>
+				((*self.0 << 2) | 0b10).encode_to(dest),
 			_ => {
 				dest.push_byte(0b11);
 				self.0.encode_to(dest);
-			}
+			},
 		}
 	}
 
@@ -360,10 +390,14 @@ impl<'a> Encode for CompactRef<'a, u64> {
 		match self.0 {
 			0..=0b0011_1111 => dest.push_byte((*self.0 as u8) << 2),
 			0..=0b0011_1111_1111_1111 => (((*self.0 as u16) << 2) | 0b01).encode_to(dest),
-			0..=0b0011_1111_1111_1111_1111_1111_1111_1111 => (((*self.0 as u32) << 2) | 0b10).encode_to(dest),
+			0..=0b0011_1111_1111_1111_1111_1111_1111_1111 =>
+				(((*self.0 as u32) << 2) | 0b10).encode_to(dest),
 			_ => {
 				let bytes_needed = 8 - self.0.leading_zeros() / 8;
-				assert!(bytes_needed >= 4, "Previous match arm matches anyting less than 2^30; qed");
+				assert!(
+					bytes_needed >= 4,
+					"Previous match arm matches anyting less than 2^30; qed"
+				);
 				dest.push_byte(0b11 + ((bytes_needed - 4) << 2) as u8);
 				let mut v = *self.0;
 				for _ in 0..bytes_needed {
@@ -371,7 +405,7 @@ impl<'a> Encode for CompactRef<'a, u64> {
 					v >>= 8;
 				}
 				assert_eq!(v, 0, "shifted sufficient bits right to lead only leading zeros; qed")
-			}
+			},
 		}
 	}
 
@@ -388,9 +422,7 @@ impl CompactLen<u64> for Compact<u64> {
 			0..=0b0011_1111 => 1,
 			0..=0b0011_1111_1111_1111 => 2,
 			0..=0b0011_1111_1111_1111_1111_1111_1111_1111 => 4,
-			_ => {
-				(8 - val.leading_zeros() / 8) as usize + 1
-			},
+			_ => (8 - val.leading_zeros() / 8) as usize + 1,
 		}
 	}
 }
@@ -404,10 +436,14 @@ impl<'a> Encode for CompactRef<'a, u128> {
 		match self.0 {
 			0..=0b0011_1111 => dest.push_byte((*self.0 as u8) << 2),
 			0..=0b0011_1111_1111_1111 => (((*self.0 as u16) << 2) | 0b01).encode_to(dest),
-			0..=0b0011_1111_1111_1111_1111_1111_1111_1111 => (((*self.0 as u32) << 2) | 0b10).encode_to(dest),
+			0..=0b0011_1111_1111_1111_1111_1111_1111_1111 =>
+				(((*self.0 as u32) << 2) | 0b10).encode_to(dest),
 			_ => {
 				let bytes_needed = 16 - self.0.leading_zeros() / 8;
-				assert!(bytes_needed >= 4, "Previous match arm matches anyting less than 2^30; qed");
+				assert!(
+					bytes_needed >= 4,
+					"Previous match arm matches anyting less than 2^30; qed"
+				);
 				dest.push_byte(0b11 + ((bytes_needed - 4) << 2) as u8);
 				let mut v = *self.0;
 				for _ in 0..bytes_needed {
@@ -415,7 +451,7 @@ impl<'a> Encode for CompactRef<'a, u128> {
 					v >>= 8;
 				}
 				assert_eq!(v, 0, "shifted sufficient bits right to lead only leading zeros; qed")
-			}
+			},
 		}
 	}
 
@@ -432,9 +468,7 @@ impl CompactLen<u128> for Compact<u128> {
 			0..=0b0011_1111 => 1,
 			0..=0b0011_1111_1111_1111 => 2,
 			0..=0b0011_1111_1111_1111_1111_1111_1111_1111 => 4,
-			_ => {
-				(16 - val.leading_zeros() / 8) as usize + 1
-			},
+			_ => (16 - val.leading_zeros() / 8) as usize + 1,
 		}
 	}
 }
@@ -457,7 +491,7 @@ impl Decode for Compact<u8> {
 		Ok(Compact(match prefix % 4 {
 			0 => prefix >> 2,
 			1 => {
-				let x = u16::decode(&mut PrefixInput{prefix: Some(prefix), input})? >> 2;
+				let x = u16::decode(&mut PrefixInput { prefix: Some(prefix), input })? >> 2;
 				if x > 0b0011_1111 && x <= 255 {
 					x as u8
 				} else {
@@ -475,7 +509,7 @@ impl Decode for Compact<u16> {
 		Ok(Compact(match prefix % 4 {
 			0 => u16::from(prefix) >> 2,
 			1 => {
-				let x = u16::decode(&mut PrefixInput{prefix: Some(prefix), input})? >> 2;
+				let x = u16::decode(&mut PrefixInput { prefix: Some(prefix), input })? >> 2;
 				if x > 0b0011_1111 && x <= 0b0011_1111_1111_1111 {
 					x
 				} else {
@@ -483,7 +517,7 @@ impl Decode for Compact<u16> {
 				}
 			},
 			2 => {
-				let x = u32::decode(&mut PrefixInput{prefix: Some(prefix), input})? >> 2;
+				let x = u32::decode(&mut PrefixInput { prefix: Some(prefix), input })? >> 2;
 				if x > 0b0011_1111_1111_1111 && x < 65536 {
 					x as u16
 				} else {
@@ -501,7 +535,7 @@ impl Decode for Compact<u32> {
 		Ok(Compact(match prefix % 4 {
 			0 => u32::from(prefix) >> 2,
 			1 => {
-				let x = u16::decode(&mut PrefixInput{prefix: Some(prefix), input})? >> 2;
+				let x = u16::decode(&mut PrefixInput { prefix: Some(prefix), input })? >> 2;
 				if x > 0b0011_1111 && x <= 0b0011_1111_1111_1111 {
 					u32::from(x)
 				} else {
@@ -509,7 +543,7 @@ impl Decode for Compact<u32> {
 				}
 			},
 			2 => {
-				let x = u32::decode(&mut PrefixInput{prefix: Some(prefix), input})? >> 2;
+				let x = u32::decode(&mut PrefixInput { prefix: Some(prefix), input })? >> 2;
 				if x > 0b0011_1111_1111_1111 && x <= u32::MAX >> 2 {
 					x
 				} else {
@@ -541,7 +575,7 @@ impl Decode for Compact<u64> {
 		Ok(Compact(match prefix % 4 {
 			0 => u64::from(prefix) >> 2,
 			1 => {
-				let x = u16::decode(&mut PrefixInput{prefix: Some(prefix), input})? >> 2;
+				let x = u16::decode(&mut PrefixInput { prefix: Some(prefix), input })? >> 2;
 				if x > 0b0011_1111 && x <= 0b0011_1111_1111_1111 {
 					u64::from(x)
 				} else {
@@ -549,7 +583,7 @@ impl Decode for Compact<u64> {
 				}
 			},
 			2 => {
-				let x = u32::decode(&mut PrefixInput{prefix: Some(prefix), input})? >> 2;
+				let x = u32::decode(&mut PrefixInput { prefix: Some(prefix), input })? >> 2;
 				if x > 0b0011_1111_1111_1111 && x <= u32::MAX >> 2 {
 					u64::from(x)
 				} else {
@@ -597,7 +631,7 @@ impl Decode for Compact<u128> {
 		Ok(Compact(match prefix % 4 {
 			0 => u128::from(prefix) >> 2,
 			1 => {
-				let x = u16::decode(&mut PrefixInput{prefix: Some(prefix), input})? >> 2;
+				let x = u16::decode(&mut PrefixInput { prefix: Some(prefix), input })? >> 2;
 				if x > 0b0011_1111 && x <= 0b0011_1111_1111_1111 {
 					u128::from(x)
 				} else {
@@ -605,7 +639,7 @@ impl Decode for Compact<u128> {
 				}
 			},
 			2 => {
-				let x = u32::decode(&mut PrefixInput{prefix: Some(prefix), input})? >> 2;
+				let x = u32::decode(&mut PrefixInput { prefix: Some(prefix), input })? >> 2;
 				if x > 0b0011_1111_1111_1111 && x <= u32::MAX >> 2 {
 					u128::from(x)
 				} else {
@@ -662,12 +696,30 @@ mod tests {
 	#[test]
 	fn compact_128_encoding_works() {
 		let tests = [
-			(0u128, 1usize), (63, 1), (64, 2), (16383, 2),
-			(16384, 4), (1073741823, 4),
-			(1073741824, 5), ((1 << 32) - 1, 5),
-			(1 << 32, 6), (1 << 40, 7), (1 << 48, 8), ((1 << 56) - 1, 8), (1 << 56, 9), ((1 << 64) - 1, 9),
-			(1 << 64, 10), (1 << 72, 11), (1 << 80, 12), (1 << 88, 13), (1 << 96, 14), (1 << 104, 15),
-			(1 << 112, 16), ((1 << 120) - 1, 16), (1 << 120, 17), (u128::MAX, 17)
+			(0u128, 1usize),
+			(63, 1),
+			(64, 2),
+			(16383, 2),
+			(16384, 4),
+			(1073741823, 4),
+			(1073741824, 5),
+			((1 << 32) - 1, 5),
+			(1 << 32, 6),
+			(1 << 40, 7),
+			(1 << 48, 8),
+			((1 << 56) - 1, 8),
+			(1 << 56, 9),
+			((1 << 64) - 1, 9),
+			(1 << 64, 10),
+			(1 << 72, 11),
+			(1 << 80, 12),
+			(1 << 88, 13),
+			(1 << 96, 14),
+			(1 << 104, 15),
+			(1 << 112, 16),
+			((1 << 120) - 1, 16),
+			(1 << 120, 17),
+			(u128::MAX, 17),
 		];
 		for &(n, l) in &tests {
 			let encoded = Compact(n as u128).encode();
@@ -680,10 +732,20 @@ mod tests {
 	#[test]
 	fn compact_64_encoding_works() {
 		let tests = [
-			(0u64, 1usize), (63, 1), (64, 2), (16383, 2),
-			(16384, 4), (1073741823, 4),
-			(1073741824, 5), ((1 << 32) - 1, 5),
-			(1 << 32, 6), (1 << 40, 7), (1 << 48, 8), ((1 << 56) - 1, 8), (1 << 56, 9), (u64::MAX, 9)
+			(0u64, 1usize),
+			(63, 1),
+			(64, 2),
+			(16383, 2),
+			(16384, 4),
+			(1073741823, 4),
+			(1073741824, 5),
+			((1 << 32) - 1, 5),
+			(1 << 32, 6),
+			(1 << 40, 7),
+			(1 << 48, 8),
+			((1 << 56) - 1, 8),
+			(1 << 56, 9),
+			(u64::MAX, 9),
 		];
 		for &(n, l) in &tests {
 			let encoded = Compact(n as u64).encode();
@@ -695,7 +757,16 @@ mod tests {
 
 	#[test]
 	fn compact_32_encoding_works() {
-		let tests = [(0u32, 1usize), (63, 1), (64, 2), (16383, 2), (16384, 4), (1073741823, 4), (1073741824, 5), (u32::MAX, 5)];
+		let tests = [
+			(0u32, 1usize),
+			(63, 1),
+			(64, 2),
+			(16383, 2),
+			(16384, 4),
+			(1073741823, 4),
+			(1073741824, 5),
+			(u32::MAX, 5),
+		];
 		for &(n, l) in &tests {
 			let encoded = Compact(n as u32).encode();
 			assert_eq!(encoded.len(), l);
@@ -729,7 +800,11 @@ mod tests {
 	}
 
 	fn hexify(bytes: &[u8]) -> String {
-		bytes.iter().map(|ref b| format!("{:02x}", b)).collect::<Vec<String>>().join(" ")
+		bytes
+			.iter()
+			.map(|ref b| format!("{:02x}", b))
+			.collect::<Vec<String>>()
+			.join(" ")
 	}
 
 	#[test]
@@ -748,7 +823,7 @@ mod tests {
 			(1 << 48, "0f 00 00 00 00 00 00 01"),
 			((1 << 56) - 1, "0f ff ff ff ff ff ff ff"),
 			(1 << 56, "13 00 00 00 00 00 00 00 01"),
-			(u64::MAX, "13 ff ff ff ff ff ff ff ff")
+			(u64::MAX, "13 ff ff ff ff ff ff ff ff"),
 		];
 		for &(n, s) in &tests {
 			// Verify u64 encoding
@@ -806,7 +881,7 @@ mod tests {
 			let encoded = compact.encode();
 			assert_eq!(encoded.len(), l);
 			assert_eq!(Compact::compact_len(&n), l);
-			let decoded = <Compact<Wrapper>>::decode(&mut & encoded[..]).unwrap();
+			let decoded = <Compact<Wrapper>>::decode(&mut &encoded[..]).unwrap();
 			let wrapper: Wrapper = decoded.into();
 			assert_eq!(wrapper, Wrapper(n));
 		}
@@ -899,7 +974,9 @@ mod tests {
 			(u64::MAX << 8) - 1,
 			u64::MAX << 16,
 			(u64::MAX << 16) - 1,
-		].iter() {
+		]
+		.iter()
+		{
 			let e = Compact::<u64>::encode(&Compact(*a));
 			let d = Compact::<u64>::decode(&mut &e[..]).unwrap().0;
 			assert_eq!(*a, d);
@@ -908,12 +985,7 @@ mod tests {
 
 	#[test]
 	fn compact_u128_test() {
-		for a in [
-			u64::MAX as u128,
-			(u64::MAX - 10) as u128,
-			u128::MAX,
-			u128::MAX - 10,
-		].iter() {
+		for a in [u64::MAX as u128, (u64::MAX - 10) as u128, u128::MAX, u128::MAX - 10].iter() {
 			let e = Compact::<u128>::encode(&Compact(*a));
 			let d = Compact::<u128>::decode(&mut &e[..]).unwrap().0;
 			assert_eq!(*a, d);
@@ -923,16 +995,33 @@ mod tests {
 	#[test]
 	fn should_avoid_overlapping_definition() {
 		check_bound!(
-			0b01, u8, u16, [ (u8, U8_OUT_OF_RANGE), (u16, U16_OUT_OF_RANGE),
-			(u32, U32_OUT_OF_RANGE), (u64, U64_OUT_OF_RANGE), (u128, U128_OUT_OF_RANGE)]
+			0b01,
+			u8,
+			u16,
+			[
+				(u8, U8_OUT_OF_RANGE),
+				(u16, U16_OUT_OF_RANGE),
+				(u32, U32_OUT_OF_RANGE),
+				(u64, U64_OUT_OF_RANGE),
+				(u128, U128_OUT_OF_RANGE)
+			]
 		);
 		check_bound!(
-			0b10, u16, u32, [ (u16, U16_OUT_OF_RANGE),
-			(u32, U32_OUT_OF_RANGE), (u64, U64_OUT_OF_RANGE), (u128, U128_OUT_OF_RANGE)]
+			0b10,
+			u16,
+			u32,
+			[
+				(u16, U16_OUT_OF_RANGE),
+				(u32, U32_OUT_OF_RANGE),
+				(u64, U64_OUT_OF_RANGE),
+				(u128, U128_OUT_OF_RANGE)
+			]
 		);
-		check_bound_u32!(
-			[(u32, U32_OUT_OF_RANGE), (u64, U64_OUT_OF_RANGE), (u128, U128_OUT_OF_RANGE)]
-		);
+		check_bound_u32!([
+			(u32, U32_OUT_OF_RANGE),
+			(u64, U64_OUT_OF_RANGE),
+			(u128, U128_OUT_OF_RANGE)
+		]);
 		for i in 5..=8 {
 			check_bound_high!(i, [(u64, U64_OUT_OF_RANGE), (u128, U128_OUT_OF_RANGE)]);
 		}

--- a/src/const_encoded_len.rs
+++ b/src/const_encoded_len.rs
@@ -13,16 +13,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! Contains the [`ConstEncodedLen`] trait. 
+//! Contains the [`ConstEncodedLen`] trait.
 
-use crate::MaxEncodedLen;
+use crate::{alloc::boxed::Box, MaxEncodedLen};
 use core::{
 	marker::PhantomData,
 	num::*,
 	ops::{Range, RangeInclusive},
 	time::Duration,
 };
-use crate::alloc::boxed::Box;
 use impl_trait_for_tuples::impl_for_tuples;
 
 /// Types that have a constant encoded length. This implies [`MaxEncodedLen`].
@@ -31,9 +30,9 @@ use impl_trait_for_tuples::impl_for_tuples;
 pub trait ConstEncodedLen: MaxEncodedLen {}
 
 #[impl_for_tuples(18)]
-impl ConstEncodedLen for Tuple { }
+impl ConstEncodedLen for Tuple {}
 
-impl<T: ConstEncodedLen, const N: usize> ConstEncodedLen for [T; N] { }
+impl<T: ConstEncodedLen, const N: usize> ConstEncodedLen for [T; N] {}
 
 /// Mark `T` or `T<S>` as `CEL`.
 macro_rules! mark_cel {
@@ -50,7 +49,18 @@ macro_rules! mark_cel {
 }
 
 mark_cel!(u8, u16, u32, u64, u128, i8, i16, i32, i64, i128, bool);
-mark_cel!(NonZeroU8, NonZeroU16, NonZeroU32, NonZeroU64, NonZeroU128, NonZeroI8, NonZeroI16, NonZeroI32, NonZeroI64, NonZeroI128);
+mark_cel!(
+	NonZeroU8,
+	NonZeroU16,
+	NonZeroU32,
+	NonZeroU64,
+	NonZeroU128,
+	NonZeroI8,
+	NonZeroI16,
+	NonZeroI32,
+	NonZeroI64,
+	NonZeroI128
+);
 
 mark_cel!(Duration);
 mark_cel!(PhantomData<T>);
@@ -85,7 +95,7 @@ mod tests {
 	test_cel_compliance!(Void);
 
 	test_cel_compliance!(u8, u16, u32, u64, u128, i8, i16, i32, i64, i128, bool);
-	
+
 	type TupleArithmetic = (u8, u16, u32, u64, u128, i8, i16, i32, i64, i128);
 	test_cel_compliance!(TupleArithmetic);
 

--- a/src/decode_all.rs
+++ b/src/decode_all.rs
@@ -17,8 +17,8 @@ use crate::{Decode, Error};
 /// The error message returned when `decode_all` fails.
 pub(crate) const DECODE_ALL_ERR_MSG: &str = "Input buffer has still data left after decoding!";
 
-/// Extension trait to [`Decode`] that ensures that the given input data is consumed completely while
-/// decoding.
+/// Extension trait to [`Decode`] that ensures that the given input data is consumed completely
+/// while decoding.
 pub trait DecodeAll: Sized {
 	/// Decode `Self` and consume all of the given input data.
 	///

--- a/src/encode_like.rs
+++ b/src/encode_like.rs
@@ -22,7 +22,7 @@ use crate::codec::Encode;
 /// # Example
 ///
 /// ```
-///# use parity_scale_codec::{EncodeLike, Encode};
+/// # use parity_scale_codec::{EncodeLike, Encode};
 /// fn encode_like<T: Encode, R: EncodeLike<T>>(data: &R) {
 ///     data.encode(); // Valid `T` encoded value.
 /// }
@@ -51,7 +51,7 @@ use crate::codec::Encode;
 /// combination or use [`Ref`](./struct.Ref.html) reference wrapper or define your own wrapper
 /// and implement `EncodeLike` on it as such:
 /// ```
-///# use parity_scale_codec::{EncodeLike, Encode, WrapperTypeEncode};
+/// # use parity_scale_codec::{EncodeLike, Encode, WrapperTypeEncode};
 /// fn encode_like<T: Encode, R: EncodeLike<T>>(data: &R) {
 ///     data.encode(); // Valid `T` encoded value.
 /// }
@@ -88,8 +88,10 @@ pub trait EncodeLike<T: Encode = Self>: Sized + Encode {}
 /// ```
 pub struct Ref<'a, T: EncodeLike<U>, U: Encode>(&'a T, core::marker::PhantomData<U>);
 impl<'a, T: EncodeLike<U>, U: Encode> core::ops::Deref for Ref<'a, T, U> {
-    type Target = T;
-    fn deref(&self) -> &Self::Target { self.0 }
+	type Target = T;
+	fn deref(&self) -> &Self::Target {
+		self.0
+	}
 }
 
 impl<'a, T: EncodeLike<U>, U: Encode> From<&'a T> for Ref<'a, T, U> {
@@ -109,7 +111,10 @@ mod tests {
 	struct ComplexStuff<T>(T);
 
 	impl<T: Encode> ComplexStuff<T> {
-		fn complex_method<R: Encode>(value: &R) -> Vec<u8> where T: EncodeLike<R> {
+		fn complex_method<R: Encode>(value: &R) -> Vec<u8>
+		where
+			T: EncodeLike<R>,
+		{
 			value.encode()
 		}
 	}

--- a/src/generic_array.rs
+++ b/src/generic_array.rs
@@ -12,9 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::alloc::vec::Vec;
-use crate::{Encode, Decode, Input, Output, Error};
-use crate::encode_like::EncodeLike;
+use crate::{alloc::vec::Vec, encode_like::EncodeLike, Decode, Encode, Error, Input, Output};
 
 impl<T: Encode, L: generic_array::ArrayLength<T>> Encode for generic_array::GenericArray<T, L> {
 	fn encode_to<W: Output + ?Sized>(&self, dest: &mut W) {
@@ -44,7 +42,7 @@ impl<T: Decode, L: generic_array::ArrayLength<T>> Decode for generic_array::Gene
 #[cfg(test)]
 mod tests {
 	use super::*;
-	use generic_array::{typenum, GenericArray, arr};
+	use generic_array::{arr, typenum, GenericArray};
 
 	#[test]
 	fn generic_array() {

--- a/src/joiner.rs
+++ b/src/joiner.rs
@@ -25,7 +25,10 @@ pub trait Joiner {
 	fn and<V: Codec + Sized>(self, value: &V) -> Self;
 }
 
-impl<T> Joiner for T where T: for<'a> Extend<&'a u8> {
+impl<T> Joiner for T
+where
+	T: for<'a> Extend<&'a u8>,
+{
 	fn and<V: Codec + Sized>(mut self, value: &V) -> Self {
 		value.using_encoded(|s| self.extend(s));
 		self

--- a/src/keyedvec.rs
+++ b/src/keyedvec.rs
@@ -16,8 +16,7 @@
 
 use core::iter::Extend;
 
-use crate::alloc::vec::Vec;
-use crate::codec::Codec;
+use crate::{alloc::vec::Vec, codec::Codec};
 
 /// Trait to allow itself to be serialised and prepended by a given slice.
 pub trait KeyedVec {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,54 +36,49 @@ pub use parity_scale_codec_derive::*;
 #[cfg(feature = "std")]
 #[doc(hidden)]
 pub mod alloc {
-	pub use std::boxed;
-	pub use std::vec;
-	pub use std::string;
-	pub use std::borrow;
-	pub use std::collections;
-	pub use std::sync;
-	pub use std::rc;
-	pub use std::alloc;
+	pub use std::{alloc, borrow, boxed, collections, rc, string, sync, vec};
 }
 
-mod codec;
-mod compact;
-mod joiner;
-mod keyedvec;
 #[cfg(feature = "bit-vec")]
 mod bit_vec;
-#[cfg(feature = "generic-array")]
-mod generic_array;
+mod codec;
+mod compact;
+#[cfg(feature = "max-encoded-len")]
+mod const_encoded_len;
 mod decode_all;
 mod decode_finished;
 mod depth_limit;
 mod encode_append;
 mod encode_like;
 mod error;
+#[cfg(feature = "generic-array")]
+mod generic_array;
+mod joiner;
+mod keyedvec;
 #[cfg(feature = "max-encoded-len")]
 mod max_encoded_len;
-#[cfg(feature = "max-encoded-len")]
-mod const_encoded_len;
 
-pub use self::error::Error;
-pub use self::codec::{
-	Input, Output, Decode, Encode, Codec, EncodeAsRef, WrapperTypeEncode, WrapperTypeDecode,
-	OptionBool, DecodeLength, FullCodec, FullEncode, decode_vec_with_len,
-};
 #[cfg(feature = "std")]
 pub use self::codec::IoReader;
-pub use self::compact::{Compact, HasCompact, CompactAs, CompactLen, CompactRef};
-pub use self::joiner::Joiner;
-pub use self::keyedvec::KeyedVec;
-pub use self::decode_all::DecodeAll;
-pub use self::decode_finished::DecodeFinished;
-pub use self::depth_limit::DecodeLimit;
-pub use self::encode_append::EncodeAppend;
-pub use self::encode_like::{EncodeLike, Ref};
-#[cfg(feature = "max-encoded-len")]
-pub use max_encoded_len::MaxEncodedLen;
+pub use self::{
+	codec::{
+		decode_vec_with_len, Codec, Decode, DecodeLength, Encode, EncodeAsRef, FullCodec,
+		FullEncode, Input, OptionBool, Output, WrapperTypeDecode, WrapperTypeEncode,
+	},
+	compact::{Compact, CompactAs, CompactLen, CompactRef, HasCompact},
+	decode_all::DecodeAll,
+	decode_finished::DecodeFinished,
+	depth_limit::DecodeLimit,
+	encode_append::EncodeAppend,
+	encode_like::{EncodeLike, Ref},
+	error::Error,
+	joiner::Joiner,
+	keyedvec::KeyedVec,
+};
 #[cfg(feature = "max-encoded-len")]
 pub use const_encoded_len::ConstEncodedLen;
+#[cfg(feature = "max-encoded-len")]
+pub use max_encoded_len::MaxEncodedLen;
 
 /// Derive macro for [`MaxEncodedLen`][max_encoded_len::MaxEncodedLen].
 ///
@@ -117,9 +112,10 @@ pub use const_encoded_len::ConstEncodedLen;
 ///
 /// # Within other macros
 ///
-/// Sometimes the `MaxEncodedLen` trait and macro are used within another macro, and it can't be
-/// guaranteed that the `parity_scale_codec` module is available at the call site. In that case, the
-/// macro should reexport the `parity_scale_codec` module and specify the path to the reexport:
+/// Sometimes the `MaxEncodedLen` trait and macro are used within another macro, and it can't
+/// be guaranteed that the `parity_scale_codec` module is available at the call site. In that
+/// case, the macro should reexport the `parity_scale_codec` module and specify the path to the
+/// reexport:
 ///
 /// ```ignore
 /// pub use parity_scale_codec as codec;

--- a/src/max_encoded_len.rs
+++ b/src/max_encoded_len.rs
@@ -15,10 +15,15 @@
 
 //! `trait MaxEncodedLen` bounds the maximum encoded length of items.
 
-use crate::{Compact, Encode};
+use crate::{alloc::boxed::Box, Compact, Encode};
+use core::{
+	marker::PhantomData,
+	mem,
+	num::*,
+	ops::{Range, RangeInclusive},
+	time::Duration,
+};
 use impl_trait_for_tuples::impl_for_tuples;
-use core::{mem, marker::PhantomData, num::*, ops::{Range, RangeInclusive}, time::Duration};
-use crate::alloc::boxed::Box;
 
 #[cfg(target_has_atomic = "ptr")]
 use crate::alloc::sync::Arc;
@@ -47,9 +52,27 @@ macro_rules! impl_primitives {
 }
 
 impl_primitives!(
-	u8, i8, u16, i16, u32, i32, u64, i64, u128, i128, bool,
-	NonZeroU8, NonZeroU16, NonZeroU32, NonZeroU64, NonZeroU128, NonZeroI8, NonZeroI16, NonZeroI32,
-	NonZeroI64, NonZeroI128
+	u8,
+	i8,
+	u16,
+	i16,
+	u32,
+	i32,
+	u64,
+	i64,
+	u128,
+	i128,
+	bool,
+	NonZeroU8,
+	NonZeroU16,
+	NonZeroU32,
+	NonZeroU64,
+	NonZeroU128,
+	NonZeroI8,
+	NonZeroI16,
+	NonZeroI32,
+	NonZeroI64,
+	NonZeroI128
 );
 
 macro_rules! impl_compact {
@@ -78,7 +101,8 @@ impl_compact!(
 	u128 => 17;
 );
 
-// impl_for_tuples for values 19 and higher fails because that's where the WrapperTypeEncode impl stops.
+// impl_for_tuples for values 19 and higher fails because that's where the WrapperTypeEncode impl
+// stops.
 #[impl_for_tuples(18)]
 impl MaxEncodedLen for Tuple {
 	fn max_encoded_len() -> usize {
@@ -96,7 +120,7 @@ impl<T: MaxEncodedLen, const N: usize> MaxEncodedLen for [T; N] {
 
 impl<T: MaxEncodedLen> MaxEncodedLen for Box<T> {
 	fn max_encoded_len() -> usize {
-	    T::max_encoded_len()
+		T::max_encoded_len()
 	}
 }
 
@@ -131,19 +155,19 @@ impl<T> MaxEncodedLen for PhantomData<T> {
 
 impl MaxEncodedLen for Duration {
 	fn max_encoded_len() -> usize {
-	    u64::max_encoded_len() + u32::max_encoded_len()
+		u64::max_encoded_len() + u32::max_encoded_len()
 	}
 }
 
 impl<T: MaxEncodedLen> MaxEncodedLen for Range<T> {
 	fn max_encoded_len() -> usize {
-	    T::max_encoded_len().saturating_mul(2)
+		T::max_encoded_len().saturating_mul(2)
 	}
 }
 
 impl<T: MaxEncodedLen> MaxEncodedLen for RangeInclusive<T> {
 	fn max_encoded_len() -> usize {
-	    T::max_encoded_len().saturating_mul(2)
+		T::max_encoded_len().saturating_mul(2)
 	}
 }
 

--- a/tests/chain-error.rs
+++ b/tests/chain-error.rs
@@ -12,15 +12,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use parity_scale_codec_derive::Decode as DeriveDecode;
 use parity_scale_codec::Decode;
+use parity_scale_codec_derive::Decode as DeriveDecode;
 
 #[derive(DeriveDecode, Debug)]
 struct Wrapper<T>(T);
 
 #[derive(DeriveDecode, Debug)]
 struct StructNamed {
-	_foo: u16
+	_foo: u16,
 }
 
 #[derive(DeriveDecode, Debug)]
@@ -28,7 +28,7 @@ struct StructUnnamed(u16);
 
 #[derive(DeriveDecode, Debug)]
 enum E {
-	VariantNamed { _foo: u16, },
+	VariantNamed { _foo: u16 },
 	VariantUnnamed(u16),
 }
 
@@ -65,10 +65,7 @@ fn full_error_enum_unknown_variant() {
 	let encoded = vec![2];
 	let err = r#"Could not decode `E`, variant doesn't exist"#;
 
-	assert_eq!(
-		E::decode(&mut &encoded[..]).unwrap_err().to_string(),
-		String::from(err),
-	);
+	assert_eq!(E::decode(&mut &encoded[..]).unwrap_err().to_string(), String::from(err),);
 }
 
 #[test]
@@ -78,10 +75,7 @@ fn full_error_enum_named_field() {
 	Not enough data to fill buffer
 "#;
 
-	assert_eq!(
-		E::decode(&mut &encoded[..]).unwrap_err().to_string(),
-		String::from(err),
-	);
+	assert_eq!(E::decode(&mut &encoded[..]).unwrap_err().to_string(), String::from(err),);
 }
 
 #[test]
@@ -91,8 +85,5 @@ fn full_error_enum_unnamed_field() {
 	Not enough data to fill buffer
 "#;
 
-	assert_eq!(
-		E::decode(&mut &encoded[..]).unwrap_err().to_string(),
-		String::from(err),
-	);
+	assert_eq!(E::decode(&mut &encoded[..]).unwrap_err().to_string(), String::from(err),);
 }

--- a/tests/max_encoded_len.rs
+++ b/tests/max_encoded_len.rs
@@ -80,7 +80,6 @@ fn compact_field_max_length() {
 	);
 }
 
-
 #[derive(Encode, MaxEncodedLen)]
 struct CompactFieldGenerics<T: MaxEncodedLen> {
 	#[codec(compact)]
@@ -90,10 +89,7 @@ struct CompactFieldGenerics<T: MaxEncodedLen> {
 
 #[test]
 fn compact_field_generics_max_length() {
-	assert_eq!(
-		CompactFieldGenerics::<u64>::max_encoded_len(),
-		CompactField::max_encoded_len()
-	);
+	assert_eq!(CompactFieldGenerics::<u64>::max_encoded_len(), CompactField::max_encoded_len());
 }
 
 #[derive(Encode, MaxEncodedLen)]

--- a/tests/mod.rs
+++ b/tests/mod.rs
@@ -679,15 +679,17 @@ fn decoding_a_huge_boxed_newtype_array_does_not_overflow_the_stack() {
 fn decoding_two_indirectly_boxed_arrays_works() {
 	// This test will fail if the check for `#[repr(transparent)]` in the derive crate
 	// doesn't work when implementing `Decode::decode_into`.
-	#[derive(DeriveDecode)]
-	#[derive(PartialEq, Eq, Debug)]
+	#[derive(DeriveDecode, PartialEq, Eq, Debug)]
 	struct SmallArrays([u8; 2], [u8; 2]);
 
 	#[derive(DeriveDecode)]
 	struct SmallArraysBox(Box<SmallArrays>);
 
 	let data = &[1, 2, 3, 4];
-	assert_eq!(*SmallArraysBox::decode(&mut data.as_slice()).unwrap().0, SmallArrays([1, 2], [3, 4]));
+	assert_eq!(
+		*SmallArraysBox::decode(&mut data.as_slice()).unwrap().0,
+		SmallArrays([1, 2], [3, 4])
+	);
 }
 
 #[test]
@@ -708,7 +710,7 @@ fn zero_sized_types_are_properly_decoded_in_a_transparent_boxed_struct() {
 		_zst_2: ZstTransparent,
 		_zst_3: ZstNonTransparent,
 		field: [u8; 1],
-		_zst_4: ConsumeByte
+		_zst_4: ConsumeByte,
 	}
 
 	#[derive(DeriveDecode)]

--- a/tests/single_field_struct_encoding.rs
+++ b/tests/single_field_struct_encoding.rs
@@ -1,6 +1,8 @@
-use parity_scale_codec_derive::{Encode as DeriveEncode, Decode as DeriveDecode, CompactAs as DeriveCompactAs};
 use parity_scale_codec::{Compact, Decode, Encode, HasCompact};
-use serde_derive::{Serialize, Deserialize};
+use parity_scale_codec_derive::{
+	CompactAs as DeriveCompactAs, Decode as DeriveDecode, Encode as DeriveEncode,
+};
+use serde_derive::{Deserialize, Serialize};
 
 #[derive(Debug, PartialEq, DeriveEncode, DeriveDecode)]
 struct S {
@@ -35,7 +37,9 @@ struct U(u32);
 
 #[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
 #[derive(Debug, PartialEq, Eq, Clone, Copy, DeriveEncode, DeriveDecode, DeriveCompactAs)]
-struct U2 { a: u64 }
+struct U2 {
+	a: u64,
+}
 
 #[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
 #[derive(Debug, PartialEq, Eq, Clone, Copy, DeriveEncode, DeriveDecode, DeriveCompactAs)]

--- a/tests/skip.rs
+++ b/tests/skip.rs
@@ -1,5 +1,5 @@
-use parity_scale_codec_derive::{Encode as DeriveEncode, Decode as DeriveDecode};
-use parity_scale_codec::{Encode, Decode};
+use parity_scale_codec::{Decode, Encode};
+use parity_scale_codec_derive::{Decode as DeriveDecode, Encode as DeriveEncode};
 
 #[test]
 fn enum_struct_test() {
@@ -9,9 +9,9 @@ fn enum_struct_test() {
 	#[derive(PartialEq, Debug)]
 	struct UncodecUndefaultType;
 
-use parity_scale_codec_derive::{Encode as DeriveEncode, Decode as DeriveDecode};
+	use parity_scale_codec_derive::{Decode as DeriveDecode, Encode as DeriveEncode};
 	#[derive(PartialEq, Debug, DeriveEncode, DeriveDecode)]
-	enum Enum<T=UncodecType, S=UncodecUndefaultType> {
+	enum Enum<T = UncodecType, S = UncodecUndefaultType> {
 		#[codec(skip)]
 		A(S),
 		B {
@@ -19,26 +19,18 @@ use parity_scale_codec_derive::{Encode as DeriveEncode, Decode as DeriveDecode};
 			_b1: T,
 			b2: u32,
 		},
-		C(
-			#[codec(skip)]
-			T,
-			u32,
-		),
+		C(#[codec(skip)] T, u32),
 	}
 
 	#[derive(PartialEq, Debug, DeriveEncode, DeriveDecode)]
-	struct StructNamed<T=UncodecType> {
+	struct StructNamed<T = UncodecType> {
 		#[codec(skip)]
 		a: T,
 		b: u32,
 	}
 
 	#[derive(PartialEq, Debug, DeriveEncode, DeriveDecode)]
-	struct StructUnnamed<T=UncodecType>(
-		#[codec(skip)]
-		T,
-		u32,
-	);
+	struct StructUnnamed<T = UncodecType>(#[codec(skip)] T, u32);
 
 	let ea: Enum = Enum::A(UncodecUndefaultType);
 	let eb: Enum = Enum::B { _b1: UncodecType, b2: 1 };
@@ -70,7 +62,7 @@ fn skip_enum_struct_inner_variant() {
 			some_named: u32,
 			#[codec(skip)]
 			ignore: Option<u32>,
-		}
+		},
 	}
 
 	let encoded = Enum::Data { some_named: 1, ignore: Some(1) }.encode();

--- a/tests/type_inference.rs
+++ b/tests/type_inference.rs
@@ -14,8 +14,8 @@
 
 //! Test for type inference issue in decode.
 
-use parity_scale_codec_derive::Decode as DeriveDecode;
 use parity_scale_codec::Decode;
+use parity_scale_codec_derive::Decode as DeriveDecode;
 
 pub trait Trait {
 	type Value;
@@ -24,10 +24,7 @@ pub trait Trait {
 
 #[derive(DeriveDecode)]
 pub enum A<T: Trait> {
-	_C(
-		(T::AccountId, T::AccountId),
-		Vec<(T::Value, T::Value)>,
-	),
+	_C((T::AccountId, T::AccountId), Vec<(T::Value, T::Value)>),
 }
 
 #[derive(DeriveDecode)]

--- a/tests/variant_number.rs
+++ b/tests/variant_number.rs
@@ -1,5 +1,5 @@
-use parity_scale_codec_derive::Encode as DeriveEncode;
 use parity_scale_codec::Encode;
+use parity_scale_codec_derive::Encode as DeriveEncode;
 
 #[test]
 fn discriminant_variant_counted_in_default_index() {


### PR DESCRIPTION
Though `rustfmt.toml` was introduced in [0841cc48bc14d2573cb7a8de8b2d342db362ee62](https://github.com/kalaninja/parity-scale-codec/commit/0841cc48bc14d2573cb7a8de8b2d342db362ee62), the code wasn't  formatted accordingly.

This PR formats the source code and adds a corresponding check to ci.

The formatting was done with `cargo +nightly fmt --all` to follow `rustfmt.toml` rules, so the check is implemented with `cargo +nightly fmt --all -- --check`