### PR TITLE
Fix `DecodeWithMemTracking` bounds for `Cow`

### DIFF
--- a/src/codec.rs
+++ b/src/codec.rs
@@ -1059,8 +1059,10 @@ where
 	}
 }
 
-impl<'a, T: ToOwned + DecodeWithMemTracking> DecodeWithMemTracking for Cow<'a, T> where
-	Cow<'a, T>: Decode
+impl<'a, T: ToOwned + ?Sized> DecodeWithMemTracking for Cow<'a, T>
+where
+	Cow<'a, T>: Decode,
+	T::Owned: DecodeWithMemTracking,
 {
 }
 

--- a/tests/mod.rs
+++ b/tests/mod.rs
@@ -15,8 +15,7 @@
 use std::borrow::Cow;
 
 use parity_scale_codec::{
-	Compact, CompactAs, Decode, DecodeWithMemTracking, Encode, EncodeAsRef, Error, HasCompact,
-	Output,
+	Compact, CompactAs, Decode, DecodeWithMemLimit, DecodeWithMemTracking, Encode, EncodeAsRef, Error, HasCompact, Output
 };
 use parity_scale_codec_derive::{
 	Decode as DeriveDecode, DecodeWithMemTracking as DeriveDecodeWithMemTracking,
@@ -968,4 +967,13 @@ fn derive_decode_for_enum_with_lifetime_param_and_struct_like_variant() {
 	let data = objs.encode();
 	let objs_d = Vec::<Enum>::decode(&mut &data[..]).unwrap();
 	assert_eq!(objs_d, objs);
+}
+
+#[test]
+fn cow_str_decode_with_mem_tracking() {
+	let data = Cow::<'static, str>::from("hello");
+	let encoded = data.encode();
+
+	let decoded = Cow::<'static, str>::decode_with_mem_limit(&mut &encoded[..], 6).unwrap();
+	assert_eq!(data, decoded);
 }

--- a/tests/mod.rs
+++ b/tests/mod.rs
@@ -15,7 +15,8 @@
 use std::borrow::Cow;
 
 use parity_scale_codec::{
-	Compact, CompactAs, Decode, DecodeWithMemLimit, DecodeWithMemTracking, Encode, EncodeAsRef, Error, HasCompact, Output
+	Compact, CompactAs, Decode, DecodeWithMemLimit, DecodeWithMemTracking, Encode, EncodeAsRef,
+	Error, HasCompact, Output,
 };
 use parity_scale_codec_derive::{
 	Decode as DeriveDecode, DecodeWithMemTracking as DeriveDecodeWithMemTracking,


### PR DESCRIPTION
The current bounds for `Cow` are incorrect and make `Cow` unusable with `DecodeWithMemTracking`. This is a breaking change, but as before it was not working no code should break by this.

Fixes: https://github.com/paritytech/parity-scale-codec/issues/734