### PR TITLE
fix(dependencies): set minimal version of `rustversion` to `1.0.6`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,11 +30,11 @@ quickcheck = "1.0"
 proptest = "1.7.0"
 trybuild = "1.0.110"
 paste = "1"
-rustversion = "1"
+rustversion = "1.0.6"
 enumflags2 = "0.7.12"
 
 [build-dependencies]
-rustversion = "1"
+rustversion = "1.0.6"
 
 [[bench]]
 name = "benches"


### PR DESCRIPTION
```
error[E0433]: failed to resolve: could not find `cfg` in `rustversion`
 --> /home/runner/.cargo/registry/src/index.crates.io-6f17d22bba15001f/parity-scale-codec-3.7.5/build.rs:3:18
  |
3 |     if rustversion::cfg!(nightly) {
  |                     ^^^ could not find `cfg` in `rustversion`
```
[CI build](https://github.com/StackOverflowExcept1on/frost/actions/runs/17329753911/job/49202781360)
