### PR TITLE
Make `mem_size_of_btree` pub but gated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this crate adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.h
 
 ## Unreleased
 
+### [3.7.5] - 2025-03-17
+
+### Added
+
+- Make `mem_size_of_btree` pub so it can be reused externally with the `btree-utils` feature ([#721](https://github.com/paritytech/parity-scale-codec/pull/721)).
+
 ### [3.7.4] - 2025-02-05
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -609,7 +609,7 @@ checksum = "0ab1bc2a289d34bd04a330323ac98a1b4bc82c9d9fcb1e66b63caa84da26b575"
 
 [[package]]
 name = "parity-scale-codec"
-version = "3.7.4"
+version = "3.7.5"
 dependencies = [
  "arbitrary",
  "arrayvec",
@@ -633,7 +633,7 @@ dependencies = [
 
 [[package]]
 name = "parity-scale-codec-derive"
-version = "3.7.4"
+version = "3.7.5"
 dependencies = [
  "parity-scale-codec",
  "proc-macro-crate",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ rust-version.workspace = true
 [dependencies]
 arrayvec = { version = "0.7", default-features = false }
 serde = { version = "1.0.218", default-features = false, optional = true }
-parity-scale-codec-derive = { path = "derive", version = "=3.7.4", default-features = false, optional = true }
+parity-scale-codec-derive = { path = "derive", version = "=3.7.5", default-features = false, optional = true }
 bitvec = { version = "1", default-features = false, features = ["alloc"], optional = true }
 bytes = { version = "1", default-features = false, optional = true }
 byte-slice-cast = { version = "1.2.3", default-features = false }
@@ -70,7 +70,7 @@ full = []
 members = ["derive", "fuzzer"]
 
 [workspace.package]
-version = "3.7.4"
+version = "3.7.5"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "Apache-2.0"
 repository = "https://github.com/paritytech/parity-scale-codec"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,6 +50,10 @@ std = ["serde/std", "bitvec?/std", "byte-slice-cast/std", "chain-error"]
 bit-vec = ["bitvec"]
 fuzz = ["std", "arbitrary"]
 
+# Exposes unstable BTree memory size estimation function. We do not guarantee
+# no code breakage when using this.
+btree-utils = []
+
 # Enables the new `MaxEncodedLen` trait.
 # NOTE: This is still considered experimental and is exempt from the usual
 # SemVer guarantees. We do not guarantee no code breakage when using this.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -95,6 +95,12 @@ pub use const_encoded_len::ConstEncodedLen;
 #[cfg(feature = "max-encoded-len")]
 pub use max_encoded_len::MaxEncodedLen;
 
+/// Function to estimate the memory size of a BTree.
+///
+/// Should not be considered stable.
+#[cfg(feature = "btree-utils")]
+pub use btree_utils::mem_size_of_btree;
+
 /// Derive macro for [`MaxEncodedLen`][max_encoded_len::MaxEncodedLen].
 ///
 /// # Examples


### PR DESCRIPTION
This allows it to be used in e.g. [`BoundedBTree` decoding](https://github.com/paritytech/parity-common/pull/906).

Feature gated to avoid the details of the implementation becoming part of the public API.
Could be persuaded to drop the gate, but it has already been done for `MaxEncodedLen` etc.