### PR TITLE
Jam compact integers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,13 +7,19 @@ and this crate adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.h
 
 ## Unreleased
 
-### [3.7.4] - 2025-02-05
+## [3.8.0] - 2025-03-03
+
+### Added
+
+- Compact integer codec compatible with JAM specification enabled via `jam` feature.
+
+## [3.7.4] - 2025-02-05
 
 ### Added
 
 - Disallow duplicate indexes using constant evaluation ([#653](https://github.com/paritytech/parity-scale-codec/pull/653))
 
-### [3.7.3] - 2025-01-30
+## [3.7.3] - 2025-01-30
 
 ### Added
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -608,7 +608,7 @@ checksum = "0ab1bc2a289d34bd04a330323ac98a1b4bc82c9d9fcb1e66b63caa84da26b575"
 
 [[package]]
 name = "parity-scale-codec"
-version = "3.7.4"
+version = "3.8.0"
 dependencies = [
  "arbitrary",
  "arrayvec",
@@ -632,7 +632,7 @@ dependencies = [
 
 [[package]]
 name = "parity-scale-codec-derive"
-version = "3.7.4"
+version = "3.8.0"
 dependencies = [
  "parity-scale-codec",
  "proc-macro-crate",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,7 +68,7 @@ full = []
 members = ["derive", "fuzzer"]
 
 [workspace.package]
-version = "3.8.0"
+version = "3.7.4"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "Apache-2.0"
 repository = "https://github.com/paritytech/parity-scale-codec"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,6 +49,7 @@ derive = ["parity-scale-codec-derive"]
 std = ["serde/std", "bitvec?/std", "byte-slice-cast/std", "chain-error"]
 bit-vec = ["bitvec"]
 fuzz = ["std", "arbitrary"]
+jam = []
 
 # Enables the new `MaxEncodedLen` trait.
 # NOTE: This is still considered experimental and is exempt from the usual

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,6 +49,7 @@ derive = ["parity-scale-codec-derive"]
 std = ["serde/std", "bitvec?/std", "byte-slice-cast/std", "chain-error"]
 bit-vec = ["bitvec"]
 fuzz = ["std", "arbitrary"]
+# JAM compact unsigned integers
 jam = []
 
 # Enables the new `MaxEncodedLen` trait.
@@ -67,7 +68,7 @@ full = []
 members = ["derive", "fuzzer"]
 
 [workspace.package]
-version = "3.7.4"
+version = "3.8.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "Apache-2.0"
 repository = "https://github.com/paritytech/parity-scale-codec"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ rust-version.workspace = true
 [dependencies]
 arrayvec = { version = "0.7", default-features = false }
 serde = { version = "1.0.217", default-features = false, optional = true }
-parity-scale-codec-derive = { path = "derive", version = "=3.7.4", default-features = false, optional = true }
+parity-scale-codec-derive = { path = "derive", version = "=3.8.0", default-features = false, optional = true }
 bitvec = { version = "1", default-features = false, features = ["alloc"], optional = true }
 bytes = { version = "1", default-features = false, optional = true }
 byte-slice-cast = { version = "1.2.2", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ rust-version.workspace = true
 [dependencies]
 arrayvec = { version = "0.7", default-features = false }
 serde = { version = "1.0.217", default-features = false, optional = true }
-parity-scale-codec-derive = { path = "derive", version = "=3.8.0", default-features = false, optional = true }
+parity-scale-codec-derive = { path = "derive", default-features = false, optional = true }
 bitvec = { version = "1", default-features = false, features = ["alloc"], optional = true }
 bytes = { version = "1", default-features = false, optional = true }
 byte-slice-cast = { version = "1.2.2", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,7 +68,7 @@ full = []
 members = ["derive", "fuzzer"]
 
 [workspace.package]
-version = "3.7.4"
+version = "3.8.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "Apache-2.0"
 repository = "https://github.com/paritytech/parity-scale-codec"

--- a/src/compact.rs
+++ b/src/compact.rs
@@ -908,7 +908,7 @@ mod compact_primitives {
 
 #[cfg(not(feature = "jam"))]
 #[cfg(test)]
-mod tests_ext {
+pub(crate) mod tests_ext {
 	use super::*;
 	use compact_primitives::*;
 
@@ -1000,116 +1000,209 @@ mod tests_ext {
 			check_bound_high!(i, [(u128, U128_OUT_OF_RANGE)]);
 		}
 	}
+
+	pub const COMPACT_U8_CASES: &[(u8, usize)] = &[(0, 1), (63, 1), (64, 2), (255, 2)];
+
+	pub const COMPACT_U16_CASES: &[(u16, usize)] =
+		&[(0, 1), (63, 1), (64, 2), (16383, 2), (16384, 4), (65535, 4)];
+
+	pub const COMPACT_U32_CASES: &[(u32, usize)] = &[
+		(0, 1),
+		(63, 1),
+		(64, 2),
+		(16383, 2),
+		(16384, 4),
+		(1073741823, 4),
+		(1073741824, 5),
+		(u32::MAX, 5),
+	];
+
+	pub const COMPACT_U64_CASES: &[(u64, usize)] = &[
+		(0, 1),
+		(63, 1),
+		(64, 2),
+		(16383, 2),
+		(16384, 4),
+		(1073741823, 4),
+		(1073741824, 5),
+		((1 << 32) - 1, 5),
+		(1 << 32, 6),
+		(1 << 40, 7),
+		(1 << 48, 8),
+		((1 << 56) - 1, 8),
+		(1 << 56, 9),
+		(u64::MAX, 9),
+	];
+
+	pub const COMPACT_U128_CASES: &[(u128, usize)] = &[
+		(0, 1),
+		(63, 1),
+		(64, 2),
+		(16383, 2),
+		(16384, 4),
+		(1073741823, 4),
+		(1073741824, 5),
+		((1 << 32) - 1, 5),
+		(1 << 32, 6),
+		(1 << 40, 7),
+		(1 << 48, 8),
+		((1 << 56) - 1, 8),
+		(1 << 56, 9),
+		((1 << 64) - 1, 9),
+		(1 << 64, 10),
+		(1 << 72, 11),
+		(1 << 80, 12),
+		(1 << 88, 13),
+		(1 << 96, 14),
+		(1 << 104, 15),
+		(1 << 112, 16),
+		((1 << 120) - 1, 16),
+		(1 << 120, 17),
+		(u128::MAX, 17),
+	];
+
+	pub const INTEGERS_ENCODING_EXP: &[(u64, &str)] = &[
+		(0, "00"),
+		(63, "fc"),
+		(64, "01 01"),
+		(16383, "fd ff"),
+		(16384, "02 00 01 00"),
+		(1073741823, "fe ff ff ff"),
+		(1073741824, "03 00 00 00 40"),
+		((1 << 32) - 1, "03 ff ff ff ff"),
+		(1 << 32, "07 00 00 00 00 01"),
+		(1 << 40, "0b 00 00 00 00 00 01"),
+		(1 << 48, "0f 00 00 00 00 00 00 01"),
+		((1 << 56) - 1, "0f ff ff ff ff ff ff ff"),
+		(1 << 56, "13 00 00 00 00 00 00 00 01"),
+		(u64::MAX, "13 ff ff ff ff ff ff ff ff"),
+	];
+}
+
+#[cfg(feature = "jam")]
+#[cfg(test)]
+mod tests_ext {
+	pub const COMPACT_U8_CASES: &[(u8, usize)] = &[(0, 1), (63, 1), (64, 1), (255, 2)];
+
+	pub const COMPACT_U16_CASES: &[(u16, usize)] =
+		&[(0, 1), (63, 1), (64, 1), (16383, 2), (16384, 3), (65535, 3)];
+
+	pub const COMPACT_U32_CASES: &[(u32, usize)] = &[
+		(0, 1),
+		(63, 1),
+		(64, 1),
+		(16383, 2),
+		(16384, 3),
+		(1073741823, 5),
+		(1073741824, 5),
+		(u32::MAX, 5),
+	];
+
+	pub const COMPACT_U64_CASES: &[(u64, usize)] = &[
+		(0, 1),
+		(63, 1),
+		(64, 1),
+		(16383, 2),
+		(16384, 3),
+		(1073741823, 5),
+		(1073741824, 5),
+		((1 << 32) - 1, 5),
+		(1 << 32, 5),
+		(1 << 40, 6),
+		(1 << 48, 7),
+		((1 << 56) - 1, 8),
+		(1 << 56, 9),
+		(u64::MAX, 9),
+	];
+
+	pub const COMPACT_U128_CASES: &[(u128, usize)] = &[
+		(0, 2),
+		(63, 2),
+		(64, 2),
+		(16383, 3),
+		(16384, 4),
+		(1073741823, 6),
+		(1073741824, 6),
+		((1 << 32) - 1, 6),
+		(1 << 32, 6),
+		(1 << 40, 7), //10
+		(1 << 48, 8),
+		((1 << 56) - 1, 9),
+		(1 << 56, 10),
+		((1 << 64) - 1, 10),
+		(1 << 64, 2),
+		(1 << 72, 3),
+		(1 << 80, 4),
+		(1 << 88, 5),
+		(1 << 96, 6),
+		(1 << 104, 7), //20
+		(1 << 112, 8),
+		((1 << 120) - 1, 17),
+		(1 << 120, 10),
+		(u128::MAX, 18),
+	];
+
+	pub const INTEGERS_ENCODING_EXP: &[(u64, &str)] = &[
+		(0, "00"),
+		(63, "3f"),
+		(64, "40"),
+		(16383, "bf ff"),
+		(16384, "c0 00 40"),
+		(1073741823, "f0 ff ff ff 3f"),
+		(1073741824, "f0 00 00 00 40"),
+		((1 << 32) - 1, "f0 ff ff ff ff"),
+		(1 << 32, "f1 00 00 00 00"),
+		(1 << 40, "f9 00 00 00 00 00"),
+		(1 << 48, "fd 00 00 00 00 00 00"),
+		((1 << 56) - 1, "fe ff ff ff ff ff ff ff"),
+		(1 << 56, "ff 00 00 00 00 00 00 00 01"),
+		(u64::MAX, "ff ff ff ff ff ff ff ff ff"),
+	];
 }
 
 #[cfg(test)]
 mod tests {
 	use super::*;
+	use tests_ext::*;
 
-	#[test]
-	fn compact_128_encoding_works() {
-		let tests = [
-			(0u128, 1usize),
-			(63, 1),
-			(64, 2),
-			(16383, 2),
-			(16384, 4),
-			(1073741823, 4),
-			(1073741824, 5),
-			((1 << 32) - 1, 5),
-			(1 << 32, 6),
-			(1 << 40, 7),
-			(1 << 48, 8),
-			((1 << 56) - 1, 8),
-			(1 << 56, 9),
-			((1 << 64) - 1, 9),
-			(1 << 64, 10),
-			(1 << 72, 11),
-			(1 << 80, 12),
-			(1 << 88, 13),
-			(1 << 96, 14),
-			(1 << 104, 15),
-			(1 << 112, 16),
-			((1 << 120) - 1, 16),
-			(1 << 120, 17),
-			(u128::MAX, 17),
-		];
-		for &(n, l) in &tests {
+	fn compact_encoding_works<T>(cases: &[(T, usize)])
+	where
+		T: std::fmt::Debug + PartialEq + Eq + Copy,
+		Compact<T>: Encode + Decode + CompactLen<T>,
+	{
+		for &(n, l) in cases {
 			let encoded = Compact(n).encode();
 			assert_eq!(encoded.len(), l);
 			assert_eq!(Compact::compact_len(&n), l);
-			assert_eq!(<Compact<u128>>::decode(&mut &encoded[..]).unwrap().0, n);
+			assert_eq!(<Compact<T>>::decode(&mut &encoded[..]).unwrap().0, n);
 		}
-	}
-
-	#[test]
-	fn compact_64_encoding_works() {
-		let tests = [
-			(0u64, 1usize),
-			(63, 1),
-			(64, 2),
-			(16383, 2),
-			(16384, 4),
-			(1073741823, 4),
-			(1073741824, 5),
-			((1 << 32) - 1, 5),
-			(1 << 32, 6),
-			(1 << 40, 7),
-			(1 << 48, 8),
-			((1 << 56) - 1, 8),
-			(1 << 56, 9),
-			(u64::MAX, 9),
-		];
-		for &(n, l) in &tests {
-			let encoded = Compact(n).encode();
-			assert_eq!(encoded.len(), l);
-			assert_eq!(Compact::compact_len(&n), l);
-			assert_eq!(<Compact<u64>>::decode(&mut &encoded[..]).unwrap().0, n);
-		}
-	}
-
-	#[test]
-	fn compact_32_encoding_works() {
-		let tests = [
-			(0u32, 1usize),
-			(63, 1),
-			(64, 2),
-			(16383, 2),
-			(16384, 4),
-			(1073741823, 4),
-			(1073741824, 5),
-			(u32::MAX, 5),
-		];
-		for &(n, l) in &tests {
-			let encoded = Compact(n).encode();
-			assert_eq!(encoded.len(), l);
-			assert_eq!(Compact::compact_len(&n), l);
-			assert_eq!(<Compact<u32>>::decode(&mut &encoded[..]).unwrap().0, n);
-		}
-	}
-
-	#[test]
-	fn compact_16_encoding_works() {
-		let tests = [(0u16, 1usize), (63, 1), (64, 2), (16383, 2), (16384, 4), (65535, 4)];
-		for &(n, l) in &tests {
-			let encoded = Compact(n).encode();
-			assert_eq!(encoded.len(), l);
-			assert_eq!(Compact::compact_len(&n), l);
-			assert_eq!(<Compact<u16>>::decode(&mut &encoded[..]).unwrap().0, n);
-		}
-		assert!(<Compact<u16>>::decode(&mut &Compact(65536u32).encode()[..]).is_err());
 	}
 
 	#[test]
 	fn compact_8_encoding_works() {
-		let tests = [(0u8, 1usize), (63, 1), (64, 2), (255, 2)];
-		for &(n, l) in &tests {
-			let encoded = Compact(n).encode();
-			assert_eq!(encoded.len(), l);
-			assert_eq!(Compact::compact_len(&n), l);
-			assert_eq!(<Compact<u8>>::decode(&mut &encoded[..]).unwrap().0, n);
-		}
+		compact_encoding_works::<u8>(COMPACT_U8_CASES);
 		assert!(<Compact<u8>>::decode(&mut &Compact(256u32).encode()[..]).is_err());
+	}
+
+	#[test]
+	fn compact_16_encoding_works() {
+		compact_encoding_works::<u16>(COMPACT_U16_CASES);
+		assert!(<Compact<u16>>::decode(&mut &Compact(65536u32).encode()[..]).is_err());
+	}
+
+	#[test]
+	fn compact_32_encoding_works() {
+		compact_encoding_works::<u32>(COMPACT_U32_CASES);
+	}
+
+	#[test]
+	fn compact_64_encoding_works() {
+		compact_encoding_works::<u64>(COMPACT_U64_CASES);
+	}
+
+	#[test]
+	fn compact_128_encoding_works() {
+		compact_encoding_works::<u128>(COMPACT_U128_CASES);
 	}
 
 	fn hexify(bytes: &[u8]) -> String {
@@ -1122,23 +1215,7 @@ mod tests {
 
 	#[test]
 	fn compact_integers_encoded_as_expected() {
-		let tests = [
-			(0u64, "00"),
-			(63, "fc"),
-			(64, "01 01"),
-			(16383, "fd ff"),
-			(16384, "02 00 01 00"),
-			(1073741823, "fe ff ff ff"),
-			(1073741824, "03 00 00 00 40"),
-			((1 << 32) - 1, "03 ff ff ff ff"),
-			(1 << 32, "07 00 00 00 00 01"),
-			(1 << 40, "0b 00 00 00 00 00 01"),
-			(1 << 48, "0f 00 00 00 00 00 00 01"),
-			((1 << 56) - 1, "0f ff ff ff ff ff ff ff"),
-			(1 << 56, "13 00 00 00 00 00 00 00 01"),
-			(u64::MAX, "13 ff ff ff ff ff ff ff ff"),
-		];
-		for &(n, s) in &tests {
+		for &(n, s) in INTEGERS_ENCODING_EXP {
 			// Verify u64 encoding
 			let encoded = Compact(n).encode();
 			assert_eq!(hexify(&encoded), s);
@@ -1188,8 +1265,7 @@ mod tests {
 
 	#[test]
 	fn compact_as_8_encoding_works() {
-		let tests = [(0u8, 1usize), (63, 1), (64, 2), (255, 2)];
-		for &(n, l) in &tests {
+		for &(n, l) in COMPACT_U8_CASES {
 			let compact: Compact<Wrapper> = Wrapper(n).into();
 			let encoded = compact.encode();
 			assert_eq!(encoded.len(), l);

--- a/src/depth_limit.rs
+++ b/src/depth_limit.rs
@@ -90,7 +90,7 @@ impl<T: Decode> DecodeLimit for T {
 #[cfg(test)]
 mod tests {
 	use super::*;
-	use crate::Encode;
+	use crate::{Compact, Encode};
 
 	#[test]
 	fn decode_limit_works() {
@@ -110,8 +110,10 @@ mod tests {
 		let encoded = nested.encode();
 		let encoded_slice = &mut encoded.as_slice();
 
+		println!("{:?}", encoded);
 		let decoded = Vec::<u8>::decode_with_depth_limit(1, encoded_slice).unwrap();
-		assert_eq!(decoded, vec![4]);
+		let expected = Compact(1_u32).encode();
+		assert_eq!(decoded, expected);
 		assert!(NestedVec::decode_with_depth_limit(3, encoded_slice).is_err());
 	}
 

--- a/tests/single_field_struct_encoding.rs
+++ b/tests/single_field_struct_encoding.rs
@@ -109,6 +109,7 @@ where
 #[test]
 fn test_encoding() {
 	let x = 3u32;
+	let x_compact_encoded = Compact(x).encode()[0];
 	let s = S { x };
 	let s_skip = SSkip { x, s1: Default::default(), s2: Default::default() };
 	let sc = Sc { x };
@@ -124,16 +125,16 @@ fn test_encoding() {
 
 	let mut s_encoded: &[u8] = &[3, 0, 0, 0];
 	let mut s_skip_encoded: &[u8] = &[3, 0, 0, 0];
-	let mut sc_encoded: &[u8] = &[12];
-	let mut sh_encoded: &[u8] = &[12];
+	let mut sc_encoded: &[u8] = &[x_compact_encoded];
+	let mut sh_encoded: &[u8] = &[x_compact_encoded];
 	let mut u_encoded: &[u8] = &[3, 0, 0, 0];
 	let mut u_skip_encoded: &[u8] = &[3, 0, 0, 0];
-	let mut uc_encoded: &[u8] = &[12];
-	let mut ucom_encoded: &[u8] = &[12];
-	let mut ucas_encoded: &[u8] = &[12];
-	let mut u_skip_cas_encoded: &[u8] = &[12];
-	let mut s_skip_cas_encoded: &[u8] = &[12];
-	let mut uh_encoded: &[u8] = &[12];
+	let mut uc_encoded: &[u8] = &[x_compact_encoded];
+	let mut ucom_encoded: &[u8] = &[x_compact_encoded];
+	let mut ucas_encoded: &[u8] = &[x_compact_encoded];
+	let mut u_skip_cas_encoded: &[u8] = &[x_compact_encoded];
+	let mut s_skip_cas_encoded: &[u8] = &[x_compact_encoded];
+	let mut uh_encoded: &[u8] = &[x_compact_encoded];
 
 	assert_eq!(s.encode(), s_encoded);
 	assert_eq!(s_skip.encode(), s_skip_encoded);


### PR DESCRIPTION
Introduce `jam` feature to unlock new compact unsigned integers codec designed for JAM.

Version bump to 3.8.0

In PolkaJam we are currently using a fork, we wish to reconcile our changes with upstream.

---

Basically `compact` module contain two mutually exclusive `compact_primitives` submodules. One with the traditional SCALE codec and another with the one defined by JAM.

The "traditional" one is untouched.

The rest of the PR is about making the tests work with the new codec
