### PR TITLE
Prep to release 3.7.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this crate are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this crate adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.7.1] - 2024-10-24
+
+### Changed
+
+- This release bumps some dependencies, primarily bumping `syn` to 2. ([#640](https://github.com/paritytech/parity-scale-codec/pull/640)).
+
+## [3.7.0] - 2024-10-09
+
+### Added
+
+- Allow decoding with a memory limit. ([616](https://github.com/paritytech/parity-scale-codec/pull/616))
+
 ## [3.6.4] - 2023-07-14
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,17 +5,13 @@ All notable changes to this crate are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this crate adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [3.7.1] - 2024-10-24
-
-### Changed
-
-- This release bumps some dependencies, primarily bumping `syn` to 2. ([#640](https://github.com/paritytech/parity-scale-codec/pull/640)).
-
-## [3.7.0] - 2024-10-09
+## [3.7.0] - 2024-10-24
 
 ### Added
-
 - Allow decoding with a memory limit. ([616](https://github.com/paritytech/parity-scale-codec/pull/616))
+
+### Changed
+- This release bumps some dependencies, primarily bumping `syn` to 2. ([#640](https://github.com/paritytech/parity-scale-codec/pull/640)).
 
 ## [3.6.4] - 2023-07-14
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -597,7 +597,7 @@ dependencies = [
 
 [[package]]
 name = "parity-scale-codec-derive"
-version = "3.6.8"
+version = "3.7.1"
 dependencies = [
  "parity-scale-codec",
  "proc-macro-crate",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -575,7 +575,7 @@ checksum = "ceedf44fb00f2d1984b0bc98102627ce622e083e49a5bacdb3e514fa4238e267"
 
 [[package]]
 name = "parity-scale-codec"
-version = "3.7.1"
+version = "3.7.0"
 dependencies = [
  "arbitrary",
  "arrayvec",
@@ -597,7 +597,7 @@ dependencies = [
 
 [[package]]
 name = "parity-scale-codec-derive"
-version = "3.7.1"
+version = "3.7.0"
 dependencies = [
  "parity-scale-codec",
  "proc-macro-crate",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -575,7 +575,7 @@ checksum = "ceedf44fb00f2d1984b0bc98102627ce622e083e49a5bacdb3e514fa4238e267"
 
 [[package]]
 name = "parity-scale-codec"
-version = "3.7.0"
+version = "3.7.1"
 dependencies = [
  "arbitrary",
  "arrayvec",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "parity-scale-codec"
 description = "SCALE - Simple Concatenating Aggregated Little Endians"
-version = "3.7.0"
+version = "3.7.1"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "Apache-2.0"
 repository = "https://github.com/paritytech/parity-scale-codec"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,13 +7,13 @@ license.workspace = true
 repository.workspace = true
 categories.workspace = true
 edition.workspace = true
-rust-version.workspace = true
 build = "build.rs"
+rust-version.workspace = true
 
 [dependencies]
 arrayvec = { version = "0.7", default-features = false }
 serde = { version = "1.0.213", default-features = false, optional = true }
-parity-scale-codec-derive = { path = "derive", version = "3.7.1", default-features = false, optional = true }
+parity-scale-codec-derive = { path = "derive", version = "3.6.8", default-features = false, optional = true }
 bitvec = { version = "1", default-features = false, features = ["alloc"], optional = true }
 bytes = { version = "1", default-features = false, optional = true }
 byte-slice-cast = { version = "1.2.2", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,19 +1,19 @@
 [package]
 name = "parity-scale-codec"
 description = "SCALE - Simple Concatenating Aggregated Little Endians"
-version = "3.7.1"
-authors = ["Parity Technologies <admin@parity.io>"]
-license = "Apache-2.0"
-repository = "https://github.com/paritytech/parity-scale-codec"
-categories = ["encoding"]
-edition = "2021"
+version.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+categories.workspace = true
+edition.workspace = true
+rust-version.workspace = true
 build = "build.rs"
-rust-version = "1.60.0"
 
 [dependencies]
 arrayvec = { version = "0.7", default-features = false }
 serde = { version = "1.0.213", default-features = false, optional = true }
-parity-scale-codec-derive = { path = "derive", version = ">= 3.6.8", default-features = false, optional = true }
+parity-scale-codec-derive = { path = "derive", version = "3.7.1", default-features = false, optional = true }
 bitvec = { version = "1", default-features = false, features = ["alloc"], optional = true }
 bytes = { version = "1", default-features = false, optional = true }
 byte-slice-cast = { version = "1.2.2", default-features = false }
@@ -62,3 +62,12 @@ full = []
 
 [workspace]
 members = ["derive", "fuzzer"]
+
+[workspace.package]
+version = "3.7.1"
+authors = ["Parity Technologies <admin@parity.io>"]
+license = "Apache-2.0"
+repository = "https://github.com/paritytech/parity-scale-codec"
+categories = ["encoding"]
+edition = "2021"
+rust-version = "1.60.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,7 +64,7 @@ full = []
 members = ["derive", "fuzzer"]
 
 [workspace.package]
-version = "3.7.1"
+version = "3.7.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "Apache-2.0"
 repository = "https://github.com/paritytech/parity-scale-codec"

--- a/derive/Cargo.toml
+++ b/derive/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "parity-scale-codec-derive"
 description = "Serialization and deserialization derive macro for Parity SCALE Codec"
-version = "3.6.8"
-authors = ["Parity Technologies <admin@parity.io>"]
-license = "Apache-2.0"
-edition = "2021"
-rust-version = "1.56.1"
-repository = "https://github.com/paritytech/parity-scale-codec"
+version.workspace = true
+authors.workspace = true
+license.workspace = true
+edition.workspace = true
+repository.workspace = true
+rust-version.workspace = true
 
 [lib]
 proc-macro = true


### PR DESCRIPTION
One thing I did here was consistify things eg versions across the workspace. The derive crate was lagging behind a bit on a 3.6.x version, so this brings it up to 3.7.1 in line with the main crate. I would hope that this wouldn't cause any breakage (even if two derive crates existed in the tree, if they both point to the same main crate then the traits implemented will ine up).

Also added a 3.7.0 changelog entry which was missing.

## [3.7.1] - 2024-10-24

### Changed

- This release bumps some dependencies, primarily bumping `syn` to 2. ([#640](https://github.com/paritytech/parity-scale-codec/pull/640)).