### PR TITLE
Move trait bounds from inline into `where`

### DIFF
--- a/derive/src/decode.rs
+++ b/derive/src/decode.rs
@@ -332,7 +332,10 @@ pub fn quote_decode_with_mem_tracking_checks(data: &Data, crate_path: &syn::Path
 	});
 
 	quote! {
-		fn check_field<T: #crate_path::DecodeWithMemTracking>() {}
+		fn check_field<T>()
+		where
+			T: #crate_path::DecodeWithMemTracking,
+		{}
 
 		#(
 			check_field::<#processed_fields>();

--- a/derive/src/encode.rs
+++ b/derive/src/encode.rs
@@ -73,10 +73,13 @@ fn encode_single_field(
 				#crate_path::Encode::size_hint(&#final_field_variable)
 			}
 
-			fn encode_to<__CodecOutputEdqy: #crate_path::Output + ?::core::marker::Sized>(
+			fn encode_to<__CodecOutputEdqy>(
 				&#i_self,
 				__codec_dest_edqy: &mut __CodecOutputEdqy
-			) {
+			)
+			where
+				__CodecOutputEdqy: #crate_path::Output + ?::core::marker::Sized,
+			{
 				#crate_path::Encode::encode_to(&#final_field_variable, __codec_dest_edqy)
 			}
 
@@ -84,12 +87,14 @@ fn encode_single_field(
 				#crate_path::Encode::encode(&#final_field_variable)
 			}
 
-			fn using_encoded<
-				__CodecOutputReturn,
+			fn using_encoded<__CodecOutputReturn, __CodecUsingEncodedCallback>(
+				&#i_self,
+				f: __CodecUsingEncodedCallback
+			) -> __CodecOutputReturn
+			where
 				__CodecUsingEncodedCallback: ::core::ops::FnOnce(
 					&[::core::primitive::u8]
-				) -> __CodecOutputReturn
-			>(&#i_self, f: __CodecUsingEncodedCallback) -> __CodecOutputReturn
+				) -> __CodecOutputReturn,
 			{
 				#crate_path::Encode::using_encoded(&#final_field_variable, f)
 			}
@@ -426,10 +431,13 @@ fn impl_encode(data: &Data, type_name: &Ident, crate_path: &syn::Path) -> TokenS
 			#hinting
 		}
 
-		fn encode_to<__CodecOutputEdqy: #crate_path::Output + ?::core::marker::Sized>(
+		fn encode_to<__CodecOutputEdqy>(
 			&#self_,
 			#dest: &mut __CodecOutputEdqy
-		) {
+		)
+		where
+			__CodecOutputEdqy: #crate_path::Output + ?::core::marker::Sized,
+		{
 			#encoding
 		}
 	}

--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -215,10 +215,13 @@ pub fn decode_derive(input: proc_macro::TokenStream) -> proc_macro::TokenStream 
 
 	let impl_decode_into = if let Some(body) = decode_into_body {
 		quote! {
-			fn decode_into<__CodecInputEdqy: #crate_path::Input>(
+			fn decode_into<__CodecInputEdqy>(
 				#input_: &mut __CodecInputEdqy,
 				dst_: &mut ::core::mem::MaybeUninit<Self>,
-			) -> ::core::result::Result<#crate_path::DecodeFinished, #crate_path::Error> {
+			) -> ::core::result::Result<#crate_path::DecodeFinished, #crate_path::Error>
+			where
+				__CodecInputEdqy: #crate_path::Input,
+			{
 				#body
 			}
 		}
@@ -229,9 +232,12 @@ pub fn decode_derive(input: proc_macro::TokenStream) -> proc_macro::TokenStream 
 	let impl_block = quote! {
 		#[automatically_derived]
 		impl #impl_generics #crate_path::Decode for #name #ty_generics #where_clause {
-			fn decode<__CodecInputEdqy: #crate_path::Input>(
+			fn decode<__CodecInputEdqy>(
 				#input_: &mut __CodecInputEdqy
-			) -> ::core::result::Result<Self, #crate_path::Error> {
+			) -> ::core::result::Result<Self, #crate_path::Error>
+			where
+				__CodecInputEdqy: #crate_path::Input,
+			{
 				#decoding
 			}
 


### PR DESCRIPTION
This is a minor mechanical change, which resolves `clippy::inline_trait_bounds` clippy lint that is very annoying to work around otherwise.

I filed https://github.com/rust-lang/rust-clippy/issues/17110 about it, but no idea if/when it'll be resolved.