### PR TITLE
Fix derive(Decode) for enums with lifetime parameters and struct-like variants

### DIFF
--- a/derive/src/decode.rs
+++ b/derive/src/decode.rs
@@ -50,7 +50,7 @@ pub fn quote(
 				let index = utils::variant_index(v, i);
 
 				let create = create_instance(
-					quote! { #type_name #type_generics :: #name },
+					quote! { #type_name :: #name #type_generics },
 					&format!("{}::{}", type_name, name),
 					input,
 					&v.fields,

--- a/tests/mod.rs
+++ b/tests/mod.rs
@@ -949,21 +949,17 @@ fn derive_decode_for_enum_with_lifetime_param_and_struct_like_variant() {
 	// An enum that has a lifetime parameter and a struct-like variant.
 	#[derive(PartialEq, Eq, Debug, DeriveDecode, DeriveEncode)]
 	enum Enum<'a> {
-		StructLike {
-			val: u8
-		},
+		StructLike { val: u8 },
 		// For completeness, also check a struct-like variant that actually uses the lifetime,
 		// as well as the corresponding tuple-like variants.
-		StructLikeCow {
-			val: Cow<'a, u8>
-		},
+		StructLikeCow { val: Cow<'a, u8> },
 		TupleLike(u8),
-		TupleLikeCow(Cow<'a, u8>)
+		TupleLikeCow(Cow<'a, u8>),
 	}
 
 	let val = 123;
 	let objs = vec![
-		Enum::StructLike { val: 234},
+		Enum::StructLike { val: 234 },
 		Enum::StructLikeCow { val: Cow::Borrowed(&val) },
 		Enum::TupleLike(234),
 		Enum::TupleLikeCow(Cow::Borrowed(&val)),


### PR DESCRIPTION
For an enum like this:
```
enum Enum<'a> {
    StructLike {
        val: u8
    },
    ... // Some other variants that use 'a
}
```
deriving `Decoode` will currently produce the compile-time error "lifetime arguments are not allowed on variant `StructLike`".

This is because the generated code creates an enum instance using the syntax `Enum::<'a>::StructLike { ... }` which the Rust compiler doesn't like (specifically, it doesn't like it when the generic parameter is a lifetime AND the variant is struct-like, but in other cases it doesn't mind).

Fortunately, the syntax `EnumName::VariantName::<GenericParam> ...` works in all cases.