### PR TITLE
Fix `MaxEncodedLen` derive macro for enum with skipped variant

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,3 @@
-
 # Parity SCALE Codec
 
 Rust implementation of the SCALE (Simple Concatenated Aggregate Little-Endian) data format

--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+
 # Parity SCALE Codec
 
 Rust implementation of the SCALE (Simple Concatenated Aggregate Little-Endian) data format

--- a/derive/src/max_encoded_len.rs
+++ b/derive/src/max_encoded_len.rs
@@ -119,12 +119,14 @@ fn data_length_expr(data: &Data, crate_path: &syn::Path) -> proc_macro2::TokenSt
 			//
 			// Each variant expression's sum is computed the way an equivalent struct's would be.
 
-			let expansion = data.variants.iter().map(|variant| {
-				let variant_expression = fields_length_expr(&variant.fields, crate_path);
-				quote! {
-					.max(#variant_expression)
-				}
-			});
+			let expansion = data.variants.iter()
+				.filter(|variant| !should_skip(&variant.attrs))
+				.map(|variant| {
+					let variant_expression = fields_length_expr(&variant.fields, crate_path);
+					quote! {
+						.max(#variant_expression)
+					}
+				});
 
 			quote! {
 				0_usize #( #expansion )* .saturating_add(1)

--- a/derive/src/max_encoded_len.rs
+++ b/derive/src/max_encoded_len.rs
@@ -119,14 +119,15 @@ fn data_length_expr(data: &Data, crate_path: &syn::Path) -> proc_macro2::TokenSt
 			//
 			// Each variant expression's sum is computed the way an equivalent struct's would be.
 
-			let expansion = data.variants.iter()
-				.filter(|variant| !should_skip(&variant.attrs))
-				.map(|variant| {
-					let variant_expression = fields_length_expr(&variant.fields, crate_path);
-					quote! {
-						.max(#variant_expression)
-					}
-				});
+			let expansion =
+				data.variants.iter().filter(|variant| !should_skip(&variant.attrs)).map(
+					|variant| {
+						let variant_expression = fields_length_expr(&variant.fields, crate_path);
+						quote! {
+							.max(#variant_expression)
+						}
+					},
+				);
 
 			quote! {
 				0_usize #( #expansion )* .saturating_add(1)

--- a/tests/max_encoded_len.rs
+++ b/tests/max_encoded_len.rs
@@ -246,3 +246,37 @@ fn skip_type_params() {
 
 	assert_eq!(SomeData::<u32, SomeStruct>::max_encoded_len(), 4);
 }
+
+#[test]
+fn skip_enum_struct_test() {
+	#[derive(Default)]
+	struct NoCodecType;
+
+	struct NoCodecNoDefaultType;
+
+	#[derive(Encode, Decode, MaxEncodedLen)]
+	enum Enum<T = NoCodecType, S = NoCodecNoDefaultType> {
+		#[codec(skip)]
+		A(S),
+		B {
+			#[codec(skip)]
+			_b1: T,
+			b2: u32,
+		},
+		C(#[codec(skip)] T, u32),
+	}
+
+	#[derive(Encode, Decode, MaxEncodedLen)]
+	struct StructNamed<T = NoCodecType> {
+		#[codec(skip)]
+		a: T,
+		b: u32,
+	}
+
+	#[derive(Encode, Decode, MaxEncodedLen)]
+	struct StructUnnamed<T = NoCodecType>(#[codec(skip)] T, u32);
+
+	assert_eq!(Enum::<NoCodecType, NoCodecNoDefaultType>::max_encoded_len(), 5);
+	assert_eq!(StructNamed::<NoCodecType>::max_encoded_len(), 4);
+	assert_eq!(StructUnnamed::<NoCodecType>::max_encoded_len(), 4);
+}

--- a/tests/max_encoded_len.rs
+++ b/tests/max_encoded_len.rs
@@ -279,4 +279,8 @@ fn skip_enum_struct_test() {
 	assert_eq!(Enum::<NoCodecType, NoCodecNoDefaultType>::max_encoded_len(), 5);
 	assert_eq!(StructNamed::<NoCodecType>::max_encoded_len(), 4);
 	assert_eq!(StructUnnamed::<NoCodecType>::max_encoded_len(), 4);
+
+	// Use the fields to avoid unused warnings.
+	let _ = Enum::<NoCodecType, NoCodecNoDefaultType>::A(NoCodecNoDefaultType);
+	let _ = StructNamed::<NoCodecType> { a: NoCodecType, b: 0 }.a;
 }


### PR DESCRIPTION
right now `MaxEncodedLen` do not differentiate betwen skipped variants and normal variants on enum.

Now skipped variant are correctly skipped.

(also thinking again, it is not so much consistent to have skipped variant being not decodable and skipped fields being decoded to default value. Maybe it should be 2 different names)