### PR TITLE
chore: max MaxEncodedLen derivation as automatically_derived

### DIFF
--- a/derive/src/max_encoded_len.rs
+++ b/derive/src/max_encoded_len.rs
@@ -54,6 +54,7 @@ pub fn derive_max_encoded_len(input: proc_macro::TokenStream) -> proc_macro::Tok
 
 	quote::quote!(
 		const _: () = {
+			#[automatically_derived]
 			impl #impl_generics #crate_path::MaxEncodedLen for #name #ty_generics #where_clause {
 				fn max_encoded_len() -> ::core::primitive::usize {
 					#data_expr


### PR DESCRIPTION
As per rust-lang/rust#120189, when marked with `#[automatically_derived]`, impl functions won't be included in coverage tests.

Although marked for `Decode`, the `check_struct` function is still shown in coverage tests, but this will be fixable when rust-lang/rust#84605 lands in stable.