### PR TITLE
Release 3.7.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this crate adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.h
 
 ## Unreleased
 
+### [3.7.5] - 2025-05-20
+
+### Fixed
+
+- Implement `on_before_alloc_mem()` for `CountedInput` [#716](https://github.com/paritytech/parity-scale-codec/pull/716)
+- Fix derive(Decode) for enums with lifetime parameters and struct-like variants
+  [#726](https://github.com/paritytech/parity-scale-codec/pull/726)
+- Fix performance regression ([#731](https://github.com/paritytech/parity-scale-codec/pull/731))
+- Fix `DecodeWithMemTracking` bounds for `Cow` [#735](https://github.com/paritytech/parity-scale-codec/pull/735)
+
+
 ### [3.7.4] - 2025-02-05
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -609,7 +609,7 @@ checksum = "0ab1bc2a289d34bd04a330323ac98a1b4bc82c9d9fcb1e66b63caa84da26b575"
 
 [[package]]
 name = "parity-scale-codec"
-version = "3.7.4"
+version = "3.7.5"
 dependencies = [
  "arbitrary",
  "arrayvec",
@@ -633,7 +633,7 @@ dependencies = [
 
 [[package]]
 name = "parity-scale-codec-derive"
-version = "3.7.4"
+version = "3.7.5"
 dependencies = [
  "parity-scale-codec",
  "proc-macro-crate",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ rust-version.workspace = true
 [dependencies]
 arrayvec = { version = "0.7", default-features = false }
 serde = { version = "1.0.219", default-features = false, optional = true }
-parity-scale-codec-derive = { path = "derive", version = "=3.7.4", default-features = false, optional = true }
+parity-scale-codec-derive = { path = "derive", version = "=3.7.5", default-features = false, optional = true }
 bitvec = { version = "1", default-features = false, features = ["alloc"], optional = true }
 bytes = { version = "1", default-features = false, optional = true }
 byte-slice-cast = { version = "1.2.3", default-features = false }
@@ -66,7 +66,7 @@ full = []
 members = ["derive", "fuzzer"]
 
 [workspace.package]
-version = "3.7.4"
+version = "3.7.5"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "Apache-2.0"
 repository = "https://github.com/paritytech/parity-scale-codec"


### PR DESCRIPTION
Related to: https://github.com/paritytech/parity-scale-codec/issues/734

Preparing release 3.7.5

`polkadot-sdk` successful CI run using `parity-scale-codec 3.7.5`: https://github.com/paritytech/polkadot-sdk/pull/8569