### PR TITLE
Pin GH actions to a specific hash

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
     container: ${{ needs.set-image.outputs.IMAGE }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
 
       - name: Show Cargo version
         run: cargo +nightly -vV
@@ -43,7 +43,7 @@ jobs:
     container: ${{ needs.set-image.outputs.IMAGE }}
     steps:
       - name: Checkout code/.
-        uses: actions/checkout@v5
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
 
       - name: Show Rust version
         run: |
@@ -52,7 +52,7 @@ jobs:
           rustup show
 
       - name: Cache Rust dependencies
-        uses: swatinem/rust-cache@v2
+        uses: swatinem/rust-cache@98c8021b550208e191a6a3145459bfc9fb29c4c0 # v2.8.0
         with:
           key: ${{ runner.os }}-rust-${{ hashFiles('**/Cargo.lock') }}
 
@@ -68,7 +68,7 @@ jobs:
     container: ${{ needs.set-image.outputs.IMAGE }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
 
       - name: Show Rust version
         run: |
@@ -77,7 +77,7 @@ jobs:
           rustup show
 
       - name: Cache Rust dependencies
-        uses: swatinem/rust-cache@v2
+        uses: swatinem/rust-cache@98c8021b550208e191a6a3145459bfc9fb29c4c0 # v2.8.0
         with:
           key: ${{ runner.os }}-rust-${{ hashFiles('**/Cargo.lock') }}
 
@@ -106,7 +106,7 @@ jobs:
     container: ${{ needs.set-image.outputs.IMAGE }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
 
       - name: Show Rust version
         run: |
@@ -115,7 +115,7 @@ jobs:
           rustup show
 
       - name: Cache Rust dependencies
-        uses: swatinem/rust-cache@v2
+        uses: swatinem/rust-cache@98c8021b550208e191a6a3145459bfc9fb29c4c0 # v2.8.0
         with:
           key: ${{ runner.os }}-rust-${{ hashFiles('**/Cargo.lock') }}
 
@@ -154,10 +154,10 @@ jobs:
     container: ${{ needs.set-image.outputs.IMAGE }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
 
       - name: Cache Rust dependencies
-        uses: swatinem/rust-cache@v2
+        uses: swatinem/rust-cache@98c8021b550208e191a6a3145459bfc9fb29c4c0 # v2.8.0
         with:
           key: ${{ runner.os }}-rust-${{ hashFiles('**/Cargo.lock') }}
 
@@ -175,10 +175,10 @@ jobs:
     container: ${{ needs.set-image.outputs.IMAGE }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
 
       - name: Cache Rust dependencies
-        uses: swatinem/rust-cache@v2
+        uses: swatinem/rust-cache@98c8021b550208e191a6a3145459bfc9fb29c4c0 # v2.8.0
         with:
           key: ${{ runner.os }}-rust-${{ hashFiles('**/Cargo.lock') }}
 
@@ -197,10 +197,10 @@ jobs:
     container: ${{ needs.set-image.outputs.IMAGE }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
 
       - name: Cache Rust dependencies
-        uses: swatinem/rust-cache@v2
+        uses: swatinem/rust-cache@98c8021b550208e191a6a3145459bfc9fb29c4c0 # v2.8.0
         with:
           key: ${{ runner.os }}-rust-${{ hashFiles('**/Cargo.lock') }}
 
@@ -213,10 +213,10 @@ jobs:
     container: ${{ needs.set-image.outputs.IMAGE }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
 
       - name: Cache Rust dependencies
-        uses: swatinem/rust-cache@v2
+        uses: swatinem/rust-cache@98c8021b550208e191a6a3145459bfc9fb29c4c0 # v2.8.0
         with:
           key: ${{ runner.os }}-rust-${{ hashFiles('**/Cargo.lock') }}
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,10 +12,10 @@ jobs:
     container: paritytech/ci-unified:bullseye-1.79.0
     steps:
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
 
       - name: Cache Rust dependencies
-        uses: swatinem/rust-cache@v2
+        uses: swatinem/rust-cache@98c8021b550208e191a6a3145459bfc9fb29c4c0 # v2.8.0
         with:
           key: ${{ runner.os }}-rust-${{ hashFiles('**/Cargo.lock') }}
 

--- a/.github/workflows/release-bot.yml
+++ b/.github/workflows/release-bot.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: send message
-        uses: s3krit/matrix-message-action@v0.0.3
+        uses: s3krit/matrix-message-action@70ad3fb812ee0e45ff8999d6af11cafad11a6ecf # v0.0.3
         with:
           room_id: ${{ secrets.MATRIX_ROOM_ID }}
           access_token: ${{ secrets.MATRIX_ACCESS_TOKEN }}


### PR DESCRIPTION
This is useful to prevent supply chain attacks conducted against upstream actions in use within the CI pipeline. If they're compromised it can lead to theft of secrets used within the CI pipeline.

To update this in the future, you can make the modification to the version you want to use and then run `pinact run` to repin the hash.

closes https://github.com/paritytech/parity-scale-codec/issues/769