### PR TITLE
Fix typo

### DIFF
--- a/derive/src/utils.rs
+++ b/derive/src/utils.rs
@@ -502,7 +502,7 @@ fn check_top_attribute(attr: &Attribute) -> syn::Result<()> {
 	let top_error = "Invalid attribute: only `#[codec(dumb_trait_bound)]`, \
 		`#[codec(crate = path::to::crate)]`, `#[codec(encode_bound(T: Encode))]`, \
 		`#[codec(decode_bound(T: Decode))]`, \
-		`#[codec(decode_bound_with_mem_tracking_bound(T: DecodeWithMemTracking))]` or \
+		`#[codec(decode_with_mem_tracking_bound(T: DecodeWithMemTracking))]` or \
 		`#[codec(mel_bound(T: MaxEncodedLen))]` are accepted as top attribute";
 	if attr.path().is_ident("codec") &&
 		attr.parse_args::<CustomTraitBound<encode_bound>>().is_err() &&

--- a/tests/max_encoded_len_ui/crate_str.stderr
+++ b/tests/max_encoded_len_ui/crate_str.stderr
@@ -1,4 +1,4 @@
-error: Invalid attribute: only `#[codec(dumb_trait_bound)]`, `#[codec(crate = path::to::crate)]`, `#[codec(encode_bound(T: Encode))]`, `#[codec(decode_bound(T: Decode))]`, `#[codec(decode_bound_with_mem_tracking_bound(T: DecodeWithMemTracking))]` or `#[codec(mel_bound(T: MaxEncodedLen))]` are accepted as top attribute
+error: Invalid attribute: only `#[codec(dumb_trait_bound)]`, `#[codec(crate = path::to::crate)]`, `#[codec(encode_bound(T: Encode))]`, `#[codec(decode_bound(T: Decode))]`, `#[codec(decode_with_mem_tracking_bound(T: DecodeWithMemTracking))]` or `#[codec(mel_bound(T: MaxEncodedLen))]` are accepted as top attribute
  --> tests/max_encoded_len_ui/crate_str.rs:4:9
   |
 4 | #[codec(crate = "parity_scale_codec")]

--- a/tests/max_encoded_len_ui/incomplete_attr.stderr
+++ b/tests/max_encoded_len_ui/incomplete_attr.stderr
@@ -1,4 +1,4 @@
-error: Invalid attribute: only `#[codec(dumb_trait_bound)]`, `#[codec(crate = path::to::crate)]`, `#[codec(encode_bound(T: Encode))]`, `#[codec(decode_bound(T: Decode))]`, `#[codec(decode_bound_with_mem_tracking_bound(T: DecodeWithMemTracking))]` or `#[codec(mel_bound(T: MaxEncodedLen))]` are accepted as top attribute
+error: Invalid attribute: only `#[codec(dumb_trait_bound)]`, `#[codec(crate = path::to::crate)]`, `#[codec(encode_bound(T: Encode))]`, `#[codec(decode_bound(T: Decode))]`, `#[codec(decode_with_mem_tracking_bound(T: DecodeWithMemTracking))]` or `#[codec(mel_bound(T: MaxEncodedLen))]` are accepted as top attribute
  --> tests/max_encoded_len_ui/incomplete_attr.rs:4:9
   |
 4 | #[codec(crate)]

--- a/tests/max_encoded_len_ui/missing_crate_specifier.stderr
+++ b/tests/max_encoded_len_ui/missing_crate_specifier.stderr
@@ -1,4 +1,4 @@
-error: Invalid attribute: only `#[codec(dumb_trait_bound)]`, `#[codec(crate = path::to::crate)]`, `#[codec(encode_bound(T: Encode))]`, `#[codec(decode_bound(T: Decode))]`, `#[codec(decode_bound_with_mem_tracking_bound(T: DecodeWithMemTracking))]` or `#[codec(mel_bound(T: MaxEncodedLen))]` are accepted as top attribute
+error: Invalid attribute: only `#[codec(dumb_trait_bound)]`, `#[codec(crate = path::to::crate)]`, `#[codec(encode_bound(T: Encode))]`, `#[codec(decode_bound(T: Decode))]`, `#[codec(decode_with_mem_tracking_bound(T: DecodeWithMemTracking))]` or `#[codec(mel_bound(T: MaxEncodedLen))]` are accepted as top attribute
  --> tests/max_encoded_len_ui/missing_crate_specifier.rs:4:9
   |
 4 | #[codec(parity_scale_codec)]


### PR DESCRIPTION
Small typo in error message for codec(decode_with_mem_tracking_bound()) attribute usage.