### PR TITLE
Add the repository field to Cargo.toml

### DIFF
--- a/derive/Cargo.toml
+++ b/derive/Cargo.toml
@@ -6,6 +6,7 @@ authors = ["Parity Technologies <admin@parity.io>"]
 license = "Apache-2.0"
 edition = "2021"
 rust-version = "1.56.1"
+repository = "https://github.com/paritytech/parity-scale-codec"
 
 [lib]
 proc-macro = true


### PR DESCRIPTION
To allow [Crates.io](https://crates.io/) , [lib.rs](https://lib.rs/) and the [Rust Digger](https://rust-digger.code-maven.com/) to link to it. See [the manifest](https://doc.rust-lang.org/cargo/reference/manifest.html#the-repository-field) for the explanation.