### PR TITLE
Introduce `CountedInput`. a wrapper which counts the number of bytes successfully read

### DIFF
--- a/src/counted_input.rs
+++ b/src/counted_input.rs
@@ -137,7 +137,7 @@ mod test {
 
 		counted_input.counter = max_exact_count;
 
-		assert_eq!(counted_input.count(), max_exact_count));
+		assert_eq!(counted_input.count(), max_exact_count);
 
 		counted_input.read(&mut [0u8; 2][..]).unwrap();
 

--- a/src/counted_input.rs
+++ b/src/counted_input.rs
@@ -16,7 +16,7 @@
 #[derive(Eq, PartialEq, Clone, Debug)]
 pub enum Count {
 	/// The counter has an exact value.
-	Exact(u64),
+	Exact(u32),
 	/// The counter has reached its maximum countable value.
 	MaxCountReached,
 }
@@ -25,10 +25,10 @@ pub enum Count {
 ///
 /// If inner `Input` fails to read, the counter is not incremented.
 ///
-/// It can count until `u64::MAX - 1` accurately.
+/// It can count until `u32::MAX - 1` accurately.
 pub struct CountedInput<'a, I: crate::Input> {
 	input: &'a mut I,
-	counter: u64,
+	counter: u32,
 }
 
 impl<'a, I: crate::Input> CountedInput<'a, I> {
@@ -38,9 +38,9 @@ impl<'a, I: crate::Input> CountedInput<'a, I> {
 	}
 
 	/// Get the number of bytes successfully read.
-	/// Count until `u64::MAX - 1` accurately.
+	/// Count until `u32::MAX - 1` accurately.
 	pub fn count(&self) -> Count {
-		if self.counter == u64::MAX {
+		if self.counter == u32::MAX {
 			Count::MaxCountReached
 		} else {
 			Count::Exact(self.counter)
@@ -57,7 +57,7 @@ impl<I: crate::Input> crate::Input for CountedInput<'_, I> {
 		self.input.read(into)
 			.map(|r| {
 				self.counter = self.counter.saturating_add(
-					into.len().try_into().unwrap_or(u64::MAX)
+					into.len().try_into().unwrap_or(u32::MAX)
 				);
 				r
 			})
@@ -122,55 +122,69 @@ mod test {
 		assert_eq!(counted_input.count(), Count::Exact(5));
 	}
 
-	#[test]
-	fn test_counted_input_max_count_read_byte() {
-		let max_exact_count = u64::MAX - 1;
 
-		let mut input = &[0u8; 1000][..];
-		let mut counted_input = CountedInput::new(&mut input);
+	struct BigInput;
+	impl Input for BigInput {
+		fn remaining_len(&mut self) -> Result<Option<usize>, crate::Error> {
+			Ok(None)
+		}
 
-		counted_input.counter = max_exact_count - 2;
+		fn read(&mut self, _into: &mut [u8]) -> Result<(), crate::Error> {
+			Ok(())
+		}
 
-		assert_eq!(counted_input.count(), Count::Exact(max_exact_count - 2));
+		fn read_byte(&mut self) -> Result<u8, crate::Error> {
+			Ok(0)
+		}
 
-		counted_input.read_byte().unwrap();
+		fn ascend_ref(&mut self) {}
 
-		assert_eq!(counted_input.count(), Count::Exact(max_exact_count - 1));
-
-		counted_input.read_byte().unwrap();
-
-		assert_eq!(counted_input.count(), Count::Exact(max_exact_count));
-
-		counted_input.read_byte().unwrap();
-
-		assert_eq!(counted_input.count(), Count::MaxCountReached);
-
-		counted_input.read_byte().unwrap();
-
-		assert_eq!(counted_input.count(), Count::MaxCountReached);
+		fn descend_ref(&mut self) -> Result<(), crate::Error> {
+			Ok(())
+		}
 	}
 
 	#[test]
-	fn test_counted_input_max_count_read() {
-		let max_exact_count = u64::MAX - 1;
+	fn test_counted_input_max_count() {
+		let max = u32::MAX - 1; // 2^32 - 2
 
-		let mut input = &[0u8; 1000][..];
+		let mut input = BigInput;
 		let mut counted_input = CountedInput::new(&mut input);
 
-		counted_input.counter = max_exact_count - 1;
+		assert_eq!(counted_input.count(), Count::Exact(0));
 
-		assert_eq!(counted_input.count(), Count::Exact(max_exact_count - 1));
+		// Test will read continuously into this page.
+		let page_size = 1024 * 1024; // 1 MB
+		let mut page = vec![0u8; page_size];
 
+		// Calculate the number of full pages and the remaining bytes
+		let total_bytes = max as usize;
+		let full_pages = total_bytes / page_size;
+		let remaining_bytes = total_bytes % page_size;
+
+		// Read full pages
+		for _ in 0..full_pages {
+			counted_input.read(&mut page[..]).unwrap();
+		}
+
+		// Read remaining bytes
+		if remaining_bytes > 0 {
+			counted_input.read(&mut page[..remaining_bytes]).unwrap();
+		}
+
+		// Max is reached exactly
+		assert_eq!(counted_input.count(), Count::Exact(max));
+
+		// Perform one additional read
 		counted_input.read_byte().unwrap();
 
-		assert_eq!(counted_input.count(), Count::Exact(max_exact_count));
-
-		counted_input.read(&mut [0u8; 2][..]).unwrap();
-
+		// Count is more than max.
 		assert_eq!(counted_input.count(), Count::MaxCountReached);
 
-		counted_input.read(&mut [0u8; 2][..]).unwrap();
+		// Perform one additional read
+		counted_input.read_byte().unwrap();
 
+		// Count is still more than max.
 		assert_eq!(counted_input.count(), Count::MaxCountReached);
 	}
 }

--- a/src/counted_input.rs
+++ b/src/counted_input.rs
@@ -1,0 +1,176 @@
+// Copyright 2017-2024 Parity Technologies
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/// The value of a counter that has a maximum.
+#[derive(Eq, PartialEq, Clone, Debug)]
+pub enum Count {
+	/// The counter has an exact value.
+	Exact(u64),
+	/// The counter has reached its maximum countable value.
+	MaxCountReached,
+}
+
+/// A wrapper for `Input` which tracks the number fo bytes that are successfully read.
+///
+/// If inner `Input` fails to read, the counter is not incremented.
+///
+/// It can count until `u64::MAX - 1` accurately.
+pub struct CountedInput<'a, I: crate::Input> {
+	input: &'a mut I,
+	counter: u64,
+}
+
+impl<'a, I: crate::Input> CountedInput<'a, I> {
+	/// Create a new `CountedInput` with the given input.
+	pub fn new(input: &'a mut I) -> Self {
+		Self { input, counter: 0 }
+	}
+
+	/// Get the number of bytes successfully read.
+	/// Count until `u64::MAX - 1` accurately.
+	pub fn count(&self) -> Count {
+		if self.counter == u64::MAX {
+			Count::MaxCountReached
+		} else {
+			Count::Exact(self.counter)
+		}
+	}
+}
+
+impl<I: crate::Input> crate::Input for CountedInput<'_, I> {
+	fn remaining_len(&mut self) -> Result<Option<usize>, crate::Error> {
+		self.input.remaining_len()
+	}
+
+	fn read(&mut self, into: &mut [u8]) -> Result<(), crate::Error> {
+		self.input.read(into)
+			.map(|r| {
+				self.counter = self.counter.saturating_add(
+					into.len().try_into().unwrap_or(u64::MAX)
+				);
+				r
+			})
+	}
+
+	fn read_byte(&mut self) -> Result<u8, crate::Error> {
+		self.input.read_byte()
+			.map(|r| {
+				self.counter = self.counter.saturating_add(1);
+				r
+			})
+	}
+
+	fn ascend_ref(&mut self) {
+		self.input.ascend_ref()
+	}
+
+	fn descend_ref(&mut self) -> Result<(), crate::Error> {
+		self.input.descend_ref()
+	}
+}
+
+#[cfg(test)]
+mod test {
+	use super::*;
+	use crate::Input;
+
+	#[test]
+	fn test_counted_input_input_impl() {
+		let mut input = &[1u8, 2, 3, 4, 5][..];
+		let mut counted_input = CountedInput::new(&mut input);
+
+		assert_eq!(counted_input.remaining_len().unwrap(), Some(5));
+		assert_eq!(counted_input.count(), Count::Exact(0));
+
+		counted_input.read_byte().unwrap();
+
+		assert_eq!(counted_input.remaining_len().unwrap(), Some(4));
+		assert_eq!(counted_input.count(), Count::Exact(1));
+
+		counted_input.read(&mut [0u8; 2][..]).unwrap();
+
+		assert_eq!(counted_input.remaining_len().unwrap(), Some(2));
+		assert_eq!(counted_input.count(), Count::Exact(3));
+
+		counted_input.ascend_ref();
+		counted_input.descend_ref().unwrap();
+
+		counted_input.read(&mut [0u8; 2][..]).unwrap();
+
+		assert_eq!(counted_input.remaining_len().unwrap(), Some(0));
+		assert_eq!(counted_input.count(), Count::Exact(5));
+
+		assert_eq!(counted_input.read_byte(), Err("Not enough data to fill buffer".into()));
+
+		assert_eq!(counted_input.remaining_len().unwrap(), Some(0));
+		assert_eq!(counted_input.count(), Count::Exact(5));
+
+		assert_eq!(counted_input.read(&mut [0u8; 2][..]), Err("Not enough data to fill buffer".into()));
+
+		assert_eq!(counted_input.remaining_len().unwrap(), Some(0));
+		assert_eq!(counted_input.count(), Count::Exact(5));
+	}
+
+	#[test]
+	fn test_counted_input_max_count_read_byte() {
+		let max_exact_count = u64::MAX - 1;
+
+		let mut input = &[0u8; 1000][..];
+		let mut counted_input = CountedInput::new(&mut input);
+
+		counted_input.counter = max_exact_count - 2;
+
+		assert_eq!(counted_input.count(), Count::Exact(max_exact_count - 2));
+
+		counted_input.read_byte().unwrap();
+
+		assert_eq!(counted_input.count(), Count::Exact(max_exact_count - 1));
+
+		counted_input.read_byte().unwrap();
+
+		assert_eq!(counted_input.count(), Count::Exact(max_exact_count));
+
+		counted_input.read_byte().unwrap();
+
+		assert_eq!(counted_input.count(), Count::MaxCountReached);
+
+		counted_input.read_byte().unwrap();
+
+		assert_eq!(counted_input.count(), Count::MaxCountReached);
+	}
+
+	#[test]
+	fn test_counted_input_max_count_read() {
+		let max_exact_count = u64::MAX - 1;
+
+		let mut input = &[0u8; 1000][..];
+		let mut counted_input = CountedInput::new(&mut input);
+
+		counted_input.counter = max_exact_count - 1;
+
+		assert_eq!(counted_input.count(), Count::Exact(max_exact_count - 1));
+
+		counted_input.read_byte().unwrap();
+
+		assert_eq!(counted_input.count(), Count::Exact(max_exact_count));
+
+		counted_input.read(&mut [0u8; 2][..]).unwrap();
+
+		assert_eq!(counted_input.count(), Count::MaxCountReached);
+
+		counted_input.read(&mut [0u8; 2][..]).unwrap();
+
+		assert_eq!(counted_input.count(), Count::MaxCountReached);
+	}
+}

--- a/src/counted_input.rs
+++ b/src/counted_input.rs
@@ -40,21 +40,17 @@ impl<I: crate::Input> crate::Input for CountedInput<'_, I> {
 	}
 
 	fn read(&mut self, into: &mut [u8]) -> Result<(), crate::Error> {
-		self.input.read(into)
-			.map(|r| {
-				self.counter = self.counter.saturating_add(
-					into.len().try_into().unwrap_or(u64::MAX)
-				);
-				r
-			})
+		self.input.read(into).map(|r| {
+			self.counter = self.counter.saturating_add(into.len().try_into().unwrap_or(u64::MAX));
+			r
+		})
 	}
 
 	fn read_byte(&mut self) -> Result<u8, crate::Error> {
-		self.input.read_byte()
-			.map(|r| {
-				self.counter = self.counter.saturating_add(1);
-				r
-			})
+		self.input.read_byte().map(|r| {
+			self.counter = self.counter.saturating_add(1);
+			r
+		})
 	}
 
 	fn ascend_ref(&mut self) {
@@ -102,7 +98,10 @@ mod test {
 		assert_eq!(counted_input.remaining_len().unwrap(), Some(0));
 		assert_eq!(counted_input.count(), 5);
 
-		assert_eq!(counted_input.read(&mut [0u8; 2][..]), Err("Not enough data to fill buffer".into()));
+		assert_eq!(
+			counted_input.read(&mut [0u8; 2][..]),
+			Err("Not enough data to fill buffer".into())
+		);
 
 		assert_eq!(counted_input.remaining_len().unwrap(), Some(0));
 		assert_eq!(counted_input.count(), 5);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -50,6 +50,7 @@ mod decode_finished;
 mod depth_limit;
 mod encode_append;
 mod encode_like;
+mod counted_input;
 mod error;
 #[cfg(feature = "generic-array")]
 mod generic_array;
@@ -74,6 +75,7 @@ pub use self::{
 	error::Error,
 	joiner::Joiner,
 	keyedvec::KeyedVec,
+	counted_input::{CountedInput, Count},
 };
 #[cfg(feature = "max-encoded-len")]
 pub use const_encoded_len::ConstEncodedLen;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -45,12 +45,12 @@ mod codec;
 mod compact;
 #[cfg(feature = "max-encoded-len")]
 mod const_encoded_len;
+mod counted_input;
 mod decode_all;
 mod decode_finished;
 mod depth_limit;
 mod encode_append;
 mod encode_like;
-mod counted_input;
 mod error;
 #[cfg(feature = "generic-array")]
 mod generic_array;
@@ -67,6 +67,7 @@ pub use self::{
 		FullEncode, Input, OptionBool, Output, WrapperTypeDecode, WrapperTypeEncode,
 	},
 	compact::{Compact, CompactAs, CompactLen, CompactRef, HasCompact},
+	counted_input::CountedInput,
 	decode_all::DecodeAll,
 	decode_finished::DecodeFinished,
 	depth_limit::DecodeLimit,
@@ -75,7 +76,6 @@ pub use self::{
 	error::Error,
 	joiner::Joiner,
 	keyedvec::KeyedVec,
-	counted_input::CountedInput,
 };
 #[cfg(feature = "max-encoded-len")]
 pub use const_encoded_len::ConstEncodedLen;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -75,7 +75,7 @@ pub use self::{
 	error::Error,
 	joiner::Joiner,
 	keyedvec::KeyedVec,
-	counted_input::{CountedInput, Count},
+	counted_input::CountedInput,
 };
 #[cfg(feature = "max-encoded-len")]
 pub use const_encoded_len::ConstEncodedLen;


### PR DESCRIPTION
I saw some code which tries to track the number of byte read with `remaining_len`. But `remaining_len` don't always give information.

I think it is better to provide an accurate counter.

I used u64 because it made the code simpler. And more general purpose.

Otherwise I was thinking using a type:
```rust
enum Count {
    Exact(u32),
    MaxReached,
}
```
and do the count in u32.

But most machine being 64bit, I think it should execute good.