### PR TITLE
Allow different reprs to still work

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -588,7 +588,7 @@ checksum = "ceedf44fb00f2d1984b0bc98102627ce622e083e49a5bacdb3e514fa4238e267"
 
 [[package]]
 name = "parity-scale-codec"
-version = "3.7.1"
+version = "3.7.2"
 dependencies = [
  "arbitrary",
  "arrayvec",
@@ -611,7 +611,7 @@ dependencies = [
 
 [[package]]
 name = "parity-scale-codec-derive"
-version = "3.7.1"
+version = "3.7.2"
 dependencies = [
  "parity-scale-codec",
  "proc-macro-crate",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,7 +65,7 @@ full = []
 members = ["derive", "fuzzer"]
 
 [workspace.package]
-version = "3.7.1"
+version = "3.7.2"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "Apache-2.0"
 repository = "https://github.com/paritytech/parity-scale-codec"

--- a/benches/benches.rs
+++ b/benches/benches.rs
@@ -65,7 +65,7 @@ fn vec_extend_from_slice(b: &mut Bencher) {
 
 struct NoLimitInput<'a>(&'a [u8]);
 
-impl<'a> Input for NoLimitInput<'a> {
+impl Input for NoLimitInput<'_> {
 	fn remaining_len(&mut self) -> Result<Option<usize>, Error> {
 		Ok(None)
 	}
@@ -121,7 +121,7 @@ where
 	let mut g = c.benchmark_group("vec_encode");
 	for vec_size in [1, 2, 5, 32, 1024, 2048, 16384] {
 		g.bench_with_input(
-			&format!("{}/{}", type_name::<T>(), vec_size),
+			format!("{}/{}", type_name::<T>(), vec_size),
 			&vec_size,
 			|b, &vec_size| {
 				let vec: Vec<T> =
@@ -137,7 +137,7 @@ where
 	let mut g = c.benchmark_group("vec_decode");
 	for vec_size in [1, 2, 5, 32, 1024, 2048, 16384] {
 		g.bench_with_input(
-			&format!("{}/{}", type_name::<T>(), vec_size),
+			format!("{}/{}", type_name::<T>(), vec_size),
 			&vec_size,
 			|b, &vec_size| {
 				let vec: Vec<T> =
@@ -157,7 +157,7 @@ where
 	let mut g = c.benchmark_group("vec_decode_no_limit");
 	for vec_size in [16384, 131072] {
 		g.bench_with_input(
-			&format!("vec_decode_no_limit_{}/{}", type_name::<T>(), vec_size),
+			format!("vec_decode_no_limit_{}/{}", type_name::<T>(), vec_size),
 			&vec_size,
 			|b, &vec_size| {
 				let vec: Vec<T> =

--- a/derive/src/utils.rs
+++ b/derive/src/utils.rs
@@ -398,7 +398,7 @@ pub fn check_attributes(input: &DeriveInput) -> syn::Result<()> {
 				// any explicit discriminants are within 0..=255
 				let discriminant = variant.discriminant.as_ref().map(|(_, d)| d);
 				if let Some(expr) = discriminant {
-					check_variant_discriminant(&expr)?;
+					check_variant_discriminant(expr)?;
 				}
 			},
 		Data::Union(_) => (),

--- a/derive/src/utils.rs
+++ b/derive/src/utils.rs
@@ -114,10 +114,8 @@ pub fn variant_index(v: &Variant, i: usize) -> TokenStream {
 
 	// if no attribute, use the discriminnant if there is one
 	if index.is_none() {
-		if let Some((_, discriminant_idx)) = &v.discriminant {
-			if let Expr::Lit(ExprLit { lit: Lit::Int(disc_lit), .. }) = discriminant_idx {
-				index = disc_lit.base10_parse().ok()
-			}
+		if let Some((_, Expr::Lit(ExprLit { lit: Lit::Int(disc_lit), .. }))) = &v.discriminant {
+			index = disc_lit.base10_parse().ok()
 		}
 	}
 

--- a/derive/src/utils.rs
+++ b/derive/src/utils.rs
@@ -123,7 +123,8 @@ pub fn variant_index(v: &Variant, i: usize) -> TokenStream {
 	let index = index.unwrap_or(i);
 
 	// output the index with no suffix (ie 1 rather than 1usize) so that these can be quoted into
-	// an array of usizes and will work regardless of what type the discriminant values actually are.
+	// an array of usizes and will work regardless of what type the discriminant values actually
+	// are.
 	let s = proc_macro2::Literal::usize_unsuffixed(index);
 	quote! { #s }
 }

--- a/derive/src/utils.rs
+++ b/derive/src/utils.rs
@@ -122,8 +122,8 @@ pub fn variant_index(v: &Variant, i: usize) -> TokenStream {
 	// fall back to the provided index if none is found.
 	let index = index.unwrap_or(i);
 
-	// output the index with no suffix (ie 1 rather than 1usize) to cater for the user wanting
-	// different reprs and let the compiler dicide the concrete type.
+	// output the index with no suffix (ie 1 rather than 1usize) so that these can be quoted into
+	// an array of usizes and will work regardless of what type the discriminant values actually are.
 	let s = proc_macro2::Literal::usize_unsuffixed(index);
 	quote! { #s }
 }

--- a/derive/src/utils.rs
+++ b/derive/src/utils.rs
@@ -117,7 +117,7 @@ pub fn variant_index(v: &Variant, i: usize) -> TokenStream {
 		if let Some((_, discriminant_idx)) = &v.discriminant {
 			if let Expr::Lit(ExprLit { lit: Lit::Int(disc_lit), .. }) = discriminant_idx {
 				index = disc_lit.base10_parse().ok()
-			} 
+			}
 		}
 	}
 
@@ -127,7 +127,7 @@ pub fn variant_index(v: &Variant, i: usize) -> TokenStream {
 	// output the index with no suffix (ie 1 rather than 1usize) to cater for the user wanting
 	// different reprs and let the compiler dicide the concrete type.
 	let s = proc_macro2::Literal::usize_unsuffixed(index);
-	quote!{ #s }
+	quote! { #s }
 }
 
 /// Look for a `#[codec(encoded_as = "SomeType")]` outer attribute on the given

--- a/derive/src/utils.rs
+++ b/derive/src/utils.rs
@@ -112,7 +112,7 @@ pub fn variant_index(v: &Variant, i: usize) -> TokenStream {
 		None
 	});
 
-	// if no attribute, use the discriminnant if there is one
+	// if no attribute, use the discriminant if there is one
 	if index.is_none() {
 		if let Some((_, Expr::Lit(ExprLit { lit: Lit::Int(disc_lit), .. }))) = &v.discriminant {
 			index = disc_lit.base10_parse().ok()

--- a/derive/src/utils.rs
+++ b/derive/src/utils.rs
@@ -396,7 +396,7 @@ pub fn check_attributes(input: &DeriveInput) -> syn::Result<()> {
 				}
 				// While we're checking things, also ensure that
 				// any explicit discriminants are within 0..=255
-				let discriminant = variant.discriminant.as_ref().map(|(_,d)| d);
+				let discriminant = variant.discriminant.as_ref().map(|(_, d)| d);
 				if let Some(expr) = discriminant {
 					check_variant_discriminant(&expr)?;
 				}
@@ -483,13 +483,13 @@ fn check_variant_attribute(attr: &Attribute) -> syn::Result<()> {
 // something in the range 0..255.
 fn check_variant_discriminant(discriminant: &Expr) -> syn::Result<()> {
 	if let Expr::Lit(ExprLit { lit: Lit::Int(lit_int), .. }) = discriminant {
-		lit_int.base10_parse::<u8>()
-			.map(|_| ())
-			.map_err(|_| syn::Error::new(lit_int.span(), "Discriminant index must be in the range 0..255"))
+		lit_int.base10_parse::<u8>().map(|_| ()).map_err(|_| {
+			syn::Error::new(lit_int.span(), "Discriminant index must be in the range 0..255")
+		})
 	} else {
 		Err(syn::Error::new(
 			discriminant.span(),
-			"Discriminant must be an integer literal in the range 0..255"
+			"Discriminant must be an integer literal in the range 0..255",
 		))
 	}
 }

--- a/src/codec.rs
+++ b/src/codec.rs
@@ -110,7 +110,7 @@ pub trait Input {
 	}
 }
 
-impl<'a> Input for &'a [u8] {
+impl Input for &[u8] {
 	fn remaining_len(&mut self) -> Result<Option<usize>, Error> {
 		Ok(Some(self.len()))
 	}
@@ -383,10 +383,10 @@ impl<T: ?Sized + Encode> EncodeLike for &mut T {}
 impl<T: Encode> EncodeLike<T> for &mut T {}
 impl<T: Encode> EncodeLike<&mut T> for T {}
 
-impl<'a, T: ToOwned + ?Sized> WrapperTypeEncode for Cow<'a, T> {}
-impl<'a, T: ToOwned + Encode + ?Sized> EncodeLike for Cow<'a, T> {}
-impl<'a, T: ToOwned + Encode> EncodeLike<T> for Cow<'a, T> {}
-impl<'a, T: ToOwned + Encode> EncodeLike<Cow<'a, T>> for T {}
+impl<T: ToOwned + ?Sized> WrapperTypeEncode for Cow<'_, T> {}
+impl<T: ToOwned + Encode + ?Sized> EncodeLike for Cow<'_, T> {}
+impl<T: ToOwned + Encode> EncodeLike<T> for Cow<'_, T> {}
+impl<T: ToOwned + Encode> EncodeLike<Cow<'_, T>> for T {}
 
 impl<T: ?Sized> WrapperTypeEncode for Rc<T> {}
 impl<T: ?Sized + Encode> EncodeLike for Rc<T> {}
@@ -973,7 +973,7 @@ impl<T: Decode, const N: usize> Decode for [T; N] {
 			slice: &'a mut [MaybeUninit<T>; N],
 		}
 
-		impl<'a, T, const N: usize> Drop for State<'a, T, N> {
+		impl<T, const N: usize> Drop for State<'_, T, N> {
 			fn drop(&mut self) {
 				if !mem::needs_drop::<T>() {
 					// If the types don't actually need to be dropped then don't even
@@ -1050,7 +1050,7 @@ impl Encode for str {
 	}
 }
 
-impl<'a, T: ToOwned + ?Sized> Decode for Cow<'a, T>
+impl<T: ToOwned + ?Sized> Decode for Cow<'_, T>
 where
 	<T as ToOwned>::Owned: Decode,
 {
@@ -1979,7 +1979,7 @@ mod tests {
 
 		struct NoLimit<'a>(&'a [u8]);
 
-		impl<'a> Input for NoLimit<'a> {
+		impl Input for NoLimit<'_> {
 			fn remaining_len(&mut self) -> Result<Option<usize>, Error> {
 				Ok(None)
 			}

--- a/src/compact.rs
+++ b/src/compact.rs
@@ -134,14 +134,14 @@ where
 	}
 }
 
-impl<'a, T> EncodeLike for CompactRef<'a, T>
+impl<T> EncodeLike for CompactRef<'_, T>
 where
 	T: CompactAs,
 	for<'b> CompactRef<'b, T::As>: Encode,
 {
 }
 
-impl<'a, T> Encode for CompactRef<'a, T>
+impl<T> Encode for CompactRef<'_, T>
 where
 	T: CompactAs,
 	for<'b> CompactRef<'b, T::As>: Encode,
@@ -258,7 +258,7 @@ where
 	type Type = Compact<T>;
 }
 
-impl<'a> Encode for CompactRef<'a, ()> {
+impl Encode for CompactRef<'_, ()> {
 	fn encode_to<W: Output + ?Sized>(&self, _dest: &mut W) {}
 
 	fn using_encoded<R, F: FnOnce(&[u8]) -> R>(&self, f: F) -> R {
@@ -270,7 +270,7 @@ impl<'a> Encode for CompactRef<'a, ()> {
 	}
 }
 
-impl<'a> Encode for CompactRef<'a, u8> {
+impl Encode for CompactRef<'_, u8> {
 	fn size_hint(&self) -> usize {
 		Compact::compact_len(self.0)
 	}
@@ -298,7 +298,7 @@ impl CompactLen<u8> for Compact<u8> {
 	}
 }
 
-impl<'a> Encode for CompactRef<'a, u16> {
+impl Encode for CompactRef<'_, u16> {
 	fn size_hint(&self) -> usize {
 		Compact::compact_len(self.0)
 	}
@@ -328,7 +328,7 @@ impl CompactLen<u16> for Compact<u16> {
 	}
 }
 
-impl<'a> Encode for CompactRef<'a, u32> {
+impl Encode for CompactRef<'_, u32> {
 	fn size_hint(&self) -> usize {
 		Compact::compact_len(self.0)
 	}
@@ -364,7 +364,7 @@ impl CompactLen<u32> for Compact<u32> {
 	}
 }
 
-impl<'a> Encode for CompactRef<'a, u64> {
+impl Encode for CompactRef<'_, u64> {
 	fn size_hint(&self) -> usize {
 		Compact::compact_len(self.0)
 	}
@@ -410,7 +410,7 @@ impl CompactLen<u64> for Compact<u64> {
 	}
 }
 
-impl<'a> Encode for CompactRef<'a, u128> {
+impl Encode for CompactRef<'_, u128> {
 	fn size_hint(&self) -> usize {
 		Compact::compact_len(self.0)
 	}

--- a/src/depth_limit.rs
+++ b/src/depth_limit.rs
@@ -37,7 +37,7 @@ struct DepthTrackingInput<'a, I> {
 	max_depth: u32,
 }
 
-impl<'a, I: Input> Input for DepthTrackingInput<'a, I> {
+impl<I: Input> Input for DepthTrackingInput<'_, I> {
 	fn remaining_len(&mut self) -> Result<Option<usize>, Error> {
 		self.input.remaining_len()
 	}

--- a/src/encode_like.rs
+++ b/src/encode_like.rs
@@ -87,7 +87,7 @@ pub trait EncodeLike<T: Encode = Self>: Sized + Encode {}
 /// }
 /// ```
 pub struct Ref<'a, T: EncodeLike<U>, U: Encode>(&'a T, core::marker::PhantomData<U>);
-impl<'a, T: EncodeLike<U>, U: Encode> core::ops::Deref for Ref<'a, T, U> {
+impl<T: EncodeLike<U>, U: Encode> core::ops::Deref for Ref<'_, T, U> {
 	type Target = T;
 	fn deref(&self) -> &Self::Target {
 		self.0
@@ -99,9 +99,9 @@ impl<'a, T: EncodeLike<U>, U: Encode> From<&'a T> for Ref<'a, T, U> {
 		Ref(x, Default::default())
 	}
 }
-impl<'a, T: EncodeLike<U>, U: Encode> crate::WrapperTypeEncode for Ref<'a, T, U> {}
-impl<'a, T: EncodeLike<U>, U: Encode> EncodeLike<U> for Ref<'a, T, U> {}
-impl<'a, T: EncodeLike<U>, U: Encode> EncodeLike<U> for &Ref<'a, T, U> {}
+impl<T: EncodeLike<U>, U: Encode> crate::WrapperTypeEncode for Ref<'_, T, U> {}
+impl<T: EncodeLike<U>, U: Encode> EncodeLike<U> for Ref<'_, T, U> {}
+impl<T: EncodeLike<U>, U: Encode> EncodeLike<U> for &Ref<'_, T, U> {}
 
 #[cfg(test)]
 mod tests {

--- a/src/mem_tracking.rs
+++ b/src/mem_tracking.rs
@@ -44,7 +44,7 @@ impl<'a, I: Input> MemTrackingInput<'a, I> {
 	}
 }
 
-impl<'a, I: Input> Input for MemTrackingInput<'a, I> {
+impl<I: Input> Input for MemTrackingInput<'_, I> {
 	fn remaining_len(&mut self) -> Result<Option<usize>, Error> {
 		self.input.remaining_len()
 	}

--- a/tests/max_encoded_len_ui/crate_str.stderr
+++ b/tests/max_encoded_len_ui/crate_str.stderr
@@ -8,18 +8,18 @@ error[E0277]: the trait bound `Example: Encode` is not satisfied
  --> tests/max_encoded_len_ui/crate_str.rs:5:8
   |
 5 | struct Example;
-  |        ^^^^^^^ the trait `WrapperTypeEncode` is not implemented for `Example`, which is required by `Example: Encode`
+  |        ^^^^^^^ the trait `WrapperTypeEncode` is not implemented for `Example`
   |
   = help: the following other types implement trait `WrapperTypeEncode`:
             &T
             &mut T
             Arc<T>
             Box<T>
-            Cow<'a, T>
+            Cow<'_, T>
             Rc<T>
             String
             Vec<T>
-            parity_scale_codec::Ref<'a, T, U>
+            parity_scale_codec::Ref<'_, T, U>
   = note: required for `Example` to implement `Encode`
 note: required by a bound in `MaxEncodedLen`
  --> src/max_encoded_len.rs
@@ -31,18 +31,18 @@ error[E0277]: the trait bound `Example: Encode` is not satisfied
  --> tests/max_encoded_len_ui/crate_str.rs:8:10
   |
 8 |     let _ = Example::max_encoded_len();
-  |             ^^^^^^^ the trait `WrapperTypeEncode` is not implemented for `Example`, which is required by `Example: Encode`
+  |             ^^^^^^^ the trait `WrapperTypeEncode` is not implemented for `Example`
   |
   = help: the following other types implement trait `WrapperTypeEncode`:
             &T
             &mut T
             Arc<T>
             Box<T>
-            Cow<'a, T>
+            Cow<'_, T>
             Rc<T>
             String
             Vec<T>
-            parity_scale_codec::Ref<'a, T, U>
+            parity_scale_codec::Ref<'_, T, U>
   = note: required for `Example` to implement `Encode`
 note: required by a bound in `max_encoded_len`
  --> src/max_encoded_len.rs

--- a/tests/max_encoded_len_ui/crate_str.stderr
+++ b/tests/max_encoded_len_ui/crate_str.stderr
@@ -8,7 +8,7 @@ error[E0277]: the trait bound `Example: Encode` is not satisfied
  --> tests/max_encoded_len_ui/crate_str.rs:5:8
   |
 5 | struct Example;
-  |        ^^^^^^^ the trait `WrapperTypeEncode` is not implemented for `Example`
+  |        ^^^^^^^ the trait `WrapperTypeEncode` is not implemented for `Example`, which is required by `Example: Encode`
   |
   = help: the following other types implement trait `WrapperTypeEncode`:
             &T
@@ -31,7 +31,7 @@ error[E0277]: the trait bound `Example: Encode` is not satisfied
  --> tests/max_encoded_len_ui/crate_str.rs:8:10
   |
 8 |     let _ = Example::max_encoded_len();
-  |             ^^^^^^^ the trait `WrapperTypeEncode` is not implemented for `Example`
+  |             ^^^^^^^ the trait `WrapperTypeEncode` is not implemented for `Example`, which is required by `Example: Encode`
   |
   = help: the following other types implement trait `WrapperTypeEncode`:
             &T

--- a/tests/max_encoded_len_ui/incomplete_attr.stderr
+++ b/tests/max_encoded_len_ui/incomplete_attr.stderr
@@ -8,18 +8,18 @@ error[E0277]: the trait bound `Example: Encode` is not satisfied
  --> tests/max_encoded_len_ui/incomplete_attr.rs:5:8
   |
 5 | struct Example;
-  |        ^^^^^^^ the trait `WrapperTypeEncode` is not implemented for `Example`, which is required by `Example: Encode`
+  |        ^^^^^^^ the trait `WrapperTypeEncode` is not implemented for `Example`
   |
   = help: the following other types implement trait `WrapperTypeEncode`:
             &T
             &mut T
             Arc<T>
             Box<T>
-            Cow<'a, T>
+            Cow<'_, T>
             Rc<T>
             String
             Vec<T>
-            parity_scale_codec::Ref<'a, T, U>
+            parity_scale_codec::Ref<'_, T, U>
   = note: required for `Example` to implement `Encode`
 note: required by a bound in `MaxEncodedLen`
  --> src/max_encoded_len.rs
@@ -31,18 +31,18 @@ error[E0277]: the trait bound `Example: Encode` is not satisfied
  --> tests/max_encoded_len_ui/incomplete_attr.rs:8:10
   |
 8 |     let _ = Example::max_encoded_len();
-  |             ^^^^^^^ the trait `WrapperTypeEncode` is not implemented for `Example`, which is required by `Example: Encode`
+  |             ^^^^^^^ the trait `WrapperTypeEncode` is not implemented for `Example`
   |
   = help: the following other types implement trait `WrapperTypeEncode`:
             &T
             &mut T
             Arc<T>
             Box<T>
-            Cow<'a, T>
+            Cow<'_, T>
             Rc<T>
             String
             Vec<T>
-            parity_scale_codec::Ref<'a, T, U>
+            parity_scale_codec::Ref<'_, T, U>
   = note: required for `Example` to implement `Encode`
 note: required by a bound in `max_encoded_len`
  --> src/max_encoded_len.rs

--- a/tests/max_encoded_len_ui/incomplete_attr.stderr
+++ b/tests/max_encoded_len_ui/incomplete_attr.stderr
@@ -8,7 +8,7 @@ error[E0277]: the trait bound `Example: Encode` is not satisfied
  --> tests/max_encoded_len_ui/incomplete_attr.rs:5:8
   |
 5 | struct Example;
-  |        ^^^^^^^ the trait `WrapperTypeEncode` is not implemented for `Example`
+  |        ^^^^^^^ the trait `WrapperTypeEncode` is not implemented for `Example`, which is required by `Example: Encode`
   |
   = help: the following other types implement trait `WrapperTypeEncode`:
             &T
@@ -31,7 +31,7 @@ error[E0277]: the trait bound `Example: Encode` is not satisfied
  --> tests/max_encoded_len_ui/incomplete_attr.rs:8:10
   |
 8 |     let _ = Example::max_encoded_len();
-  |             ^^^^^^^ the trait `WrapperTypeEncode` is not implemented for `Example`
+  |             ^^^^^^^ the trait `WrapperTypeEncode` is not implemented for `Example`, which is required by `Example: Encode`
   |
   = help: the following other types implement trait `WrapperTypeEncode`:
             &T

--- a/tests/max_encoded_len_ui/missing_crate_specifier.stderr
+++ b/tests/max_encoded_len_ui/missing_crate_specifier.stderr
@@ -8,7 +8,7 @@ error[E0277]: the trait bound `Example: Encode` is not satisfied
  --> tests/max_encoded_len_ui/missing_crate_specifier.rs:5:8
   |
 5 | struct Example;
-  |        ^^^^^^^ the trait `WrapperTypeEncode` is not implemented for `Example`
+  |        ^^^^^^^ the trait `WrapperTypeEncode` is not implemented for `Example`, which is required by `Example: Encode`
   |
   = help: the following other types implement trait `WrapperTypeEncode`:
             &T
@@ -31,7 +31,7 @@ error[E0277]: the trait bound `Example: Encode` is not satisfied
  --> tests/max_encoded_len_ui/missing_crate_specifier.rs:8:10
   |
 8 |     let _ = Example::max_encoded_len();
-  |             ^^^^^^^ the trait `WrapperTypeEncode` is not implemented for `Example`
+  |             ^^^^^^^ the trait `WrapperTypeEncode` is not implemented for `Example`, which is required by `Example: Encode`
   |
   = help: the following other types implement trait `WrapperTypeEncode`:
             &T

--- a/tests/max_encoded_len_ui/missing_crate_specifier.stderr
+++ b/tests/max_encoded_len_ui/missing_crate_specifier.stderr
@@ -8,18 +8,18 @@ error[E0277]: the trait bound `Example: Encode` is not satisfied
  --> tests/max_encoded_len_ui/missing_crate_specifier.rs:5:8
   |
 5 | struct Example;
-  |        ^^^^^^^ the trait `WrapperTypeEncode` is not implemented for `Example`, which is required by `Example: Encode`
+  |        ^^^^^^^ the trait `WrapperTypeEncode` is not implemented for `Example`
   |
   = help: the following other types implement trait `WrapperTypeEncode`:
             &T
             &mut T
             Arc<T>
             Box<T>
-            Cow<'a, T>
+            Cow<'_, T>
             Rc<T>
             String
             Vec<T>
-            parity_scale_codec::Ref<'a, T, U>
+            parity_scale_codec::Ref<'_, T, U>
   = note: required for `Example` to implement `Encode`
 note: required by a bound in `MaxEncodedLen`
  --> src/max_encoded_len.rs
@@ -31,18 +31,18 @@ error[E0277]: the trait bound `Example: Encode` is not satisfied
  --> tests/max_encoded_len_ui/missing_crate_specifier.rs:8:10
   |
 8 |     let _ = Example::max_encoded_len();
-  |             ^^^^^^^ the trait `WrapperTypeEncode` is not implemented for `Example`, which is required by `Example: Encode`
+  |             ^^^^^^^ the trait `WrapperTypeEncode` is not implemented for `Example`
   |
   = help: the following other types implement trait `WrapperTypeEncode`:
             &T
             &mut T
             Arc<T>
             Box<T>
-            Cow<'a, T>
+            Cow<'_, T>
             Rc<T>
             String
             Vec<T>
-            parity_scale_codec::Ref<'a, T, U>
+            parity_scale_codec::Ref<'_, T, U>
   = note: required for `Example` to implement `Encode`
 note: required by a bound in `max_encoded_len`
  --> src/max_encoded_len.rs

--- a/tests/max_encoded_len_ui/not_encode.stderr
+++ b/tests/max_encoded_len_ui/not_encode.stderr
@@ -2,18 +2,18 @@ error[E0277]: the trait bound `NotEncode: Encode` is not satisfied
  --> tests/max_encoded_len_ui/not_encode.rs:4:8
   |
 4 | struct NotEncode;
-  |        ^^^^^^^^^ the trait `WrapperTypeEncode` is not implemented for `NotEncode`, which is required by `NotEncode: Encode`
+  |        ^^^^^^^^^ the trait `WrapperTypeEncode` is not implemented for `NotEncode`
   |
   = help: the following other types implement trait `WrapperTypeEncode`:
             &T
             &mut T
             Arc<T>
             Box<T>
-            Cow<'a, T>
+            Cow<'_, T>
             Rc<T>
             String
             Vec<T>
-            parity_scale_codec::Ref<'a, T, U>
+            parity_scale_codec::Ref<'_, T, U>
   = note: required for `NotEncode` to implement `Encode`
 note: required by a bound in `MaxEncodedLen`
  --> src/max_encoded_len.rs

--- a/tests/max_encoded_len_ui/not_encode.stderr
+++ b/tests/max_encoded_len_ui/not_encode.stderr
@@ -2,7 +2,7 @@ error[E0277]: the trait bound `NotEncode: Encode` is not satisfied
  --> tests/max_encoded_len_ui/not_encode.rs:4:8
   |
 4 | struct NotEncode;
-  |        ^^^^^^^^^ the trait `WrapperTypeEncode` is not implemented for `NotEncode`
+  |        ^^^^^^^^^ the trait `WrapperTypeEncode` is not implemented for `NotEncode`, which is required by `NotEncode: Encode`
   |
   = help: the following other types implement trait `WrapperTypeEncode`:
             &T

--- a/tests/mod.rs
+++ b/tests/mod.rs
@@ -112,6 +112,17 @@ enum TestCompactAttributeEnum {
 	},
 }
 
+// Check that we can properly derive encode/decode when discriminants are set to u32.
+#[repr(u32)]
+#[derive(DeriveEncode, DeriveDecode)]
+enum DigestItemType {
+    Other = 0u32,
+    Consensus = 4u32,
+    Seal = 5u32,
+    PreRuntime = 6u32,
+    RuntimeEnvironmentUpdated = 8u32,
+}
+
 #[test]
 fn should_work_for_simple_enum() {
 	let a = EnumType::A;

--- a/tests/mod.rs
+++ b/tests/mod.rs
@@ -29,7 +29,7 @@ struct Unit;
 struct Indexed(u32, u64);
 
 #[derive(Debug, PartialEq, DeriveEncode, DeriveDecode, DeriveDecodeWithMemTracking, Default)]
-struct Struct<A, B, C> {
+struct Struct<A, B, C> { 
 	pub a: A,
 	pub b: B,
 	pub c: C,
@@ -112,15 +112,23 @@ enum TestCompactAttributeEnum {
 	},
 }
 
-// Check that we can properly derive encode/decode when discriminants are set to u32.
+// Check that we can properly derive encode/decode with custom repr
 #[repr(u32)]
 #[derive(DeriveEncode, DeriveDecode)]
-enum DigestItemType {
+enum EnumWithU32Repr {
 	Other = 0u32,
 	Consensus = 4u32,
 	Seal = 5u32,
 	PreRuntime = 6u32,
 	RuntimeEnvironmentUpdated = 8u32,
+}
+
+// Check that we can properly derive encode/decode with custom repr
+#[repr(i32)]
+#[derive(DeriveEncode, DeriveDecode)]
+enum EnumWithI32Repr {
+	A = 1i32,
+	B = 2i32,
 }
 
 #[test]

--- a/tests/mod.rs
+++ b/tests/mod.rs
@@ -116,11 +116,11 @@ enum TestCompactAttributeEnum {
 #[repr(u32)]
 #[derive(DeriveEncode, DeriveDecode)]
 enum DigestItemType {
-    Other = 0u32,
-    Consensus = 4u32,
-    Seal = 5u32,
-    PreRuntime = 6u32,
-    RuntimeEnvironmentUpdated = 8u32,
+	Other = 0u32,
+	Consensus = 4u32,
+	Seal = 5u32,
+	PreRuntime = 6u32,
+	RuntimeEnvironmentUpdated = 8u32,
 }
 
 #[test]

--- a/tests/mod.rs
+++ b/tests/mod.rs
@@ -29,7 +29,7 @@ struct Unit;
 struct Indexed(u32, u64);
 
 #[derive(Debug, PartialEq, DeriveEncode, DeriveDecode, DeriveDecodeWithMemTracking, Default)]
-struct Struct<A, B, C> { 
+struct Struct<A, B, C> {
 	pub a: A,
 	pub b: B,
 	pub c: C,


### PR DESCRIPTION
Don't output suffixes when generating the index array in the const fun, to avoid the suffix types from conflicting with the declared type of the index array (usize) which leads to compile errors when indexes are from discriminants and are not usizes.

Should fix #686 