### PR TITLE
Follow-up on #605

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ on:
   pull_request:
 
 env:
-  IMAGE: paritytech/ci-unified:bullseye-1.73.0
+  IMAGE: paritytech/ci-unified:bullseye-1.79.0
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,7 +9,7 @@ jobs:
   publish-crate:
     runs-on: ubuntu-latest
     environment: release
-    container: paritytech/ci-unified:bullseye-1.73.0
+    container: paritytech/ci-unified:bullseye-1.79.0
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/benches/benches.rs
+++ b/benches/benches.rs
@@ -184,7 +184,7 @@ fn encode_decode_complex_type(c: &mut Criterion) {
 
 	let complex_types = vec![
 		ComplexType { _val: 3, _other_val: 345634635, _vec: vec![1, 2, 3, 5, 6, 7] },
-		ComplexType { _val: 1000, _other_val: 0980345634635, _vec: vec![1, 2, 3, 5, 6, 7] },
+		ComplexType { _val: 1000, _other_val: 980345634635, _vec: vec![1, 2, 3, 5, 6, 7] },
 		ComplexType { _val: 43564, _other_val: 342342345634635, _vec: vec![1, 2, 3, 5, 6, 7] },
 	];
 

--- a/derive/src/encode.rs
+++ b/derive/src/encode.rs
@@ -103,7 +103,7 @@ enum FieldAttribute<'a> {
 	None(&'a Field),
 	Compact(&'a Field),
 	EncodedAs { field: &'a Field, encoded_as: &'a TokenStream },
-	Skip(&'a Field),
+	Skip,
 }
 
 fn iterate_over_fields<F, H, J>(
@@ -138,7 +138,7 @@ where
 		} else if let Some(ref encoded_as) = encoded_as {
 			field_handler(field, FieldAttribute::EncodedAs { field: f, encoded_as })
 		} else if skip {
-			field_handler(field, FieldAttribute::Skip(f))
+			field_handler(field, FieldAttribute::Skip)
 		} else {
 			field_handler(field, FieldAttribute::None(f))
 		}
@@ -191,7 +191,7 @@ where
 					}
 				}
 			},
-			FieldAttribute::Skip(_) => quote! {
+			FieldAttribute::Skip => quote! {
 				let _ = #field;
 			},
 		},
@@ -236,7 +236,7 @@ where
 					))
 				}
 			},
-			FieldAttribute::Skip(_) => quote!(),
+			FieldAttribute::Skip => quote!(),
 		},
 		|recurse| {
 			quote! {

--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -309,7 +309,7 @@ pub fn compact_as_derive(input: proc_macro::TokenStream) -> proc_macro::TokenStr
 				(&field.ty, quote!(&self.#field_name), constructor)
 			},
 			Fields::Unnamed(ref fields) if utils::filter_skip_unnamed(fields).count() == 1 => {
-				let recurse = fields.unnamed.iter().enumerate().map(|(_, f)| {
+				let recurse = fields.unnamed.iter().map(|f| {
 					let val_or_default = val_or_default(f);
 					quote_spanned!(f.span()=> #val_or_default)
 				});

--- a/fuzzer/src/main.rs
+++ b/fuzzer/src/main.rs
@@ -47,8 +47,13 @@ pub enum MockEnum {
 	Empty,
 	Unit(u32),
 	UnitVec(Vec<u8>),
-	Complex { data: Vec<u32>, bitvec: BitVecWrapper<u8, Msb0>, string: String },
+	Complex {
+		data: Vec<u32>,
+		bitvec: BitVecWrapper<u8, Msb0>,
+		string: String,
+	},
 	Mock(MockStruct),
+	#[allow(clippy::type_complexity)]
 	NestedVec(Vec<Vec<Vec<Vec<Vec<Vec<Vec<Vec<Option<u8>>>>>>>>>),
 }
 

--- a/src/codec.rs
+++ b/src/codec.rs
@@ -1110,8 +1110,7 @@ where
 		}
 	}
 
-	input.descend_ref()?;
-	let vec = decode_vec_chunked(len, |decoded_vec, chunk_len| {
+	decode_vec_chunked(len, |decoded_vec, chunk_len| {
 		let decoded_vec_len = decoded_vec.len();
 		let decoded_vec_size = decoded_vec_len * mem::size_of::<T>();
 		unsafe {
@@ -1120,10 +1119,7 @@ where
 
 		let bytes_slice = decoded_vec.as_mut_byte_slice();
 		input.read(&mut bytes_slice[decoded_vec_size..])
-	})?;
-	input.ascend_ref();
-
-	Ok(vec)
+	})
 }
 
 fn decode_vec_from_items<T, I>(input: &mut I, len: usize) -> Result<Vec<T>, Error>

--- a/src/codec.rs
+++ b/src/codec.rs
@@ -1110,7 +1110,8 @@ where
 		}
 	}
 
-	decode_vec_chunked(len, |decoded_vec, chunk_len| {
+	input.descend_ref()?;
+	let vec = decode_vec_chunked(len, |decoded_vec, chunk_len| {
 		let decoded_vec_len = decoded_vec.len();
 		let decoded_vec_size = decoded_vec_len * mem::size_of::<T>();
 		unsafe {
@@ -1119,7 +1120,10 @@ where
 
 		let bytes_slice = decoded_vec.as_mut_byte_slice();
 		input.read(&mut bytes_slice[decoded_vec_size..])
-	})
+	})?;
+	input.ascend_ref();
+
+	Ok(vec)
 }
 
 fn decode_vec_from_items<T, I>(input: &mut I, len: usize) -> Result<Vec<T>, Error>

--- a/src/codec.rs
+++ b/src/codec.rs
@@ -1706,7 +1706,7 @@ mod tests {
 		assert_eq!(decoded, &b"hello"[..]);
 
 		// The `slice_ref` will panic if the `decoded` is not a subslice of `encoded`.
-		assert_eq!(encoded.slice_ref(&decoded), &b"hello"[..]);
+		assert_eq!(encoded.slice_ref(decoded), &b"hello"[..]);
 	}
 
 	fn test_encode_length<T: Encode + Decode + DecodeLength>(thing: &T, len: usize) {
@@ -1897,8 +1897,8 @@ mod tests {
 	fn boolean() {
 		assert_eq!(true.encode(), vec![1]);
 		assert_eq!(false.encode(), vec![0]);
-		assert_eq!(bool::decode(&mut &[1][..]).unwrap(), true);
-		assert_eq!(bool::decode(&mut &[0][..]).unwrap(), false);
+		assert!(bool::decode(&mut &[1][..]).unwrap());
+		assert!(!bool::decode(&mut &[0][..]).unwrap());
 	}
 
 	#[test]
@@ -1915,7 +1915,7 @@ mod tests {
 		let encoded = data.encode();
 
 		let decoded = Vec::<u32>::decode(&mut &encoded[..]).unwrap();
-		assert!(decoded.iter().all(|v| data.contains(&v)));
+		assert!(decoded.iter().all(|v| data.contains(v)));
 		assert_eq!(data.len(), decoded.len());
 
 		let encoded = decoded.encode();
@@ -1946,7 +1946,7 @@ mod tests {
 		let num_nanos = 37;
 
 		let duration = Duration::new(num_secs, num_nanos);
-		let expected = (num_secs, num_nanos as u32).encode();
+		let expected = (num_secs, num_nanos).encode();
 
 		assert_eq!(duration.encode(), expected);
 		assert_eq!(Duration::decode(&mut &expected[..]).unwrap(), duration);

--- a/src/codec.rs
+++ b/src/codec.rs
@@ -1071,7 +1071,7 @@ fn decode_vec_chunked<T, F>(len: usize, mut decode_chunk: F) -> Result<Vec<T>, E
 where
 	F: FnMut(&mut Vec<T>, usize) -> Result<(), Error>,
 {
-	debug_assert!(MAX_PREALLOCATION >= mem::size_of::<T>(), "Invalid precondition");
+	const { assert!(MAX_PREALLOCATION >= mem::size_of::<T>()) }
 	// we have to account for the fact that `mem::size_of::<T>` can be 0 for types like `()`
 	// for example.
 	let chunk_len = MAX_PREALLOCATION.checked_div(mem::size_of::<T>()).unwrap_or(usize::MAX);

--- a/src/compact.rs
+++ b/src/compact.rs
@@ -735,7 +735,7 @@ mod tests {
 			(u128::MAX, 17),
 		];
 		for &(n, l) in &tests {
-			let encoded = Compact(n as u128).encode();
+			let encoded = Compact(n).encode();
 			assert_eq!(encoded.len(), l);
 			assert_eq!(Compact::compact_len(&n), l);
 			assert_eq!(<Compact<u128>>::decode(&mut &encoded[..]).unwrap().0, n);
@@ -761,7 +761,7 @@ mod tests {
 			(u64::MAX, 9),
 		];
 		for &(n, l) in &tests {
-			let encoded = Compact(n as u64).encode();
+			let encoded = Compact(n).encode();
 			assert_eq!(encoded.len(), l);
 			assert_eq!(Compact::compact_len(&n), l);
 			assert_eq!(<Compact<u64>>::decode(&mut &encoded[..]).unwrap().0, n);
@@ -781,7 +781,7 @@ mod tests {
 			(u32::MAX, 5),
 		];
 		for &(n, l) in &tests {
-			let encoded = Compact(n as u32).encode();
+			let encoded = Compact(n).encode();
 			assert_eq!(encoded.len(), l);
 			assert_eq!(Compact::compact_len(&n), l);
 			assert_eq!(<Compact<u32>>::decode(&mut &encoded[..]).unwrap().0, n);
@@ -792,7 +792,7 @@ mod tests {
 	fn compact_16_encoding_works() {
 		let tests = [(0u16, 1usize), (63, 1), (64, 2), (16383, 2), (16384, 4), (65535, 4)];
 		for &(n, l) in &tests {
-			let encoded = Compact(n as u16).encode();
+			let encoded = Compact(n).encode();
 			assert_eq!(encoded.len(), l);
 			assert_eq!(Compact::compact_len(&n), l);
 			assert_eq!(<Compact<u16>>::decode(&mut &encoded[..]).unwrap().0, n);
@@ -804,7 +804,7 @@ mod tests {
 	fn compact_8_encoding_works() {
 		let tests = [(0u8, 1usize), (63, 1), (64, 2), (255, 2)];
 		for &(n, l) in &tests {
-			let encoded = Compact(n as u8).encode();
+			let encoded = Compact(n).encode();
 			assert_eq!(encoded.len(), l);
 			assert_eq!(Compact::compact_len(&n), l);
 			assert_eq!(<Compact<u8>>::decode(&mut &encoded[..]).unwrap().0, n);
@@ -840,7 +840,7 @@ mod tests {
 		];
 		for &(n, s) in &tests {
 			// Verify u64 encoding
-			let encoded = Compact(n as u64).encode();
+			let encoded = Compact(n).encode();
 			assert_eq!(hexify(&encoded), s);
 			assert_eq!(<Compact<u64>>::decode(&mut &encoded[..]).unwrap().0, n);
 
@@ -849,19 +849,19 @@ mod tests {
 				assert_eq!(<Compact<u32>>::decode(&mut &encoded[..]).unwrap().0, n as u32);
 				let encoded = Compact(n as u32).encode();
 				assert_eq!(hexify(&encoded), s);
-				assert_eq!(<Compact<u64>>::decode(&mut &encoded[..]).unwrap().0, n as u64);
+				assert_eq!(<Compact<u64>>::decode(&mut &encoded[..]).unwrap().0, n);
 			}
 			if n <= u16::MAX as u64 {
 				assert_eq!(<Compact<u16>>::decode(&mut &encoded[..]).unwrap().0, n as u16);
 				let encoded = Compact(n as u16).encode();
 				assert_eq!(hexify(&encoded), s);
-				assert_eq!(<Compact<u64>>::decode(&mut &encoded[..]).unwrap().0, n as u64);
+				assert_eq!(<Compact<u64>>::decode(&mut &encoded[..]).unwrap().0, n);
 			}
 			if n <= u8::MAX as u64 {
 				assert_eq!(<Compact<u8>>::decode(&mut &encoded[..]).unwrap().0, n as u8);
 				let encoded = Compact(n as u8).encode();
 				assert_eq!(hexify(&encoded), s);
-				assert_eq!(<Compact<u64>>::decode(&mut &encoded[..]).unwrap().0, n as u64);
+				assert_eq!(<Compact<u64>>::decode(&mut &encoded[..]).unwrap().0, n);
 			}
 		}
 	}

--- a/src/depth_limit.rs
+++ b/src/depth_limit.rs
@@ -94,7 +94,7 @@ mod tests {
 		let nested: NestedVec = vec![vec![vec![vec![1]]]];
 		let encoded = nested.encode();
 
-		let decoded = NestedVec::decode_with_depth_limit(3, &mut encoded.as_slice()).unwrap();
+		let decoded = NestedVec::decode_with_depth_limit(4, &mut encoded.as_slice()).unwrap();
 		assert_eq!(decoded, nested);
 		assert!(NestedVec::decode_with_depth_limit(2, &mut encoded.as_slice()).is_err());
 	}
@@ -117,12 +117,12 @@ mod tests {
 		let nested: NestedVec = vec![vec![vec![vec![1]]]];
 		let mut encoded = NestedVec::encode(&nested);
 
-		let decoded = NestedVec::decode_all_with_depth_limit(3, &mut encoded.as_slice()).unwrap();
+		let decoded = NestedVec::decode_all_with_depth_limit(4, &mut encoded.as_slice()).unwrap();
 		assert_eq!(decoded, nested);
 
 		encoded.extend(&[1, 2, 3, 4, 5, 6]);
 		assert_eq!(
-			NestedVec::decode_all_with_depth_limit(3, &mut encoded.as_slice())
+			NestedVec::decode_all_with_depth_limit(4, &mut encoded.as_slice())
 				.unwrap_err()
 				.to_string(),
 			"Input buffer has still data left after decoding!",

--- a/src/depth_limit.rs
+++ b/src/depth_limit.rs
@@ -94,7 +94,7 @@ mod tests {
 		let nested: NestedVec = vec![vec![vec![vec![1]]]];
 		let encoded = nested.encode();
 
-		let decoded = NestedVec::decode_with_depth_limit(4, &mut encoded.as_slice()).unwrap();
+		let decoded = NestedVec::decode_with_depth_limit(3, &mut encoded.as_slice()).unwrap();
 		assert_eq!(decoded, nested);
 		assert!(NestedVec::decode_with_depth_limit(2, &mut encoded.as_slice()).is_err());
 	}
@@ -117,12 +117,12 @@ mod tests {
 		let nested: NestedVec = vec![vec![vec![vec![1]]]];
 		let mut encoded = NestedVec::encode(&nested);
 
-		let decoded = NestedVec::decode_all_with_depth_limit(4, &mut encoded.as_slice()).unwrap();
+		let decoded = NestedVec::decode_all_with_depth_limit(3, &mut encoded.as_slice()).unwrap();
 		assert_eq!(decoded, nested);
 
 		encoded.extend(&[1, 2, 3, 4, 5, 6]);
 		assert_eq!(
-			NestedVec::decode_all_with_depth_limit(4, &mut encoded.as_slice())
+			NestedVec::decode_all_with_depth_limit(3, &mut encoded.as_slice())
 				.unwrap_err()
 				.to_string(),
 			"Input buffer has still data left after decoding!",

--- a/src/encode_append.rs
+++ b/src/encode_append.rs
@@ -160,7 +160,7 @@ mod tests {
 	#[test]
 	fn vec_encode_append_multiple_items_works() {
 		let encoded = (0..TEST_VALUE).fold(Vec::new(), |encoded, v| {
-			<Vec<u32> as EncodeAppend>::append_or_new(encoded, &[v, v, v, v]).unwrap()
+			<Vec<u32> as EncodeAppend>::append_or_new(encoded, [v, v, v, v]).unwrap()
 		});
 
 		let decoded = Vec::<u32>::decode(&mut &encoded[..]).unwrap();
@@ -184,7 +184,7 @@ mod tests {
 	#[test]
 	fn vecdeque_encode_append_multiple_items_works() {
 		let encoded = (0..TEST_VALUE).fold(Vec::new(), |encoded, v| {
-			<VecDeque<u32> as EncodeAppend>::append_or_new(encoded, &[v, v, v, v]).unwrap()
+			<VecDeque<u32> as EncodeAppend>::append_or_new(encoded, [v, v, v, v]).unwrap()
 		});
 
 		let decoded = VecDeque::<u32>::decode(&mut &encoded[..]).unwrap();
@@ -228,7 +228,7 @@ mod tests {
 	#[test]
 	fn vec_encode_like_append_works() {
 		let encoded = (0..TEST_VALUE).fold(Vec::new(), |encoded, v| {
-			<Vec<u32> as EncodeAppend>::append_or_new(encoded, std::iter::once(Box::new(v as u32)))
+			<Vec<u32> as EncodeAppend>::append_or_new(encoded, std::iter::once(Box::new(v)))
 				.unwrap()
 		});
 

--- a/src/encode_like.rs
+++ b/src/encode_like.rs
@@ -122,7 +122,7 @@ mod tests {
 	#[test]
 	fn vec_and_slice_are_working() {
 		let slice: &[u8] = &[1, 2, 3, 4];
-		let data: Vec<u8> = slice.iter().copied().collect();
+		let data: Vec<u8> = slice.to_vec();
 
 		let data_encoded = data.encode();
 		let slice_encoded = ComplexStuff::<Vec<u8>>::complex_method(&slice);

--- a/tests/chain-error.rs
+++ b/tests/chain-error.rs
@@ -24,17 +24,17 @@ struct StructNamed {
 }
 
 #[derive(DeriveDecode, Debug)]
-struct StructUnnamed(u16);
+struct StructUnnamed(#[allow(dead_code)] u16);
 
 #[derive(DeriveDecode, Debug)]
 enum E {
 	VariantNamed { _foo: u16 },
-	VariantUnnamed(u16),
+	VariantUnnamed(#[allow(dead_code)] u16),
 }
 
 #[test]
 fn full_error_struct_named() {
-	let encoded = vec![0];
+	let encoded = [0];
 	let err = r#"Could not decode `Wrapper.0`:
 	Could not decode `StructNamed::_foo`:
 		Not enough data to fill buffer
@@ -48,7 +48,7 @@ fn full_error_struct_named() {
 
 #[test]
 fn full_error_struct_unnamed() {
-	let encoded = vec![0];
+	let encoded = [0];
 	let err = r#"Could not decode `Wrapper.0`:
 	Could not decode `StructUnnamed.0`:
 		Not enough data to fill buffer
@@ -62,7 +62,7 @@ fn full_error_struct_unnamed() {
 
 #[test]
 fn full_error_enum_unknown_variant() {
-	let encoded = vec![2];
+	let encoded = [2];
 	let err = r#"Could not decode `E`, variant doesn't exist"#;
 
 	assert_eq!(E::decode(&mut &encoded[..]).unwrap_err().to_string(), String::from(err),);
@@ -70,7 +70,7 @@ fn full_error_enum_unknown_variant() {
 
 #[test]
 fn full_error_enum_named_field() {
-	let encoded = vec![0, 0];
+	let encoded = [0, 0];
 	let err = r#"Could not decode `E::VariantNamed::_foo`:
 	Not enough data to fill buffer
 "#;
@@ -80,7 +80,7 @@ fn full_error_enum_named_field() {
 
 #[test]
 fn full_error_enum_unnamed_field() {
-	let encoded = vec![1, 0];
+	let encoded = [1, 0];
 	let err = r#"Could not decode `E::VariantUnnamed.0`:
 	Not enough data to fill buffer
 "#;

--- a/tests/max_encoded_len_ui/crate_str.stderr
+++ b/tests/max_encoded_len_ui/crate_str.stderr
@@ -4,25 +4,51 @@ error: Invalid attribute: only `#[codec(dumb_trait_bound)]`, `#[codec(crate = pa
 4 | #[codec(crate = "parity_scale_codec")]
   |         ^^^^^
 
-error[E0277]: the trait bound `Example: WrapperTypeEncode` is not satisfied
+error[E0277]: the trait bound `Example: Encode` is not satisfied
  --> tests/max_encoded_len_ui/crate_str.rs:5:8
   |
 5 | struct Example;
-  |        ^^^^^^^ the trait `WrapperTypeEncode` is not implemented for `Example`
+  |        ^^^^^^^ the trait `WrapperTypeEncode` is not implemented for `Example`, which is required by `Example: Encode`
   |
-  = help: the following other types implement trait `WrapperTypeEncode`:
-            Box<T>
-            Cow<'a, T>
-            parity_scale_codec::Ref<'a, T, U>
-            Rc<T>
-            Arc<T>
-            Vec<T>
-            String
-            &T
-            &mut T
+  = help: the following other types implement trait `Encode`:
+            ()
+            (A0, B0, C0, D0, E0, F0, G0, H0, I0, J0, K0, L0, M0, N0, O0, P0, Q0, R0)
+            (B0, C0, D0, E0, F0, G0, H0, I0, J0, K0, L0, M0, N0, O0, P0, Q0, R0)
+            (C0, D0, E0, F0, G0, H0, I0, J0, K0, L0, M0, N0, O0, P0, Q0, R0)
+            (D0, E0, F0, G0, H0, I0, J0, K0, L0, M0, N0, O0, P0, Q0, R0)
+            (E0, F0, G0, H0, I0, J0, K0, L0, M0, N0, O0, P0, Q0, R0)
+            (F0, G0, H0, I0, J0, K0, L0, M0, N0, O0, P0, Q0, R0)
+            (G0, H0, I0, J0, K0, L0, M0, N0, O0, P0, Q0, R0)
+          and $N others
   = note: required for `Example` to implement `Encode`
 note: required by a bound in `MaxEncodedLen`
  --> src/max_encoded_len.rs
   |
   | pub trait MaxEncodedLen: Encode {
   |                          ^^^^^^ required by this bound in `MaxEncodedLen`
+
+error[E0277]: the trait bound `Example: Encode` is not satisfied
+ --> tests/max_encoded_len_ui/crate_str.rs:8:10
+  |
+8 |     let _ = Example::max_encoded_len();
+  |             ^^^^^^^ the trait `WrapperTypeEncode` is not implemented for `Example`, which is required by `Example: Encode`
+  |
+  = help: the following other types implement trait `Encode`:
+            ()
+            (A0, B0, C0, D0, E0, F0, G0, H0, I0, J0, K0, L0, M0, N0, O0, P0, Q0, R0)
+            (B0, C0, D0, E0, F0, G0, H0, I0, J0, K0, L0, M0, N0, O0, P0, Q0, R0)
+            (C0, D0, E0, F0, G0, H0, I0, J0, K0, L0, M0, N0, O0, P0, Q0, R0)
+            (D0, E0, F0, G0, H0, I0, J0, K0, L0, M0, N0, O0, P0, Q0, R0)
+            (E0, F0, G0, H0, I0, J0, K0, L0, M0, N0, O0, P0, Q0, R0)
+            (F0, G0, H0, I0, J0, K0, L0, M0, N0, O0, P0, Q0, R0)
+            (G0, H0, I0, J0, K0, L0, M0, N0, O0, P0, Q0, R0)
+          and $N others
+  = note: required for `Example` to implement `Encode`
+note: required by a bound in `max_encoded_len`
+ --> src/max_encoded_len.rs
+  |
+  | pub trait MaxEncodedLen: Encode {
+  |                          ^^^^^^ required by this bound in `MaxEncodedLen::max_encoded_len`
+  |     /// Upper bound, in bytes, of the maximum encoded size of this item.
+  |     fn max_encoded_len() -> usize;
+  |        --------------- required by a bound in this associated function

--- a/tests/max_encoded_len_ui/incomplete_attr.stderr
+++ b/tests/max_encoded_len_ui/incomplete_attr.stderr
@@ -4,25 +4,51 @@ error: Invalid attribute: only `#[codec(dumb_trait_bound)]`, `#[codec(crate = pa
 4 | #[codec(crate)]
   |         ^^^^^
 
-error[E0277]: the trait bound `Example: WrapperTypeEncode` is not satisfied
+error[E0277]: the trait bound `Example: Encode` is not satisfied
  --> tests/max_encoded_len_ui/incomplete_attr.rs:5:8
   |
 5 | struct Example;
-  |        ^^^^^^^ the trait `WrapperTypeEncode` is not implemented for `Example`
+  |        ^^^^^^^ the trait `WrapperTypeEncode` is not implemented for `Example`, which is required by `Example: Encode`
   |
-  = help: the following other types implement trait `WrapperTypeEncode`:
-            Box<T>
-            Cow<'a, T>
-            parity_scale_codec::Ref<'a, T, U>
-            Rc<T>
-            Arc<T>
-            Vec<T>
-            String
-            &T
-            &mut T
+  = help: the following other types implement trait `Encode`:
+            ()
+            (A0, B0, C0, D0, E0, F0, G0, H0, I0, J0, K0, L0, M0, N0, O0, P0, Q0, R0)
+            (B0, C0, D0, E0, F0, G0, H0, I0, J0, K0, L0, M0, N0, O0, P0, Q0, R0)
+            (C0, D0, E0, F0, G0, H0, I0, J0, K0, L0, M0, N0, O0, P0, Q0, R0)
+            (D0, E0, F0, G0, H0, I0, J0, K0, L0, M0, N0, O0, P0, Q0, R0)
+            (E0, F0, G0, H0, I0, J0, K0, L0, M0, N0, O0, P0, Q0, R0)
+            (F0, G0, H0, I0, J0, K0, L0, M0, N0, O0, P0, Q0, R0)
+            (G0, H0, I0, J0, K0, L0, M0, N0, O0, P0, Q0, R0)
+          and $N others
   = note: required for `Example` to implement `Encode`
 note: required by a bound in `MaxEncodedLen`
  --> src/max_encoded_len.rs
   |
   | pub trait MaxEncodedLen: Encode {
   |                          ^^^^^^ required by this bound in `MaxEncodedLen`
+
+error[E0277]: the trait bound `Example: Encode` is not satisfied
+ --> tests/max_encoded_len_ui/incomplete_attr.rs:8:10
+  |
+8 |     let _ = Example::max_encoded_len();
+  |             ^^^^^^^ the trait `WrapperTypeEncode` is not implemented for `Example`, which is required by `Example: Encode`
+  |
+  = help: the following other types implement trait `Encode`:
+            ()
+            (A0, B0, C0, D0, E0, F0, G0, H0, I0, J0, K0, L0, M0, N0, O0, P0, Q0, R0)
+            (B0, C0, D0, E0, F0, G0, H0, I0, J0, K0, L0, M0, N0, O0, P0, Q0, R0)
+            (C0, D0, E0, F0, G0, H0, I0, J0, K0, L0, M0, N0, O0, P0, Q0, R0)
+            (D0, E0, F0, G0, H0, I0, J0, K0, L0, M0, N0, O0, P0, Q0, R0)
+            (E0, F0, G0, H0, I0, J0, K0, L0, M0, N0, O0, P0, Q0, R0)
+            (F0, G0, H0, I0, J0, K0, L0, M0, N0, O0, P0, Q0, R0)
+            (G0, H0, I0, J0, K0, L0, M0, N0, O0, P0, Q0, R0)
+          and $N others
+  = note: required for `Example` to implement `Encode`
+note: required by a bound in `max_encoded_len`
+ --> src/max_encoded_len.rs
+  |
+  | pub trait MaxEncodedLen: Encode {
+  |                          ^^^^^^ required by this bound in `MaxEncodedLen::max_encoded_len`
+  |     /// Upper bound, in bytes, of the maximum encoded size of this item.
+  |     fn max_encoded_len() -> usize;
+  |        --------------- required by a bound in this associated function

--- a/tests/max_encoded_len_ui/missing_crate_specifier.stderr
+++ b/tests/max_encoded_len_ui/missing_crate_specifier.stderr
@@ -4,25 +4,51 @@ error: Invalid attribute: only `#[codec(dumb_trait_bound)]`, `#[codec(crate = pa
 4 | #[codec(parity_scale_codec)]
   |         ^^^^^^^^^^^^^^^^^^
 
-error[E0277]: the trait bound `Example: WrapperTypeEncode` is not satisfied
+error[E0277]: the trait bound `Example: Encode` is not satisfied
  --> tests/max_encoded_len_ui/missing_crate_specifier.rs:5:8
   |
 5 | struct Example;
-  |        ^^^^^^^ the trait `WrapperTypeEncode` is not implemented for `Example`
+  |        ^^^^^^^ the trait `WrapperTypeEncode` is not implemented for `Example`, which is required by `Example: Encode`
   |
-  = help: the following other types implement trait `WrapperTypeEncode`:
-            Box<T>
-            Cow<'a, T>
-            parity_scale_codec::Ref<'a, T, U>
-            Rc<T>
-            Arc<T>
-            Vec<T>
-            String
-            &T
-            &mut T
+  = help: the following other types implement trait `Encode`:
+            ()
+            (A0, B0, C0, D0, E0, F0, G0, H0, I0, J0, K0, L0, M0, N0, O0, P0, Q0, R0)
+            (B0, C0, D0, E0, F0, G0, H0, I0, J0, K0, L0, M0, N0, O0, P0, Q0, R0)
+            (C0, D0, E0, F0, G0, H0, I0, J0, K0, L0, M0, N0, O0, P0, Q0, R0)
+            (D0, E0, F0, G0, H0, I0, J0, K0, L0, M0, N0, O0, P0, Q0, R0)
+            (E0, F0, G0, H0, I0, J0, K0, L0, M0, N0, O0, P0, Q0, R0)
+            (F0, G0, H0, I0, J0, K0, L0, M0, N0, O0, P0, Q0, R0)
+            (G0, H0, I0, J0, K0, L0, M0, N0, O0, P0, Q0, R0)
+          and $N others
   = note: required for `Example` to implement `Encode`
 note: required by a bound in `MaxEncodedLen`
  --> src/max_encoded_len.rs
   |
   | pub trait MaxEncodedLen: Encode {
   |                          ^^^^^^ required by this bound in `MaxEncodedLen`
+
+error[E0277]: the trait bound `Example: Encode` is not satisfied
+ --> tests/max_encoded_len_ui/missing_crate_specifier.rs:8:10
+  |
+8 |     let _ = Example::max_encoded_len();
+  |             ^^^^^^^ the trait `WrapperTypeEncode` is not implemented for `Example`, which is required by `Example: Encode`
+  |
+  = help: the following other types implement trait `Encode`:
+            ()
+            (A0, B0, C0, D0, E0, F0, G0, H0, I0, J0, K0, L0, M0, N0, O0, P0, Q0, R0)
+            (B0, C0, D0, E0, F0, G0, H0, I0, J0, K0, L0, M0, N0, O0, P0, Q0, R0)
+            (C0, D0, E0, F0, G0, H0, I0, J0, K0, L0, M0, N0, O0, P0, Q0, R0)
+            (D0, E0, F0, G0, H0, I0, J0, K0, L0, M0, N0, O0, P0, Q0, R0)
+            (E0, F0, G0, H0, I0, J0, K0, L0, M0, N0, O0, P0, Q0, R0)
+            (F0, G0, H0, I0, J0, K0, L0, M0, N0, O0, P0, Q0, R0)
+            (G0, H0, I0, J0, K0, L0, M0, N0, O0, P0, Q0, R0)
+          and $N others
+  = note: required for `Example` to implement `Encode`
+note: required by a bound in `max_encoded_len`
+ --> src/max_encoded_len.rs
+  |
+  | pub trait MaxEncodedLen: Encode {
+  |                          ^^^^^^ required by this bound in `MaxEncodedLen::max_encoded_len`
+  |     /// Upper bound, in bytes, of the maximum encoded size of this item.
+  |     fn max_encoded_len() -> usize;
+  |        --------------- required by a bound in this associated function

--- a/tests/max_encoded_len_ui/not_encode.stderr
+++ b/tests/max_encoded_len_ui/not_encode.stderr
@@ -1,19 +1,19 @@
-error[E0277]: the trait bound `NotEncode: WrapperTypeEncode` is not satisfied
+error[E0277]: the trait bound `NotEncode: Encode` is not satisfied
  --> tests/max_encoded_len_ui/not_encode.rs:4:8
   |
 4 | struct NotEncode;
-  |        ^^^^^^^^^ the trait `WrapperTypeEncode` is not implemented for `NotEncode`
+  |        ^^^^^^^^^ the trait `WrapperTypeEncode` is not implemented for `NotEncode`, which is required by `NotEncode: Encode`
   |
-  = help: the following other types implement trait `WrapperTypeEncode`:
-            Box<T>
-            Cow<'a, T>
-            parity_scale_codec::Ref<'a, T, U>
-            Rc<T>
-            Arc<T>
-            Vec<T>
-            String
-            &T
-            &mut T
+  = help: the following other types implement trait `Encode`:
+            ()
+            (A0, B0, C0, D0, E0, F0, G0, H0, I0, J0, K0, L0, M0, N0, O0, P0, Q0, R0)
+            (B0, C0, D0, E0, F0, G0, H0, I0, J0, K0, L0, M0, N0, O0, P0, Q0, R0)
+            (C0, D0, E0, F0, G0, H0, I0, J0, K0, L0, M0, N0, O0, P0, Q0, R0)
+            (D0, E0, F0, G0, H0, I0, J0, K0, L0, M0, N0, O0, P0, Q0, R0)
+            (E0, F0, G0, H0, I0, J0, K0, L0, M0, N0, O0, P0, Q0, R0)
+            (F0, G0, H0, I0, J0, K0, L0, M0, N0, O0, P0, Q0, R0)
+            (G0, H0, I0, J0, K0, L0, M0, N0, O0, P0, Q0, R0)
+          and $N others
   = note: required for `NotEncode` to implement `Encode`
 note: required by a bound in `MaxEncodedLen`
  --> src/max_encoded_len.rs

--- a/tests/max_encoded_len_ui/not_mel.stderr
+++ b/tests/max_encoded_len_ui/not_mel.stderr
@@ -5,10 +5,7 @@ error[E0599]: the function or associated item `max_encoded_len` exists for struc
    | ------------- doesn't satisfy `NotMel: MaxEncodedLen`
 ...
 7  | struct Generic<T> {
-   | -----------------
-   | |
-   | function or associated item `max_encoded_len` not found for this struct
-   | doesn't satisfy `Generic<NotMel>: MaxEncodedLen`
+   | ----------------- function or associated item `max_encoded_len` not found for this struct because it doesn't satisfy `Generic<NotMel>: MaxEncodedLen`
 ...
 12 |     let _ = Generic::<NotMel>::max_encoded_len();
    |                                ^^^^^^^^^^^^^^^ function or associated item cannot be called on `Generic<NotMel>` due to unsatisfied trait bounds

--- a/tests/max_encoded_len_ui/unsupported_variant.stderr
+++ b/tests/max_encoded_len_ui/unsupported_variant.stderr
@@ -5,12 +5,12 @@ error[E0277]: the trait bound `NotMel: MaxEncodedLen` is not satisfied
   |            ^^^^^^ the trait `MaxEncodedLen` is not implemented for `NotMel`
   |
   = help: the following other types implement trait `MaxEncodedLen`:
-            bool
-            i8
-            i16
-            i32
-            i64
-            i128
-            u8
-            u16
+            ()
+            (TupleElement0, TupleElement1)
+            (TupleElement0, TupleElement1, TupleElement2)
+            (TupleElement0, TupleElement1, TupleElement2, TupleElement3)
+            (TupleElement0, TupleElement1, TupleElement2, TupleElement3, TupleElement4)
+            (TupleElement0, TupleElement1, TupleElement2, TupleElement3, TupleElement4, TupleElement5)
+            (TupleElement0, TupleElement1, TupleElement2, TupleElement3, TupleElement4, TupleElement5, TupleElement6)
+            (TupleElement0, TupleElement1, TupleElement2, TupleElement3, TupleElement4, TupleElement5, TupleElement6, TupleElement7)
           and $N others

--- a/tests/mod.rs
+++ b/tests/mod.rs
@@ -234,11 +234,11 @@ const U64_TEST_COMPACT_VALUES: &[(u64, usize)] = &[
 	(16384, 4),
 	(1073741823, 4),
 	(1073741824, 5),
-	(1 << 32 - 1, 5),
+	(1 << (32 - 1), 5),
 	(1 << 32, 6),
 	(1 << 40, 7),
 	(1 << 48, 8),
-	(1 << 56 - 1, 8),
+	(1 << (56 - 1), 8),
 	(1 << 56, 9),
 	(u64::MAX, 9),
 ];
@@ -251,11 +251,11 @@ const U64_TEST_COMPACT_VALUES_FOR_ENUM: &[(u64, usize)] = &[
 	(16384, 5),
 	(1073741823, 5),
 	(1073741824, 6),
-	(1 << 32 - 1, 6),
+	(1 << (32 - 1), 6),
 	(1 << 32, 7),
 	(1 << 40, 8),
 	(1 << 48, 9),
-	(1 << 56 - 1, 9),
+	(1 << (56 - 1), 9),
 	(1 << 56, 10),
 	(u64::MAX, 10),
 ];
@@ -669,7 +669,7 @@ fn decoding_a_huge_boxed_newtype_array_does_not_overflow_the_stack() {
 	struct HugeArrayNewtype([u8; 100 * 1024 * 1024]);
 
 	#[derive(DeriveDecode)]
-	struct HugeArrayNewtypeBox(Box<HugeArrayNewtype>);
+	struct HugeArrayNewtypeBox(#[allow(dead_code)] Box<HugeArrayNewtype>);
 
 	let data = &[];
 	assert!(HugeArrayNewtypeBox::decode(&mut data.as_slice()).is_err());
@@ -714,7 +714,7 @@ fn zero_sized_types_are_properly_decoded_in_a_transparent_boxed_struct() {
 	}
 
 	#[derive(DeriveDecode)]
-	struct NewtypeWithZstBox(Box<NewtypeWithZst>);
+	struct NewtypeWithZstBox(#[allow(dead_code)] Box<NewtypeWithZst>);
 
 	impl Decode for ConsumeByte {
 		fn decode<I: parity_scale_codec::Input>(input: &mut I) -> Result<Self, Error> {
@@ -761,11 +761,11 @@ fn decoding_an_array_of_boxed_zero_sized_types_works() {
 #[test]
 fn incomplete_decoding_of_an_array_drops_partially_read_elements_if_reading_fails() {
 	thread_local! {
-		pub static COUNTER: core::cell::Cell<usize> = core::cell::Cell::new(0);
+		pub static COUNTER: core::cell::Cell<usize> = const { core::cell::Cell::new(0) };
 	}
 
 	#[derive(DeriveDecode)]
-	struct Foobar(u8);
+	struct Foobar(#[allow(dead_code)] u8);
 
 	impl Drop for Foobar {
 		fn drop(&mut self) {
@@ -786,10 +786,10 @@ fn incomplete_decoding_of_an_array_drops_partially_read_elements_if_reading_fail
 #[test]
 fn incomplete_decoding_of_an_array_drops_partially_read_elements_if_reading_panics() {
 	thread_local! {
-		pub static COUNTER: core::cell::Cell<usize> = core::cell::Cell::new(0);
+		pub static COUNTER: core::cell::Cell<usize> = const { core::cell::Cell::new(0) };
 	}
 
-	struct Foobar(u8);
+	struct Foobar(#[allow(dead_code)] u8);
 
 	impl Decode for Foobar {
 		fn decode<I: parity_scale_codec::Input>(input: &mut I) -> Result<Self, Error> {
@@ -825,6 +825,7 @@ fn deserializing_of_big_recursively_nested_enum_works() {
 	struct Data([u8; 1472]);
 
 	#[derive(PartialEq, Eq, DeriveDecode, DeriveEncode)]
+	#[allow(clippy::large_enum_variant)]
 	enum Enum {
 		Nested(Vec<Enum>),
 		Data(Data),

--- a/tests/mod.rs
+++ b/tests/mod.rs
@@ -351,6 +351,7 @@ fn associated_type_bounds() {
 }
 
 #[test]
+#[allow(non_local_definitions)]
 fn generic_bound_encoded_as() {
 	// This struct does not impl Codec nor HasCompact
 	struct StructEncodeAsRef;

--- a/tests/type_inference.rs
+++ b/tests/type_inference.rs
@@ -28,4 +28,4 @@ pub enum A<T: Trait> {
 }
 
 #[derive(DeriveDecode)]
-pub struct B<T: Trait>((T::AccountId, T::AccountId), Vec<(T::Value, T::Value)>);
+pub struct B<T: Trait>((T::AccountId, T::AccountId), #[allow(dead_code)] Vec<(T::Value, T::Value)>);


### PR DESCRIPTION
Addressing the code review comments for https://github.com/paritytech/parity-scale-codec/pull/605

Also calling `descend_ref()` and `ascend_ref()` for `read_vec_from_u8s()`. Not sure if it was desired, or it was just a miss. To me it seems like they should be called. I hope I understood correctly. 

**Please note that this PR also updates the rust toolchain used by the CI from 1.73.0 to version 1.79.0.** We need this in order to use `inline const`.