### PR TITLE
Enforce `parity-scale-codec-derive` version with `=x.y.z`.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -206,3 +206,20 @@ jobs:
 
       - name: Build for Linux (Ubuntu, AMD64)
         run: cargo build --verbose --release --features bit-vec,bytes,generic-array,derive
+
+  publish-dry-run:
+    runs-on: ubuntu-latest
+    needs: [ set-image, build-linux-ubuntu-amd64 ]
+    container: ${{ needs.set-image.outputs.IMAGE }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Cache Rust dependencies
+        uses: swatinem/rust-cache@v2
+        with:
+          key: ${{ runner.os }}-rust-${{ hashFiles('**/Cargo.lock') }}
+
+      - name: Dry Run Publish
+        if: github.event_name == 'pull_request'
+        run: cargo publish -p parity-scale-codec-derive --dry-run

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -206,20 +206,3 @@ jobs:
 
       - name: Build for Linux (Ubuntu, AMD64)
         run: cargo build --verbose --release --features bit-vec,bytes,generic-array,derive
-
-  publish-dry-run:
-    runs-on: ubuntu-latest
-    needs: [ set-image, build-linux-ubuntu-amd64 ]
-    container: ${{ needs.set-image.outputs.IMAGE }}
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-
-      - name: Cache Rust dependencies
-        uses: swatinem/rust-cache@v2
-        with:
-          key: ${{ runner.os }}-rust-${{ hashFiles('**/Cargo.lock') }}
-
-      - name: Dry Run Publish
-        if: github.event_name == 'pull_request'
-        run: cargo publish -p parity-scale-codec --dry-run

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,4 +20,6 @@ jobs:
           key: ${{ runner.os }}-rust-${{ hashFiles('**/Cargo.lock') }}
 
       - name: Publish Crate
-        run: cargo publish --token ${{ secrets.CARGO_REGISTRY_TOKEN }} -p parity-scale-codec
+        run: |
+          cargo publish --token ${{ secrets.CARGO_REGISTRY_TOKEN }} -p parity-scale-codec-derive
+          cargo publish --token ${{ secrets.CARGO_REGISTRY_TOKEN }} -p parity-scale-codec

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ rust-version.workspace = true
 [dependencies]
 arrayvec = { version = "0.7", default-features = false }
 serde = { version = "1.0.217", default-features = false, optional = true }
-parity-scale-codec-derive = { path = "derive", version = "3.6.8", default-features = false, optional = true }
+parity-scale-codec-derive = { path = "derive", version = "=3.7.3", default-features = false, optional = true }
 bitvec = { version = "1", default-features = false, features = ["alloc"], optional = true }
 bytes = { version = "1", default-features = false, optional = true }
 byte-slice-cast = { version = "1.2.2", default-features = false }


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/0ad5b669-7c1c-44be-a2de-d7168e775879)

Rust doc suggest this approach can be ok: https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html#version-metadata

I am not sure myself, but I think it can be better.